### PR TITLE
ci: fix deprecated golangci-lint --deadline flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           version: latest
           working-directory: backend
-          args: --timeout=5m --deadline=10m
+          args: --timeout=5m
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           version: latest
           working-directory: backend
           args: --timeout=5m
+          install-mode: goinstall
 
       - name: Check go mod tidy
         run: |

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.52.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -144,8 +144,6 @@ github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
## Summary
PR #111 merged before this one-commit fix landed. `Backend Lint & Format` still fails on `master` with `unknown flag: --deadline` - `--deadline` is golangci-lint's old pre-1.x flag name, superseded by `--timeout` (already present on the same args line). This was dormant until #111 fixed the branch-trigger mismatch that let the CI Pipeline workflow actually run against `master` PRs for the first time.

## Test plan
- [ ] `Backend Lint & Format` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)