### PR TITLE
fix(mitigations): make a plan's status changeable from the board (À faire → En cours)

### DIFF
--- a/backend/internal/application/mitigation/update_plan_usecase.go
+++ b/backend/internal/application/mitigation/update_plan_usecase.go
@@ -28,9 +28,21 @@ type UpdateMitigationPlanInput struct {
 	PlanID      uuid.UUID
 	Title       *string
 	Description *string
+	Status      *domain.MitigationStatus
 	Priority    *domain.MitigationPriority
 	AssignedTo  *domain.UUIDArray
 	DueDate     *time.Time
+}
+
+// validMitigationStatus reports whether s is a known lifecycle status.
+func validMitigationStatus(s domain.MitigationStatus) bool {
+	switch s {
+	case domain.MitigationPlanned, domain.MitigationInProgress,
+		domain.MitigationReview, domain.MitigationDone, domain.MitigationCancelled:
+		return true
+	default:
+		return false
+	}
 }
 
 // Execute updates a mitigation plan
@@ -49,6 +61,19 @@ func (uc *UpdateMitigationPlanUseCase) Execute(input UpdateMitigationPlanInput) 
 	}
 	if input.Description != nil {
 		mitigation.Description = *input.Description
+	}
+	if input.Status != nil {
+		if !validMitigationStatus(*input.Status) {
+			return fmt.Errorf("invalid status: %s", *input.Status)
+		}
+		mitigation.Status = *input.Status
+		// Keep the coarse progress in sync with the terminal states so the board
+		// bar and the status agree (sub-actions still drive intermediate values).
+		if *input.Status == domain.MitigationDone {
+			mitigation.Progress = 100
+		} else if *input.Status == domain.MitigationPlanned {
+			mitigation.Progress = 0
+		}
 	}
 	if input.Priority != nil {
 		mitigation.Priority = *input.Priority

--- a/backend/internal/handler/mitigation_handler.go
+++ b/backend/internal/handler/mitigation_handler.go
@@ -204,6 +204,7 @@ func UpdateMitigation(c *fiber.Ctx) error {
 	payload := struct {
 		Title       *string  `json:"title"`
 		Description *string  `json:"description"`
+		Status      *string  `json:"status"`
 		Priority    *string  `json:"priority"`
 		AssignedTo  []string `json:"assigned_to"`
 		DueDate     *string  `json:"due_date"`
@@ -211,6 +212,12 @@ func UpdateMitigation(c *fiber.Ctx) error {
 
 	if err := c.BodyParser(&payload); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid payload"})
+	}
+
+	var status *domain.MitigationStatus
+	if payload.Status != nil {
+		s := domain.MitigationStatus(*payload.Status)
+		status = &s
 	}
 
 	// Convert assignedTo if provided
@@ -246,6 +253,7 @@ func UpdateMitigation(c *fiber.Ctx) error {
 		PlanID:      uuid.MustParse(planID),
 		Title:       payload.Title,
 		Description: payload.Description,
+		Status:      status,
 		Priority:    priority,
 		AssignedTo:  assignedTo,
 		DueDate:     dueDate,

--- a/frontend/src/features/mitigations/MitigationsBoard.tsx
+++ b/frontend/src/features/mitigations/MitigationsBoard.tsx
@@ -8,13 +8,20 @@
 
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Clock, ShieldCheck, KanbanSquare, Rows3, GanttChartSquare } from 'lucide-react';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Plus, Clock, ShieldCheck, KanbanSquare, Rows3, GanttChartSquare, X } from 'lucide-react';
 import { PageFrame, PageHeader, Btn, Avatar, Skeleton, EmptyState, softFill } from '../../shared/ui';
 import { critColor } from '../../shared/riskColors';
 import { useUIStrings } from '../../shared/uiStrings';
 import { useUIStore } from '../../store/uiStore';
+import { mitigationService, type BoardStatus } from '../../services/mitigationService';
 import { useMitigations, type Column, type UiMiti } from './useMitigations';
 import { useMitigationEvents } from './useMitigationEvents';
+
+// Backend status ⇄ board column. A freshly-created plan is PLANNED (the "todo" column).
+const COL_TO_STATUS: Record<Column, BoardStatus> = { todo: 'PLANNED', progress: 'IN_PROGRESS', review: 'REVIEW', done: 'DONE' };
+const STATUS_TO_COL: Record<string, Column> = { PLANNED: 'todo', TODO: 'todo', IN_PROGRESS: 'progress', REVIEW: 'review', DONE: 'done' };
 
 type View = 'kanban' | 'table' | 'gantt';
 
@@ -25,6 +32,7 @@ export function MitigationsBoard() {
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   const { columns, items, isLoading } = useMitigations();
   const [view, setView] = useState<View>('kanban');
+  const [selected, setSelected] = useState<UiMiti | null>(null);
 
   // Live scanner-driven auto-completions push over SSE → refresh the board so the
   // "Auto-detected" badge appears without a manual reload.
@@ -86,25 +94,139 @@ export function MitigationsBoard() {
                 {isLoading ? (
                   <div className="flex flex-col gap-2.5">{[0, 1].map((i) => <Skeleton key={i} style={{ height: 92 }} />)}</div>
                 ) : (
-                  columns[key].map((c) => <KanbanCard key={c.id} c={c} />)
+                  columns[key].map((c) => <KanbanCard key={c.id} c={c} onOpen={() => setSelected(c)} />)
                 )}
               </div>
             ))}
           </div>
         </div>
       ) : view === 'table' ? (
-        <TableView items={items} isLoading={isLoading} statusLabel={statusLabel} statusColor={statusColor} />
+        <TableView items={items} isLoading={isLoading} statusLabel={statusLabel} statusColor={statusColor} onOpen={setSelected} />
       ) : (
         <GanttView items={items} isLoading={isLoading} statusColor={statusColor} />
+      )}
+
+      {selected && (
+        <MitigationDrawer
+          miti={selected}
+          onClose={() => setSelected(null)}
+          onChanged={(s) => setSelected({ ...selected, rawStatus: s, column: STATUS_TO_COL[s] ?? selected.column })}
+        />
       )}
     </PageFrame>
   );
 }
 
-function KanbanCard({ c }: { c: UiMiti }) {
+/* ---------------- detail drawer with status control ---------------- */
+function MitigationDrawer({ miti, onClose, onChanged }: { miti: UiMiti; onClose: () => void; onChanged: (status: BoardStatus) => void }) {
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  const qc = useQueryClient();
+  const L = useUIStrings();
+
+  const setStatus = useMutation({
+    mutationFn: (status: BoardStatus) => mitigationService.setStatus(miti.id, status),
+    onSuccess: (_data, status) => {
+      onChanged(status);
+      qc.invalidateQueries({ queryKey: ['mitigations'] });
+      toast.success(tr('Statut mis à jour', 'Status updated'));
+    },
+    onError: () => toast.error(tr('Échec de la mise à jour', 'Update failed')),
+  });
+
+  const current = STATUS_TO_COL[miti.rawStatus] ?? miti.column;
+  const steps: [Column, string][] = [
+    ['todo', L.col_todo],
+    ['progress', L.col_doing],
+    ['review', L.col_review],
+    ['done', L.col_done],
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex" onClick={onClose}>
+      <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.45)' }} />
+      <div
+        className="or-slidein ml-auto relative w-full max-w-[460px] h-full flex flex-col"
+        style={{ background: 'var(--bg-elevated)', borderLeft: '1px solid var(--border-strong)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="shrink-0 flex items-center justify-between px-5 py-4" style={{ borderBottom: '1px solid var(--border)' }}>
+          <span className="text-[15px] font-semibold text-ink">{tr('Détail de la mitigation', 'Mitigation detail')}</span>
+          <button onClick={onClose} className="p-1 rounded-md hover:bg-hover"><X size={18} className="text-ink-muted" /></button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+          <div>
+            <div className="text-[16px] font-semibold text-ink leading-snug">{miti.title}</div>
+            <div className="flex items-center gap-2 mt-1.5">
+              <span className="w-1.5 h-1.5 rounded-full" style={{ background: critColor[miti.crit] }} />
+              <span className="mono text-[11.5px] text-ink-muted">{miti.risk}</span>
+              <span className="text-[11.5px] font-semibold px-2 py-[2px] rounded-full" style={{ color: critColor[miti.crit], background: softFill(critColor[miti.crit], 15) }}>{miti.crit}</span>
+            </div>
+          </div>
+
+          {/* Status control — the answer to "how does it move from À faire to En cours". */}
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted mb-2">{tr('Statut', 'Status')}</div>
+            <div className="inline-flex rounded-[10px] p-0.5 w-full" style={{ border: '1px solid var(--border-strong)', background: 'var(--bg-secondary)' }}>
+              {steps.map(([col, label]) => {
+                const active = current === col;
+                return (
+                  <button
+                    key={col}
+                    disabled={setStatus.isPending}
+                    onClick={() => !active && setStatus.mutate(COL_TO_STATUS[col])}
+                    className="flex-1 h-9 rounded-[8px] text-[12px] font-semibold transition-colors disabled:opacity-60"
+                    style={{ background: active ? 'var(--accent)' : 'transparent', color: active ? '#fff' : 'var(--text-secondary)' }}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="text-[11.5px] text-ink-muted mt-1.5">{tr('Cliquez un statut pour déplacer le plan sur le board.', 'Click a status to move the plan across the board.')}</div>
+          </div>
+
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted mb-2">{tr('Avancement', 'Progress')}</div>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-1.5 rounded overflow-hidden" style={{ background: 'var(--bg-hover)' }}>
+                <div className="h-full rounded" style={{ width: `${miti.progress}%`, background: miti.progress === 100 ? 'var(--low)' : 'var(--accent)' }} />
+              </div>
+              <span className="mono text-[11px] text-ink-muted w-9 text-right">{miti.progress}%</span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted mb-1">{tr('Échéance', 'Due')}</div>
+              <div className="text-[13px] inline-flex items-center gap-1.5" style={{ color: miti.overdue ? 'var(--critical)' : 'var(--text-secondary)' }}>
+                {miti.overdue && <Clock size={13} />}{miti.deadline}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted mb-1">{tr('Responsable', 'Owner')}</div>
+              <Avatar initials={miti.owner} size={26} />
+            </div>
+          </div>
+
+          {miti.description && (
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted mb-1">Description</div>
+              <p className="text-[13px] text-ink-soft leading-relaxed">{miti.description}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KanbanCard({ c, onOpen }: { c: UiMiti; onOpen: () => void }) {
   const [hover, setHover] = useState(false);
   return (
     <div
+      onClick={onOpen}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       className="rounded-[11px] p-[13px] mb-2.5 cursor-pointer transition-all"
@@ -134,7 +256,7 @@ function KanbanCard({ c }: { c: UiMiti }) {
 }
 
 /* ---------------- table view ---------------- */
-function TableView({ items, isLoading, statusLabel, statusColor }: { items: UiMiti[]; isLoading: boolean; statusLabel: Record<Column, string>; statusColor: Record<Column, string> }) {
+function TableView({ items, isLoading, statusLabel, statusColor, onOpen }: { items: UiMiti[]; isLoading: boolean; statusLabel: Record<Column, string>; statusColor: Record<Column, string>; onOpen: (m: UiMiti) => void }) {
   const lang = useUIStore((s) => s.lang);
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   if (isLoading) return <div className="flex flex-col gap-2">{[0, 1, 2, 3].map((i) => <Skeleton key={i} style={{ height: 44 }} />)}</div>;
@@ -151,7 +273,7 @@ function TableView({ items, isLoading, statusLabel, statusColor }: { items: UiMi
           </thead>
           <tbody>
             {items.map((c) => (
-              <tr key={c.id} style={{ borderBottom: '1px solid var(--border)' }} className="hover:bg-hover transition-colors">
+              <tr key={c.id} onClick={() => onOpen(c)} style={{ borderBottom: '1px solid var(--border)', cursor: 'pointer' }} className="hover:bg-hover transition-colors">
                 <td className="px-3.5 py-3 text-[13.5px] font-medium text-ink max-w-[300px] truncate">{c.title}</td>
                 <td className="px-3.5 py-3"><span className="mono text-[11.5px] text-ink-muted">{c.risk}</span></td>
                 <td className="px-3.5 py-3">

--- a/frontend/src/features/mitigations/useMitigations.ts
+++ b/frontend/src/features/mitigations/useMitigations.ts
@@ -21,12 +21,16 @@ export interface UiMiti {
   crit: Criticality;
   overdue: boolean;
   column: Column;
+  /** Raw backend status (domain.MitigationStatus) for the drawer's status control. */
+  rawStatus: string;
+  description?: string;
   /** Raw ISO dates for the Gantt view (may be undefined). */
   startISO?: string;
   dueISO?: string;
 }
 
-const COL: Record<string, Column> = { TODO: 'todo', IN_PROGRESS: 'progress', REVIEW: 'review', DONE: 'done' };
+// Backend uses PLANNED for a freshly-created plan (not TODO) — both land in "todo".
+const COL: Record<string, Column> = { PLANNED: 'todo', TODO: 'todo', IN_PROGRESS: 'progress', REVIEW: 'review', DONE: 'done' };
 const CRIT: Record<string, Criticality> = { critical: 'critical', high: 'high', medium: 'medium', low: 'low' };
 
 function fmtDate(iso?: string): string {
@@ -36,7 +40,7 @@ function fmtDate(iso?: string): string {
 }
 
 export function mapMitigation(m: Mitigation): UiMiti {
-  const mm = m as Mitigation & { assignee?: string; risk_title?: string; created_at?: string };
+  const mm = m as Mitigation & { assignee?: string; risk_title?: string; created_at?: string; progress?: number };
   const column = COL[m.status] ?? 'todo';
   const overdue = column !== 'done' && !!m.due_date && new Date(m.due_date).getTime() < Date.now();
   return {
@@ -45,10 +49,13 @@ export function mapMitigation(m: Mitigation): UiMiti {
     risk: mm.risk_title || (m.risk_id ? `#${m.risk_id.slice(0, 8)}` : '—'),
     owner: initialsOf(mm.assignee),
     deadline: fmtDate(m.due_date),
-    progress: m.progress_percentage ?? 0,
+    // Backend serialises the field as `progress`; keep the legacy fallback.
+    progress: mm.progress ?? m.progress_percentage ?? 0,
     crit: CRIT[(m.priority ?? 'low').toLowerCase()] ?? 'low',
     overdue,
     column,
+    rawStatus: m.status,
+    description: m.description,
     startISO: mm.created_at,
     dueISO: m.due_date,
   };

--- a/frontend/src/services/mitigationService.ts
+++ b/frontend/src/services/mitigationService.ts
@@ -20,6 +20,9 @@ import type {
   SubAction,
 } from '../types/mitigation';
 
+/** Backend lifecycle vocabulary (domain.MitigationStatus). */
+export type BoardStatus = 'PLANNED' | 'IN_PROGRESS' | 'REVIEW' | 'DONE';
+
 export const mitigationService = {
   /**
    * List mitigations with filters and pagination
@@ -55,6 +58,16 @@ export const mitigationService = {
    */
   updateMitigation: async (id: string, payload: UpdateMitigationInput): Promise<Mitigation> => {
     const response = await api.patch<Mitigation>(`/mitigations/${id}`, payload);
+    return response.data;
+  },
+
+  /**
+   * Move a mitigation across its lifecycle (PLANNED → IN_PROGRESS → REVIEW → DONE).
+   * Backend status vocabulary (domain.MitigationStatus), which the board maps to
+   * its four columns.
+   */
+  setStatus: async (id: string, status: BoardStatus): Promise<Mitigation> => {
+    const response = await api.patch<Mitigation>(`/mitigations/${id}`, { status });
     return response.data;
   },
 


### PR DESCRIPTION
Clicking a mitigation card did nothing and there was no way to advance a plan across the Kanban. Two root causes:

- Backend: PATCH /mitigations/:id silently ignored `status` — the handler body struct and UpdateMitigationPlanInput had no Status field. Added it, with validation against the domain vocabulary (PLANNED/IN_PROGRESS/REVIEW/DONE/ CANCELLED) and progress synced on the terminal states (DONE→100, PLANNED→0).
- Frontend: the Kanban card / table row had cursor:pointer but no onClick, and the orphaned dark-only detail drawer was never wired. Added a dc.html-styled drawer opened on click with a status segmented control (À faire/En cours/En revue/Terminé) → mitigationService.setStatus → invalidates the board so the card moves columns. Also fixed the board mapping: a new plan is PLANNED (now mapped to the "todo" column) and progress reads the backend `progress` field (was reading the non-existent `progress_percentage`, always 0).

Live-verified: create → PLANNED; PATCH IN_PROGRESS 200; PATCH DONE 200 progress 100; invalid status 400.