### PR TITLE
chore(license): relicense to open-core — AGPLv3 core + commercial Enterprise Edition

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,31 +1,661 @@
-Business Source License 1.1
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Parameters
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Licensor: OpenDefender Contributors
-Licensed Work: OpenRisk
-Additional Use Grant: You may use the Licensed Work for any purpose other than providing the Licensed Work as a managed service (SaaS) or otherwise using it to provide a commercial competitive offering to third parties.
-Change Date: 2030-06-30
-Change License: Apache License, Version 2.0
+                            Preamble
 
-Terms
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License).
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+                       TERMS AND CONDITIONS
 
-Limit of Liability
+  0. Definitions.
 
-In no event will the Licensor be liable for any indirect, special, incidental, or consequential damages arising out of the use of or inability to use the Licensed Work, including but not limited to loss of data, loss of business, or loss of profits.
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE.commercial
+++ b/LICENSE.commercial
@@ -1,0 +1,51 @@
+OpenRisk Commercial License (Enterprise Edition)
+================================================
+
+Copyright (c) 2026 OpenDefender. All rights reserved.
+
+This license governs the "Enterprise Edition" (EE) portions of OpenRisk. Files
+that are part of the Enterprise Edition carry the SPDX identifier
+`LicenseRef-OpenRisk-Commercial` in their header, and the authoritative list of
+EE paths is maintained in LICENSING.md. Everything else in this repository is the
+Community Edition, licensed separately under the GNU Affero General Public
+License v3.0 (see LICENSE).
+
+The Enterprise Edition is NOT covered by the AGPLv3 and is NOT open source.
+
+1. Grant of license
+   Subject to a valid, paid subscription agreement with OpenDefender (the
+   "Commercial Agreement") and to the terms below, OpenDefender grants the
+   customer a non-exclusive, non-transferable, non-sublicensable right to use,
+   in object form, the Enterprise Edition solely for the customer's internal
+   business purposes, for the number of instances and users covered by the
+   Commercial Agreement.
+
+2. Restrictions
+   Absent a separate written agreement, you may NOT: (a) use the Enterprise
+   Edition in production without a valid Commercial Agreement; (b) copy, modify,
+   distribute, sublicense, rent, lease, or make the Enterprise Edition available
+   to any third party as a hosted or managed service; (c) remove or alter any
+   proprietary notices; or (d) reverse engineer the Enterprise Edition except to
+   the extent that applicable law expressly permits despite this limitation.
+
+3. Evaluation
+   OpenDefender may make the Enterprise Edition source available for evaluation,
+   development, and testing. Such use does not grant any production right and is
+   subject to this license.
+
+4. Ownership
+   The Enterprise Edition is licensed, not sold. OpenDefender retains all right,
+   title, and interest, including all intellectual property rights.
+
+5. No warranty; limitation of liability
+   THE ENTERPRISE EDITION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. TO
+   THE MAXIMUM EXTENT PERMITTED BY LAW, OPENDEFENDER SHALL NOT BE LIABLE FOR ANY
+   INDIRECT, INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR IN
+   CONNECTION WITH THE ENTERPRISE EDITION.
+
+6. Termination
+   This license terminates automatically if you breach it or upon expiry of the
+   Commercial Agreement. On termination you must cease all use of the Enterprise
+   Edition and destroy all copies.
+
+For commercial licensing, contact: licensing@opendefender.io

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,93 @@
+# OpenRisk licensing (open-core)
+
+OpenRisk is **open-core**. It ships as two editions in one repository:
+
+| Edition | License | SPDX in file headers | License file |
+|---|---|---|---|
+| **Community Edition (CE)** — the core GRC platform | **GNU AGPL v3.0** | `AGPL-3.0-only` | [`LICENSE`](LICENSE) |
+| **Enterprise Edition (EE)** — commercial add-ons | **OpenRisk Commercial License** | `LicenseRef-OpenRisk-Commercial` | [`LICENSE.commercial`](LICENSE.commercial) |
+
+Every source file declares its edition via its `SPDX-License-Identifier` header.
+**This file is the authoritative boundary** between the two.
+
+## Why AGPLv3 for the core
+
+The AGPL is a strong copyleft that also covers **use over a network**: anyone who
+runs a modified OpenRisk core as a hosted service must release their
+modifications under the AGPL. This closes the "SaaS loophole" and keeps a
+competitor from taking the community core and offering it as a closed hosted GRC
+— while the community remains free to self-host, study, modify and redistribute.
+
+Copyright in the existing code is held by OpenDefender / its contributors
+("OpenDefender Contributors"), so OpenDefender retains the right to **dual-license**
+(offer the same core under a commercial license to customers who cannot accept
+the AGPL). New external contributions are accepted under the project's CLA/DCO so
+this right is preserved.
+
+## What is Enterprise (commercial), and what is Community (AGPL)
+
+Everything **not** listed below is Community Edition (AGPLv3).
+
+### Enterprise Edition — `LicenseRef-OpenRisk-Commercial`
+
+**Advanced SSO** (basic email/password + JWT login, MFA and Personal Access
+Tokens stay in CE):
+- `backend/internal/handler/oauth2_handler.go`
+- `backend/internal/handler/saml2_handler.go`
+- `backend/internal/handler/sso_session.go`
+
+**AI copilot** (GRC assistant, board report, treatment-plan/emerging-risk/
+evidence generation):
+- `backend/pkg/ai/`
+- `backend/internal/application/ai/`
+- `backend/internal/application/board/`
+- `backend/internal/handler/ai_handler.go`
+- `backend/internal/handler/board_report_handler.go`
+- `frontend/src/features/ai/`
+- `frontend/src/features/reports/BoardReportPage.tsx`
+
+**Premium connectors & automation** (SOAR engine, real cloud discovery
+collectors, vulnerability live-pull, ITSM ticketing, ChatOps):
+- `backend/internal/application/automation/`
+- `backend/internal/infrastructure/automation/`
+- `backend/internal/handler/automation_handler.go`
+- `backend/internal/scanner/collectors/`
+- `backend/internal/vulnscan/livepull/`
+- `backend/pkg/ticketing/`
+- `backend/pkg/notify/chatops.go`
+- `frontend/src/features/automation/`
+- `frontend/src/features/infrastructure/`
+
+### The multi-tenancy caveat (important)
+
+"Multi-tenant" is listed as an enterprise capability, but it is **not a separable
+module**: tenant isolation (`tenant_id` filtering) is a cross-cutting concern
+present in *every* Community repository and use case, and it stays **AGPL/CE** —
+you cannot meaningfully paywall the plumbing that keeps data safe. What can be
+gated commercially is **multi-organisation management** (a super-admin / tenant
+provisioning / cross-tenant administration surface). That surface is not built
+yet; when it is, it will live under `ee/` and be listed here.
+
+## How the split is enforced (roadmap)
+
+- **Phase 1 — licensing (done):** `LICENSE` (AGPLv3) + `LICENSE.commercial`,
+  this manifest, and per-file `SPDX-License-Identifier` headers set to the
+  correct edition across the whole repository.
+- **Phase 2 — physical isolation (next):** move the EE paths above under an
+  `ee/` tree (`backend/ee/…`, `frontend/src/ee/…`) guarded by a Go build tag
+  (`//go:build enterprise`) and a matching front-end build flag, so the default
+  open-source build compiles and ships **without** the Enterprise Edition. The
+  application wiring (`cmd/server/main.go`) is split into a core path and an
+  `//go:build enterprise` path; an EE build additionally verifies a license key
+  at startup. A CE build simply omits the EE routes.
+
+Until Phase 2 lands, EE files remain in place but are unambiguously marked
+commercial by their headers and by this manifest; a build that ships them
+requires a Commercial Agreement.
+
+## Third-party licenses
+
+Dependencies retain their own licenses. The AGPL applies to OpenRisk's own
+Community source, not to independently-licensed third-party libraries it uses.
+
+For commercial licensing questions: **licensing@opendefender.io**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   
   Part of the [OpenDefender](https://github.com/opendefender) Ecosystem
 
-  [![GitHub license](https://img.shields.io/badge/license-BUSL%201.1-blue.svg)](LICENSE)
+  [![License: AGPL v3](https://img.shields.io/badge/license-AGPL%20v3%20%2B%20Commercial-blue.svg)](LICENSING.md)
   [![GitHub release](https://img.shields.io/badge/version-1.0.6-brightgreen.svg)](https://github.com/opendefender/OpenRisk/releases)
   [![GitHub Actions CI/CD](https://github.com/opendefender/OpenRisk/workflows/CI/badge.svg)](https://github.com/opendefender/OpenRisk/actions)
   [![Go version](https://img.shields.io/badge/go-1.25.4-blue.svg)](https://golang.org)
@@ -468,15 +468,21 @@ We welcome contributions from the community! Please see [CONTRIBUTING.md](CONTRI
 
 ## 📝 License
 
-OpenRisk is licensed under the **Business Source License 1.1** (BUSL-1.1) - see the [LICENSE](LICENSE) file for details.
+OpenRisk is **open-core**:
 
-### BUSL-1.1 Key Terms:
-- ✅ Free for non-commercial and internal use
-- ✅ Source code availability for modifications
-- ⚠️ Cannot be offered as a competitive SaaS product
-- 🔄 Reverts to Apache 2.0 license after 4 years
+- **Community Edition** (the core GRC platform) — **GNU AGPL v3.0** ([`LICENSE`](LICENSE)).
+  Free to self-host, study, modify and redistribute. The AGPL's network clause
+  means anyone running a **modified** core as a hosted service must publish their
+  changes under the AGPL.
+- **Enterprise Edition** (advanced SSO, AI copilot, premium connectors & SOAR,
+  multi-organisation management) — **OpenRisk Commercial License**
+  ([`LICENSE.commercial`](LICENSE.commercial)), used under a paid subscription.
 
-For more information on the Business Source License, visit: https://mariadb.com/bsl11/
+Every source file declares its edition via its `SPDX-License-Identifier` header
+(`AGPL-3.0-only` or `LicenseRef-OpenRisk-Commercial`). The authoritative boundary
+between the two is [`LICENSING.md`](LICENSING.md).
+
+For commercial licensing: **licensing@opendefender.io**
 
 ---
 

--- a/backend/cmd/server/executive_wiring.go
+++ b/backend/cmd/server/executive_wiring.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/backend/internal/analytics/time_series_analyzer.go
+++ b/backend/internal/analytics/time_series_analyzer.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package analytics
 

--- a/backend/internal/api/http/handlers/risks.go
+++ b/backend/internal/api/http/handlers/risks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handlers
 

--- a/backend/internal/application/ai/ai_test.go
+++ b/backend/internal/application/ai/ai_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/ai/analyze_evidence.go
+++ b/backend/internal/application/ai/analyze_evidence.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/ai/assistant_query.go
+++ b/backend/internal/application/ai/assistant_query.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/ai/detect_emerging_risks.go
+++ b/backend/internal/application/ai/detect_emerging_risks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/ai/generate_audit_report.go
+++ b/backend/internal/application/ai/generate_audit_report.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/ai/ports.go
+++ b/backend/internal/application/ai/ports.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package ai wires the tenant-scoped GRC data (risks, assets, compliance,
 // vulnerabilities, audits) to the pure pkg/ai.Assistant. Each use case assembles

--- a/backend/internal/application/ai/suggest_treatment_plan.go
+++ b/backend/internal/application/ai/suggest_treatment_plan.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/internal/application/asset/asset_dependency_test.go
+++ b/backend/internal/application/asset/asset_dependency_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/create_asset.go
+++ b/backend/internal/application/asset/create_asset.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/create_asset_dependency.go
+++ b/backend/internal/application/asset/create_asset_dependency.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/create_asset_test.go
+++ b/backend/internal/application/asset/create_asset_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/delete_asset.go
+++ b/backend/internal/application/asset/delete_asset.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/delete_asset_dependency.go
+++ b/backend/internal/application/asset/delete_asset_dependency.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/delete_asset_test.go
+++ b/backend/internal/application/asset/delete_asset_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/get_asset.go
+++ b/backend/internal/application/asset/get_asset.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/get_asset_test.go
+++ b/backend/internal/application/asset/get_asset_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/list_asset_dependencies.go
+++ b/backend/internal/application/asset/list_asset_dependencies.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/list_asset_snapshots.go
+++ b/backend/internal/application/asset/list_asset_snapshots.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/list_asset_snapshots_test.go
+++ b/backend/internal/application/asset/list_asset_snapshots_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/list_assets.go
+++ b/backend/internal/application/asset/list_assets.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/list_assets_test.go
+++ b/backend/internal/application/asset/list_assets_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/test_utils_test.go
+++ b/backend/internal/application/asset/test_utils_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/update_asset.go
+++ b/backend/internal/application/asset/update_asset.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/asset/update_asset_test.go
+++ b/backend/internal/application/asset/update_asset_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package asset
 

--- a/backend/internal/application/auth/login.go
+++ b/backend/internal/application/auth/login.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/auth/logout.go
+++ b/backend/internal/application/auth/logout.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/auth/mfa_usecase.go
+++ b/backend/internal/application/auth/mfa_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/auth/mfa_usecase_test.go
+++ b/backend/internal/application/auth/mfa_usecase_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/auth/refresh_token.go
+++ b/backend/internal/application/auth/refresh_token.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/auth/register.go
+++ b/backend/internal/application/auth/register.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/application/automation/channels.go
+++ b/backend/internal/application/automation/channels.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/application/automation/engine.go
+++ b/backend/internal/application/automation/engine.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/application/automation/engine_test.go
+++ b/backend/internal/application/automation/engine_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package automation
 

--- a/backend/internal/application/automation/executions.go
+++ b/backend/internal/application/automation/executions.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/application/automation/mocks_test.go
+++ b/backend/internal/application/automation/mocks_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package automation
 

--- a/backend/internal/application/automation/ports.go
+++ b/backend/internal/application/automation/ports.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package automation is the Security Automation / SOAR engine (spec §10
 // « Automatisation »). It binds platform events (triggers) to ordered action

--- a/backend/internal/application/automation/rules.go
+++ b/backend/internal/application/automation/rules.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/application/automation/rules_test.go
+++ b/backend/internal/application/automation/rules_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package automation
 

--- a/backend/internal/application/automation/sla.go
+++ b/backend/internal/application/automation/sla.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/application/automation/sla_test.go
+++ b/backend/internal/application/automation/sla_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package automation
 

--- a/backend/internal/application/board/board_usecases.go
+++ b/backend/internal/application/board/board_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package board
 

--- a/backend/internal/application/board/exposure.go
+++ b/backend/internal/application/board/exposure.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package board
 

--- a/backend/internal/application/board/generate_board_report.go
+++ b/backend/internal/application/board/generate_board_report.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package board
 

--- a/backend/internal/application/board/ports.go
+++ b/backend/internal/application/board/ports.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package board holds the monthly board-of-directors report use cases: it
 // aggregates a tenant's risk and compliance posture, asks an ai.Advisor to write

--- a/backend/internal/application/compliance/control_mapping.go
+++ b/backend/internal/application/compliance/control_mapping.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/controls_test.go
+++ b/backend/internal/application/compliance/controls_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/create_control.go
+++ b/backend/internal/application/compliance/create_control.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/create_evidence.go
+++ b/backend/internal/application/compliance/create_evidence.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/create_framework.go
+++ b/backend/internal/application/compliance/create_framework.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/delete_control.go
+++ b/backend/internal/application/compliance/delete_control.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/delete_evidence.go
+++ b/backend/internal/application/compliance/delete_evidence.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/delete_framework.go
+++ b/backend/internal/application/compliance/delete_framework.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/delete_framework_test.go
+++ b/backend/internal/application/compliance/delete_framework_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/download_evidence.go
+++ b/backend/internal/application/compliance/download_evidence.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/evidences_test.go
+++ b/backend/internal/application/compliance/evidences_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/frameworks_test.go
+++ b/backend/internal/application/compliance/frameworks_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/gap_analysis.go
+++ b/backend/internal/application/compliance/gap_analysis.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/gap_analysis_test.go
+++ b/backend/internal/application/compliance/gap_analysis_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/generate_compliance_report.go
+++ b/backend/internal/application/compliance/generate_compliance_report.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/generate_compliance_report_test.go
+++ b/backend/internal/application/compliance/generate_compliance_report_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/get_compliance_progress.go
+++ b/backend/internal/application/compliance/get_compliance_progress.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/get_control.go
+++ b/backend/internal/application/compliance/get_control.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/get_framework.go
+++ b/backend/internal/application/compliance/get_framework.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/import_catalog.go
+++ b/backend/internal/application/compliance/import_catalog.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/import_catalog_test.go
+++ b/backend/internal/application/compliance/import_catalog_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/list_catalogs.go
+++ b/backend/internal/application/compliance/list_catalogs.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/list_catalogs_test.go
+++ b/backend/internal/application/compliance/list_catalogs_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/list_controls.go
+++ b/backend/internal/application/compliance/list_controls.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/list_evidences.go
+++ b/backend/internal/application/compliance/list_evidences.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/list_frameworks.go
+++ b/backend/internal/application/compliance/list_frameworks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/progress_test.go
+++ b/backend/internal/application/compliance/progress_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/test_utils_test.go
+++ b/backend/internal/application/compliance/test_utils_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/compliance/update_control.go
+++ b/backend/internal/application/compliance/update_control.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/internal/application/complianceaudit/audit_usecases.go
+++ b/backend/internal/application/complianceaudit/audit_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package complianceaudit holds the use cases for compliance audits (plan,
 // execute, archive) and remediation plans (create, assign, track). Each use case

--- a/backend/internal/application/complianceaudit/generate_remediations.go
+++ b/backend/internal/application/complianceaudit/generate_remediations.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package complianceaudit
 

--- a/backend/internal/application/complianceaudit/generate_remediations_test.go
+++ b/backend/internal/application/complianceaudit/generate_remediations_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package complianceaudit
 

--- a/backend/internal/application/complianceaudit/remediation_usecases.go
+++ b/backend/internal/application/complianceaudit/remediation_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package complianceaudit
 

--- a/backend/internal/application/dashboard/cyber_score.go
+++ b/backend/internal/application/dashboard/cyber_score.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package dashboard
 

--- a/backend/internal/application/dashboard/cyber_score_test.go
+++ b/backend/internal/application/dashboard/cyber_score_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package dashboard
 

--- a/backend/internal/application/dashboard/executive_dashboard.go
+++ b/backend/internal/application/dashboard/executive_dashboard.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package dashboard assembles the executive ("Tableau de bord exécutif", spec §11)
 // dashboard: a single tenant-scoped aggregation that consolidates risk, financial,

--- a/backend/internal/application/dashboard/executive_dashboard_test.go
+++ b/backend/internal/application/dashboard/executive_dashboard_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package dashboard
 

--- a/backend/internal/application/governance/approval_usecases.go
+++ b/backend/internal/application/governance/approval_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package governance
 

--- a/backend/internal/application/governance/audit_usecases.go
+++ b/backend/internal/application/governance/audit_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package governance holds the use cases for the Governance module (spec §15):
 // the immutable audit trail, time-boxed delegations, and the configurable

--- a/backend/internal/application/governance/delegation_usecases.go
+++ b/backend/internal/application/governance/delegation_usecases.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package governance
 

--- a/backend/internal/application/governance/governance_test.go
+++ b/backend/internal/application/governance/governance_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package governance
 

--- a/backend/internal/application/mitigation/auto_complete_subaction_usecase.go
+++ b/backend/internal/application/mitigation/auto_complete_subaction_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/complete_subaction_usecase.go
+++ b/backend/internal/application/mitigation/complete_subaction_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/complete_subaction_usecase_test.go
+++ b/backend/internal/application/mitigation/complete_subaction_usecase_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/create_plan_usecase.go
+++ b/backend/internal/application/mitigation/create_plan_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/create_plan_usecase_test.go
+++ b/backend/internal/application/mitigation/create_plan_usecase_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/reorder_subactions_usecase.go
+++ b/backend/internal/application/mitigation/reorder_subactions_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/revert_subaction_usecase.go
+++ b/backend/internal/application/mitigation/revert_subaction_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/update_plan_usecase.go
+++ b/backend/internal/application/mitigation/update_plan_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/mitigation/validate_plan_usecase.go
+++ b/backend/internal/application/mitigation/validate_plan_usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package mitigation
 

--- a/backend/internal/application/notification/usecase.go
+++ b/backend/internal/application/notification/usecase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package notification
 

--- a/backend/internal/application/notification/usecase_test.go
+++ b/backend/internal/application/notification/usecase_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package notification
 

--- a/backend/internal/application/risk/accept_risk.go
+++ b/backend/internal/application/risk/accept_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/bulk_action.go
+++ b/backend/internal/application/risk/bulk_action.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/compute_smart_score.go
+++ b/backend/internal/application/risk/compute_smart_score.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/compute_smart_score_test.go
+++ b/backend/internal/application/risk/compute_smart_score_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/create_risk.go
+++ b/backend/internal/application/risk/create_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/create_risk_test.go
+++ b/backend/internal/application/risk/create_risk_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/delete_risk.go
+++ b/backend/internal/application/risk/delete_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/duplicate_risk.go
+++ b/backend/internal/application/risk/duplicate_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/export_risks.go
+++ b/backend/internal/application/risk/export_risks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/financial_summary.go
+++ b/backend/internal/application/risk/financial_summary.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/financial_summary_test.go
+++ b/backend/internal/application/risk/financial_summary_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/get_history.go
+++ b/backend/internal/application/risk/get_history.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/get_risk.go
+++ b/backend/internal/application/risk/get_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/get_score_breakdown.go
+++ b/backend/internal/application/risk/get_score_breakdown.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/get_score_breakdown_test.go
+++ b/backend/internal/application/risk/get_score_breakdown_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/import_risks.go
+++ b/backend/internal/application/risk/import_risks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/list_risks.go
+++ b/backend/internal/application/risk/list_risks.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/mark_reviewed.go
+++ b/backend/internal/application/risk/mark_reviewed.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/risk_usecases_test.go
+++ b/backend/internal/application/risk/risk_usecases_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/smart_score_weights.go
+++ b/backend/internal/application/risk/smart_score_weights.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/test_utils_test.go
+++ b/backend/internal/application/risk/test_utils_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/transition_phase.go
+++ b/backend/internal/application/risk/transition_phase.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/transition_phase_test.go
+++ b/backend/internal/application/risk/transition_phase_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/risk/update_risk.go
+++ b/backend/internal/application/risk/update_risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package risk
 

--- a/backend/internal/application/scanner/agents_test.go
+++ b/backend/internal/application/scanner/agents_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/create_config.go
+++ b/backend/internal/application/scanner/create_config.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/create_config_test.go
+++ b/backend/internal/application/scanner/create_config_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/credentials.go
+++ b/backend/internal/application/scanner/credentials.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package scanner (application) holds the scan-engine use cases. They orchestrate
 // the domain repositories, the scanner pipeline and Redis, enforcing tenant

--- a/backend/internal/application/scanner/list_configs.go
+++ b/backend/internal/application/scanner/list_configs.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/manage_agents.go
+++ b/backend/internal/application/scanner/manage_agents.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/mocks_test.go
+++ b/backend/internal/application/scanner/mocks_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/preview.go
+++ b/backend/internal/application/scanner/preview.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/preview_test.go
+++ b/backend/internal/application/scanner/preview_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/push_results.go
+++ b/backend/internal/application/scanner/push_results.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/push_results_test.go
+++ b/backend/internal/application/scanner/push_results_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/register_agent.go
+++ b/backend/internal/application/scanner/register_agent.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/trigger_scan.go
+++ b/backend/internal/application/scanner/trigger_scan.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/scanner/trigger_scan_test.go
+++ b/backend/internal/application/scanner/trigger_scan_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/application/vulnerability/cti_enrich.go
+++ b/backend/internal/application/vulnerability/cti_enrich.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/cti_enrich_test.go
+++ b/backend/internal/application/vulnerability/cti_enrich_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/ingest.go
+++ b/backend/internal/application/vulnerability/ingest.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package vulnerability holds the vulnerability-management use cases: ingest
 // (normalise + prioritise findings from Nessus/OpenVAS/Qualys/Defender/Inspector/

--- a/backend/internal/application/vulnerability/integrations.go
+++ b/backend/internal/application/vulnerability/integrations.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/integrations_test.go
+++ b/backend/internal/application/vulnerability/integrations_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/livepull.go
+++ b/backend/internal/application/vulnerability/livepull.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/mutations.go
+++ b/backend/internal/application/vulnerability/mutations.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/queries.go
+++ b/backend/internal/application/vulnerability/queries.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/risk_auto.go
+++ b/backend/internal/application/vulnerability/risk_auto.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/risk_auto_test.go
+++ b/backend/internal/application/vulnerability/risk_auto_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/scheduler.go
+++ b/backend/internal/application/vulnerability/scheduler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/ticketing.go
+++ b/backend/internal/application/vulnerability/ticketing.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/ticketing_test.go
+++ b/backend/internal/application/vulnerability/ticketing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/application/vulnerability/vulnerability_test.go
+++ b/backend/internal/application/vulnerability/vulnerability_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnerability
 

--- a/backend/internal/audit/compliance_checker.go
+++ b/backend/internal/audit/compliance_checker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package audit
 

--- a/backend/internal/auth/audit.go
+++ b/backend/internal/auth/audit.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/auth/interfaces.go
+++ b/backend/internal/auth/interfaces.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/auth/password_hasher.go
+++ b/backend/internal/auth/password_hasher.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/auth/pat.go
+++ b/backend/internal/auth/pat.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/auth/token.go
+++ b/backend/internal/auth/token.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package config
 

--- a/backend/internal/database/pool_config.go
+++ b/backend/internal/database/pool_config.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package database
 

--- a/backend/internal/documentation/api_docs.go
+++ b/backend/internal/documentation/api_docs.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package documentation
 

--- a/backend/internal/domain/admin_audit_event.go
+++ b/backend/internal/domain/admin_audit_event.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/api_token.go
+++ b/backend/internal/domain/api_token.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/api_token_test.go
+++ b/backend/internal/domain/api_token_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/asset.go
+++ b/backend/internal/domain/asset.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/asset_dependency.go
+++ b/backend/internal/domain/asset_dependency.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/asset_repository.go
+++ b/backend/internal/domain/asset_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/audit_log.go
+++ b/backend/internal/domain/audit_log.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/automation.go
+++ b/backend/internal/domain/automation.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/board_report.go
+++ b/backend/internal/domain/board_report.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/bulk_operation.go
+++ b/backend/internal/domain/bulk_operation.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/compliance.go
+++ b/backend/internal/domain/compliance.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/compliance_audit.go
+++ b/backend/internal/domain/compliance_audit.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/compliance_repository.go
+++ b/backend/internal/domain/compliance_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/control_mapping.go
+++ b/backend/internal/domain/control_mapping.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/custom_field.go
+++ b/backend/internal/domain/custom_field.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/custom_metric.go
+++ b/backend/internal/domain/custom_metric.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/errors_test.go
+++ b/backend/internal/domain/errors_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/governance.go
+++ b/backend/internal/domain/governance.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/governance_auditable.go
+++ b/backend/internal/domain/governance_auditable.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/history.go
+++ b/backend/internal/domain/history.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/incident.go
+++ b/backend/internal/domain/incident.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/integration_models.go
+++ b/backend/internal/domain/integration_models.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/invitation.go
+++ b/backend/internal/domain/invitation.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/marketplace.go
+++ b/backend/internal/domain/marketplace.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/membership.go
+++ b/backend/internal/domain/membership.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/mfa.go
+++ b/backend/internal/domain/mfa.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/mitigation.go
+++ b/backend/internal/domain/mitigation.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/mitigation_events.go
+++ b/backend/internal/domain/mitigation_events.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/mitigation_subaction.go
+++ b/backend/internal/domain/mitigation_subaction.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/organization.go
+++ b/backend/internal/domain/organization.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/permission.go
+++ b/backend/internal/domain/permission.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/permission_test.go
+++ b/backend/internal/domain/permission_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/rbac.go
+++ b/backend/internal/domain/rbac.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/risk.go
+++ b/backend/internal/domain/risk.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/risk_repository.go
+++ b/backend/internal/domain/risk_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/risk_scoring.go
+++ b/backend/internal/domain/risk_scoring.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/scanner.go
+++ b/backend/internal/domain/scanner.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/team.go
+++ b/backend/internal/domain/team.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/trend_analysis.go
+++ b/backend/internal/domain/trend_analysis.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/user_session.go
+++ b/backend/internal/domain/user_session.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/user_test.go
+++ b/backend/internal/domain/user_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/vuln_integration.go
+++ b/backend/internal/domain/vuln_integration.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/vulnerability.go
+++ b/backend/internal/domain/vulnerability.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/domain/vulnerability_repository.go
+++ b/backend/internal/domain/vulnerability_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package domain
 

--- a/backend/internal/handler/ai_handler.go
+++ b/backend/internal/handler/ai_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/analytics_handler.go
+++ b/backend/internal/handler/analytics_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/asset_dependency_handler.go
+++ b/backend/internal/handler/asset_dependency_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/asset_handler.go
+++ b/backend/internal/handler/asset_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/audit_log_handler.go
+++ b/backend/internal/handler/audit_log_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/handler/auth/mfa_handler.go
+++ b/backend/internal/handler/auth/mfa_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/handler/auth/pat_handler.go
+++ b/backend/internal/handler/auth/pat_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/automation_handler.go
+++ b/backend/internal/handler/automation_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/board_report_handler.go
+++ b/backend/internal/handler/board_report_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/bulk_operation_handler.go
+++ b/backend/internal/handler/bulk_operation_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/cache_integration.go
+++ b/backend/internal/handler/cache_integration.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/compliance_audit_handler.go
+++ b/backend/internal/handler/compliance_audit_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/compliance_handler.go
+++ b/backend/internal/handler/compliance_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/compliance_handler_test.go
+++ b/backend/internal/handler/compliance_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/context_helpers.go
+++ b/backend/internal/handler/context_helpers.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/cti_handler.go
+++ b/backend/internal/handler/cti_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/custom_field_handler.go
+++ b/backend/internal/handler/custom_field_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/dashboard_handler.go
+++ b/backend/internal/handler/dashboard_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/enhanced_dashboard_handler.go
+++ b/backend/internal/handler/enhanced_dashboard_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/executive_dashboard_handler.go
+++ b/backend/internal/handler/executive_dashboard_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/export_handler.go
+++ b/backend/internal/handler/export_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/gamification_handler.go
+++ b/backend/internal/handler/gamification_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/governance_handler.go
+++ b/backend/internal/handler/governance_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/incident_handler.go
+++ b/backend/internal/handler/incident_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/incident_handler_test.go
+++ b/backend/internal/handler/incident_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/integration_handler.go
+++ b/backend/internal/handler/integration_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/marketplace_handler.go
+++ b/backend/internal/handler/marketplace_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/mitigation_events_handler.go
+++ b/backend/internal/handler/mitigation_events_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/mitigation_handler.go
+++ b/backend/internal/handler/mitigation_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/mitigation_subaction_handler.go
+++ b/backend/internal/handler/mitigation_subaction_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/mitigation_subaction_handler_test.go
+++ b/backend/internal/handler/mitigation_subaction_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/monitoring_handler.go
+++ b/backend/internal/handler/monitoring_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/multitenancy_auth_handler.go
+++ b/backend/internal/handler/multitenancy_auth_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/multitenancy_org_handler.go
+++ b/backend/internal/handler/multitenancy_org_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/notification_handler_test.go
+++ b/backend/internal/handler/notification_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/oauth2_handler.go
+++ b/backend/internal/handler/oauth2_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/organization_handler.go
+++ b/backend/internal/handler/organization_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/rbac_role_handler.go
+++ b/backend/internal/handler/rbac_role_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/rbac_tenant_handler.go
+++ b/backend/internal/handler/rbac_tenant_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/rbac_user_handler.go
+++ b/backend/internal/handler/rbac_user_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/risk_financial_handler.go
+++ b/backend/internal/handler/risk_financial_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/risk_handler.go
+++ b/backend/internal/handler/risk_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/risk_handler_integration_test.go
+++ b/backend/internal/handler/risk_handler_integration_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/internal/handler/risk_handler_test.go
+++ b/backend/internal/handler/risk_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/risk_timeline_handler.go
+++ b/backend/internal/handler/risk_timeline_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/saml2_handler.go
+++ b/backend/internal/handler/saml2_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/scanner_agent_handler.go
+++ b/backend/internal/handler/scanner_agent_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/scanner_handler.go
+++ b/backend/internal/handler/scanner_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/score_engine_handler.go
+++ b/backend/internal/handler/score_engine_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/seed_rbac.go
+++ b/backend/internal/handler/seed_rbac.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // SeedRBAC provisions the RBAC / multi-tenant tables so the Settings admin tabs
 // (Roles, Organizations, Audit log) are fully functional. It is idempotent and

--- a/backend/internal/handler/smart_score_handler.go
+++ b/backend/internal/handler/smart_score_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/sso_session.go
+++ b/backend/internal/handler/sso_session.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package handler
 

--- a/backend/internal/handler/stats_handler.go
+++ b/backend/internal/handler/stats_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/team_handler.go
+++ b/backend/internal/handler/team_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/test_helpers.go
+++ b/backend/internal/handler/test_helpers.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/token_flow_integration_test.go
+++ b/backend/internal/handler/token_flow_integration_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/internal/handler/token_handler.go
+++ b/backend/internal/handler/token_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/token_handler_test.go
+++ b/backend/internal/handler/token_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/trend_handler.go
+++ b/backend/internal/handler/trend_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/vuln_integration_handler.go
+++ b/backend/internal/handler/vuln_integration_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/vuln_webhook_handler.go
+++ b/backend/internal/handler/vuln_webhook_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/vuln_webhook_handler_test.go
+++ b/backend/internal/handler/vuln_webhook_handler_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/handler/vulnerability_handler.go
+++ b/backend/internal/handler/vulnerability_handler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package handler
 

--- a/backend/internal/infrastructure/audittrail/context.go
+++ b/backend/internal/infrastructure/audittrail/context.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package audittrail wires an immutable, append-only audit trail into GORM.
 //

--- a/backend/internal/infrastructure/audittrail/plugin.go
+++ b/backend/internal/infrastructure/audittrail/plugin.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package audittrail
 

--- a/backend/internal/infrastructure/audittrail/plugin_test.go
+++ b/backend/internal/infrastructure/audittrail/plugin_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package audittrail
 

--- a/backend/internal/infrastructure/automation/actions.go
+++ b/backend/internal/infrastructure/automation/actions.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/infrastructure/automation/notifier.go
+++ b/backend/internal/infrastructure/automation/notifier.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package automation (infrastructure) wires the SOAR engine's abstract action
 // ports to concrete capabilities: the multi-channel alert Notifier, the ITSM

--- a/backend/internal/infrastructure/automation/vuln_event_publisher.go
+++ b/backend/internal/infrastructure/automation/vuln_event_publisher.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package automation
 

--- a/backend/internal/infrastructure/ctimatch/matcher.go
+++ b/backend/internal/infrastructure/ctimatch/matcher.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package ctimatch wires the CTI engine (pkg/cti) to the Asset inventory and the
 // Risk Register: it sweeps every tenant's assets, intersects their CPEs against

--- a/backend/internal/infrastructure/database/database.go
+++ b/backend/internal/infrastructure/database/database.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package database
 

--- a/backend/internal/infrastructure/database/pool_config.go
+++ b/backend/internal/infrastructure/database/pool_config.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package database
 

--- a/backend/internal/infrastructure/email/email.go
+++ b/backend/internal/infrastructure/email/email.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package email
 

--- a/backend/internal/infrastructure/integrations/email/email_provider.go
+++ b/backend/internal/infrastructure/integrations/email/email_provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package providers
 

--- a/backend/internal/infrastructure/integrations/notifications/slack_provider.go
+++ b/backend/internal/infrastructure/integrations/notifications/slack_provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package providers
 

--- a/backend/internal/infrastructure/integrations/thehive/client.go
+++ b/backend/internal/infrastructure/integrations/thehive/client.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package thehive
 

--- a/backend/internal/infrastructure/integrations/thehive/client_test.go
+++ b/backend/internal/infrastructure/integrations/thehive/client_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package thehive
 

--- a/backend/internal/infrastructure/integrations/webhooks/webhook_provider.go
+++ b/backend/internal/infrastructure/integrations/webhooks/webhook_provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package providers
 

--- a/backend/internal/infrastructure/redis/client.go
+++ b/backend/internal/infrastructure/redis/client.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package redis
 

--- a/backend/internal/infrastructure/redis/mitigation_events.go
+++ b/backend/internal/infrastructure/redis/mitigation_events.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package redis
 

--- a/backend/internal/infrastructure/repository/admin_audit_event_repository.go
+++ b/backend/internal/infrastructure/repository/admin_audit_event_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_admin_audit_event_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_admin_audit_event_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_asset_dependency_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_asset_dependency_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_asset_dependency_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_asset_dependency_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_asset_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_asset_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_asset_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_asset_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_auth_audit_log_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_auth_audit_log_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_automation_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_automation_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_board_report_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_board_report_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_compliance_audit_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_compliance_audit_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_compliance_audit_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_compliance_audit_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_compliance_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_compliance_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_compliance_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_compliance_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_control_mapping_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_control_mapping_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_control_mapping_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_control_mapping_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_cti_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_cti_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_governance_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_governance_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_incident_counter.go
+++ b/backend/internal/infrastructure/repository/gorm_incident_counter.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_mfa_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_mfa_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_organization_member_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_organization_member_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_organization_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_organization_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_organization_role_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_organization_role_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_personal_access_token_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_personal_access_token_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_risk_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_risk_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_risk_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_risk_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_risk_review_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_risk_review_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_risk_scoring_weights_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_risk_scoring_weights_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_scanner_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_scanner_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_user_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_user_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_vuln_integration_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_vuln_integration_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/gorm_vulnerability_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_vulnerability_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/interfaces.go
+++ b/backend/internal/infrastructure/repository/interfaces.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/mfa_repository_interface.go
+++ b/backend/internal/infrastructure/repository/mfa_repository_interface.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/mitigation_repository.go
+++ b/backend/internal/infrastructure/repository/mitigation_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/mitigation_subaction_repository.go
+++ b/backend/internal/infrastructure/repository/mitigation_subaction_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/notification_repository.go
+++ b/backend/internal/infrastructure/repository/notification_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/notification_repository_test.go
+++ b/backend/internal/infrastructure/repository/notification_repository_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/risk_repo.go
+++ b/backend/internal/infrastructure/repository/risk_repo.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/repository/risk_repository.go
+++ b/backend/internal/infrastructure/repository/risk_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package repository
 

--- a/backend/internal/infrastructure/scanmitigation/detector.go
+++ b/backend/internal/infrastructure/scanmitigation/detector.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package scanmitigation implements scanner.MitigationAutoDetector: it turns a
 // remediated finding (a CVE that a follow-up scan no longer detects) into an

--- a/backend/internal/infrastructure/vulnrisk/creator.go
+++ b/backend/internal/infrastructure/vulnrisk/creator.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package vulnrisk wires the vulnerability register to the Risk Register: a
 // high-priority (P1 / CISA-KEV) vulnerability attributed to an asset is turned

--- a/backend/internal/infrastructure/workers/automation_worker.go
+++ b/backend/internal/infrastructure/workers/automation_worker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/mitigation_event_worker.go
+++ b/backend/internal/infrastructure/workers/mitigation_event_worker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/risk_review_worker.go
+++ b/backend/internal/infrastructure/workers/risk_review_worker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/scan_scheduler.go
+++ b/backend/internal/infrastructure/workers/scan_scheduler.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/score_worker.go
+++ b/backend/internal/infrastructure/workers/score_worker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/sla_monitor.go
+++ b/backend/internal/infrastructure/workers/sla_monitor.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/sync_engine.go
+++ b/backend/internal/infrastructure/workers/sync_engine.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/infrastructure/workers/sync_engine_test.go
+++ b/backend/internal/infrastructure/workers/sync_engine_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package workers
 

--- a/backend/internal/middleware/alert_manager.go
+++ b/backend/internal/middleware/alert_manager.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/context.go
+++ b/backend/internal/middleware/context.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/metrics_collector.go
+++ b/backend/internal/middleware/metrics_collector.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/pat_middleware.go
+++ b/backend/internal/middleware/pat_middleware.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/pat_middleware_test.go
+++ b/backend/internal/middleware/pat_middleware_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/permission.go
+++ b/backend/internal/middleware/permission.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/permission_middleware.go
+++ b/backend/internal/middleware/permission_middleware.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/permission_test.go
+++ b/backend/internal/middleware/permission_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/protect.go
+++ b/backend/internal/middleware/protect.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/security_hardening.go
+++ b/backend/internal/middleware/security_hardening.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/tokenauth.go
+++ b/backend/internal/middleware/tokenauth.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/middleware/tokenauth_test.go
+++ b/backend/internal/middleware/tokenauth_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package middleware
 

--- a/backend/internal/migrations/migrator.go
+++ b/backend/internal/migrations/migrator.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package migrations
 

--- a/backend/internal/repository/integrations.go
+++ b/backend/internal/repository/integrations.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package ports
 

--- a/backend/internal/repository/multitenancy_repository.go
+++ b/backend/internal/repository/multitenancy_repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package ports
 

--- a/backend/internal/scanner/agent_scanner.go
+++ b/backend/internal/scanner/agent_scanner.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/agentauth.go
+++ b/backend/internal/scanner/agentauth.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/cloud.go
+++ b/backend/internal/scanner/cloud.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/collectors/active_directory.go
+++ b/backend/internal/scanner/collectors/active_directory.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/active_directory_test.go
+++ b/backend/internal/scanner/collectors/active_directory_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/aws.go
+++ b/backend/internal/scanner/collectors/aws.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package collectors holds the real cloud-SDK enumerators that plug into the
 // scan engine's CloudCollector seam. Keeping them out of internal/scanner keeps

--- a/backend/internal/scanner/collectors/azure.go
+++ b/backend/internal/scanner/collectors/azure.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/docker.go
+++ b/backend/internal/scanner/collectors/docker.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/docker_test.go
+++ b/backend/internal/scanner/collectors/docker_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/gcp.go
+++ b/backend/internal/scanner/collectors/gcp.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/github.go
+++ b/backend/internal/scanner/collectors/github.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/github_test.go
+++ b/backend/internal/scanner/collectors/github_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/gitlab.go
+++ b/backend/internal/scanner/collectors/gitlab.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/gitlab_test.go
+++ b/backend/internal/scanner/collectors/gitlab_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/kubernetes.go
+++ b/backend/internal/scanner/collectors/kubernetes.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/kubernetes_test.go
+++ b/backend/internal/scanner/collectors/kubernetes_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/m365.go
+++ b/backend/internal/scanner/collectors/m365.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/m365_test.go
+++ b/backend/internal/scanner/collectors/m365_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/collectors/vmware.go
+++ b/backend/internal/scanner/collectors/vmware.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package collectors
 

--- a/backend/internal/scanner/collectors/vmware_test.go
+++ b/backend/internal/scanner/collectors/vmware_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 
 package collectors
 

--- a/backend/internal/scanner/dedupe.go
+++ b/backend/internal/scanner/dedupe.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/lock.go
+++ b/backend/internal/scanner/lock.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/mitigation.go
+++ b/backend/internal/scanner/mitigation.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/normalize.go
+++ b/backend/internal/scanner/normalize.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/notify.go
+++ b/backend/internal/scanner/notify.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/pipeline.go
+++ b/backend/internal/scanner/pipeline.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/preview.go
+++ b/backend/internal/scanner/preview.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/registry.go
+++ b/backend/internal/scanner/registry.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package scanner is the OpenRisk scan engine. It defines the Scanner port,
 // the discovery DTOs pushed by cloud SDKs and on-prem Agents, and the pipeline

--- a/backend/internal/scanner/scanner_test.go
+++ b/backend/internal/scanner/scanner_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scanner
 

--- a/backend/internal/service/admin_audit_service.go
+++ b/backend/internal/service/admin_audit_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/ai_risk_predictor_service.go
+++ b/backend/internal/service/ai_risk_predictor_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/analytics_service.go
+++ b/backend/internal/service/analytics_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/audit_service.go
+++ b/backend/internal/service/audit_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/audit_service_test.go
+++ b/backend/internal/service/audit_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/bulk_operation_service.go
+++ b/backend/internal/service/bulk_operation_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/cache_service.go
+++ b/backend/internal/service/cache_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/cache_service_test.go
+++ b/backend/internal/service/cache_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/custom_field_service.go
+++ b/backend/internal/service/custom_field_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/dashboard_data_service.go
+++ b/backend/internal/service/dashboard_data_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/gamification_service.go
+++ b/backend/internal/service/gamification_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/incident_service.go
+++ b/backend/internal/service/incident_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/marketplace_service.go
+++ b/backend/internal/service/marketplace_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/marketplace_service_test.go
+++ b/backend/internal/service/marketplace_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/migration_service.go
+++ b/backend/internal/service/migration_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/multitenancy_auth_service.go
+++ b/backend/internal/service/multitenancy_auth_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/multitenancy_org_service.go
+++ b/backend/internal/service/multitenancy_org_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/notification_service.go
+++ b/backend/internal/service/notification_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/notification_service_test.go
+++ b/backend/internal/service/notification_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/oauth_state_service.go
+++ b/backend/internal/service/oauth_state_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/organization_service.go
+++ b/backend/internal/service/organization_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/performance_optimizer.go
+++ b/backend/internal/service/performance_optimizer.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/permission_service.go
+++ b/backend/internal/service/permission_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/permission_service_test.go
+++ b/backend/internal/service/permission_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/query_optimizer.go
+++ b/backend/internal/service/query_optimizer.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/query_optimizer_test.go
+++ b/backend/internal/service/query_optimizer_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/recommendation_service.go
+++ b/backend/internal/service/recommendation_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/risk_timeline_service.go
+++ b/backend/internal/service/risk_timeline_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/role_service.go
+++ b/backend/internal/service/role_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/score_engine_service.go
+++ b/backend/internal/service/score_engine_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/score_engine_service_test.go
+++ b/backend/internal/service/score_engine_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/tenant_service.go
+++ b/backend/internal/service/tenant_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/token_service.go
+++ b/backend/internal/service/token_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/token_service_test.go
+++ b/backend/internal/service/token_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/trend_analysis_service.go
+++ b/backend/internal/service/trend_analysis_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package service
 

--- a/backend/internal/vulnscan/connectors.go
+++ b/backend/internal/vulnscan/connectors.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnscan
 

--- a/backend/internal/vulnscan/livepull/livepull.go
+++ b/backend/internal/vulnscan/livepull/livepull.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package livepull turns a configured vulnerability integration into a set of
 // NATIVE findings by calling the tool's REST API. The findings it returns are in

--- a/backend/internal/vulnscan/livepull/livepull_test.go
+++ b/backend/internal/vulnscan/livepull/livepull_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package livepull
 

--- a/backend/internal/vulnscan/livepull/pullers.go
+++ b/backend/internal/vulnscan/livepull/pullers.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package livepull
 

--- a/backend/internal/vulnscan/normalize.go
+++ b/backend/internal/vulnscan/normalize.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package vulnscan is the vulnerability-management integration layer. Each
 // supported product (Nessus, OpenVAS, Qualys, Microsoft Defender, AWS Inspector,

--- a/backend/pkg/ai/advisor.go
+++ b/backend/pkg/ai/advisor.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package ai turns an already-aggregated risk/compliance posture into a
 // board-ready, non-technical narrative. It is deliberately split in two:

--- a/backend/pkg/ai/assistant.go
+++ b/backend/pkg/ai/assistant.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/assistant_factory.go
+++ b/backend/pkg/ai/assistant_factory.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/claude_advisor.go
+++ b/backend/pkg/ai/claude_advisor.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/claude_assistant.go
+++ b/backend/pkg/ai/claude_assistant.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/factory.go
+++ b/backend/pkg/ai/factory.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/template_advisor.go
+++ b/backend/pkg/ai/template_advisor.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/template_advisor_test.go
+++ b/backend/pkg/ai/template_advisor_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/template_assistant.go
+++ b/backend/pkg/ai/template_assistant.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/ai/template_assistant_test.go
+++ b/backend/pkg/ai/template_assistant_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ai
 

--- a/backend/pkg/auth/blacklist.go
+++ b/backend/pkg/auth/blacklist.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/pkg/auth/jwt.go
+++ b/backend/pkg/auth/jwt.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/pkg/auth/jwt_test.go
+++ b/backend/pkg/auth/jwt_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/pkg/auth/rsa.go
+++ b/backend/pkg/auth/rsa.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/pkg/auth/token.go
+++ b/backend/pkg/auth/token.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package auth
 

--- a/backend/pkg/cache/advanced_cache.go
+++ b/backend/pkg/cache/advanced_cache.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cache
 

--- a/backend/pkg/cache/cache.go
+++ b/backend/pkg/cache/cache.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cache
 

--- a/backend/pkg/cache/decoration.go
+++ b/backend/pkg/cache/decoration.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cache
 

--- a/backend/pkg/cache/errors.go
+++ b/backend/pkg/cache/errors.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cache
 

--- a/backend/pkg/cache/pool.go
+++ b/backend/pkg/cache/pool.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cache
 

--- a/backend/pkg/compliance/catalog.go
+++ b/backend/pkg/compliance/catalog.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package compliance holds regulatory control catalogs: static reference data a tenant can
 // import into their own ComplianceFramework/ComplianceControl rows (see

--- a/backend/pkg/compliance/catalog_antic_cm_2010.go
+++ b/backend/pkg/compliance/catalog_antic_cm_2010.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_bceao_2002.go
+++ b/backend/pkg/compliance/catalog_bceao_2002.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_cis_v8.go
+++ b/backend/pkg/compliance/catalog_cis_v8.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_cobac_2016.go
+++ b/backend/pkg/compliance/catalog_cobac_2016.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_dora_2022_2554.go
+++ b/backend/pkg/compliance/catalog_dora_2022_2554.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_gdpr_2016_679.go
+++ b/backend/pkg/compliance/catalog_gdpr_2016_679.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_hipaa_security.go
+++ b/backend/pkg/compliance/catalog_hipaa_security.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_iso27001_2022.go
+++ b/backend/pkg/compliance/catalog_iso27001_2022.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_iso27005_2022.go
+++ b/backend/pkg/compliance/catalog_iso27005_2022.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_iso31000_2018.go
+++ b/backend/pkg/compliance/catalog_iso31000_2018.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_nis2_2022_2555.go
+++ b/backend/pkg/compliance/catalog_nis2_2022_2555.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_nist_800_53_r5.go
+++ b/backend/pkg/compliance/catalog_nist_800_53_r5.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_nist_csf_2_0.go
+++ b/backend/pkg/compliance/catalog_nist_csf_2_0.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_pci_dss_4_0.go
+++ b/backend/pkg/compliance/catalog_pci_dss_4_0.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_placeholders.go
+++ b/backend/pkg/compliance/catalog_placeholders.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_soc2_tsc.go
+++ b/backend/pkg/compliance/catalog_soc2_tsc.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_sox_2002.go
+++ b/backend/pkg/compliance/catalog_sox_2002.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/compliance/catalog_test.go
+++ b/backend/pkg/compliance/catalog_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package compliance
 

--- a/backend/pkg/crq/crq.go
+++ b/backend/pkg/crq/crq.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package crq is OpenRisk's Cyber Risk Quantification engine. It turns a risk's
 // qualitative posture (or explicit loss inputs) into a monetary figure in both

--- a/backend/pkg/crq/crq_test.go
+++ b/backend/pkg/crq/crq_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package crq
 

--- a/backend/pkg/crq/financial.go
+++ b/backend/pkg/crq/financial.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // financial.go extends the CRQ engine (crq.go) from a bare ALE = SLE × ARO into
 // the full quantitative model expected by spec §9 "Quantification financière":

--- a/backend/pkg/crq/financial_test.go
+++ b/backend/pkg/crq/financial_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package crq
 

--- a/backend/pkg/crypto/aes.go
+++ b/backend/pkg/crypto/aes.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package crypto
 

--- a/backend/pkg/cti/client.go
+++ b/backend/pkg/cti/client.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/cti.go
+++ b/backend/pkg/cti/cti.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/embed.go
+++ b/backend/pkg/cti/embed.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/matcher.go
+++ b/backend/pkg/cti/matcher.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/model.go
+++ b/backend/pkg/cti/model.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/repository.go
+++ b/backend/pkg/cti/repository.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/service.go
+++ b/backend/pkg/cti/service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/cti/sync.go
+++ b/backend/pkg/cti/sync.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package cti
 

--- a/backend/pkg/events/events.go
+++ b/backend/pkg/events/events.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package events
 

--- a/backend/pkg/monitoring/metrics.go
+++ b/backend/pkg/monitoring/metrics.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package monitoring
 

--- a/backend/pkg/notify/chatops.go
+++ b/backend/pkg/notify/chatops.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package notify
 

--- a/backend/pkg/notify/chatops_test.go
+++ b/backend/pkg/notify/chatops_test.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package notify
 

--- a/backend/pkg/notify/email_service.go
+++ b/backend/pkg/notify/email_service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package notify
 

--- a/backend/pkg/otp/totp.go
+++ b/backend/pkg/otp/totp.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package otp
 

--- a/backend/pkg/report/board_pdf.go
+++ b/backend/pkg/report/board_pdf.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package report
 

--- a/backend/pkg/report/board_pdf_test.go
+++ b/backend/pkg/report/board_pdf_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package report
 

--- a/backend/pkg/report/compliance_pdf.go
+++ b/backend/pkg/report/compliance_pdf.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package report
 

--- a/backend/pkg/report/compliance_pdf_test.go
+++ b/backend/pkg/report/compliance_pdf_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package report
 

--- a/backend/pkg/report/model.go
+++ b/backend/pkg/report/model.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package report renders official, print-ready compliance documents (PDF) from
 // already-assembled data. It is intentionally pure: it never touches a database

--- a/backend/pkg/scoring/engine.go
+++ b/backend/pkg/scoring/engine.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring
 

--- a/backend/pkg/scoring/errors.go
+++ b/backend/pkg/scoring/errors.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring
 

--- a/backend/pkg/scoring/scorer_test.go
+++ b/backend/pkg/scoring/scorer_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring_test
 

--- a/backend/pkg/scoring/scoring.go
+++ b/backend/pkg/scoring/scoring.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring
 

--- a/backend/pkg/scoring/smart.go
+++ b/backend/pkg/scoring/smart.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring
 

--- a/backend/pkg/scoring/smart_test.go
+++ b/backend/pkg/scoring/smart_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package scoring
 

--- a/backend/pkg/storage/local.go
+++ b/backend/pkg/storage/local.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package storage
 

--- a/backend/pkg/storage/local_test.go
+++ b/backend/pkg/storage/local_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package storage
 

--- a/backend/pkg/storage/storage.go
+++ b/backend/pkg/storage/storage.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package storage provides a driver-agnostic blob store for user-uploaded
 // files (e.g. compliance evidence). Callers are responsible for tenant

--- a/backend/pkg/ticketing/jira.go
+++ b/backend/pkg/ticketing/jira.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ticketing
 

--- a/backend/pkg/ticketing/servicenow.go
+++ b/backend/pkg/ticketing/servicenow.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ticketing
 

--- a/backend/pkg/ticketing/ticketing.go
+++ b/backend/pkg/ticketing/ticketing.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 // Package ticketing opens ITSM tickets (Jira, ServiceNow) from OpenRisk. Each
 // provider makes REAL authenticated REST calls; with absent/wrong credentials it

--- a/backend/pkg/ticketing/ticketing_test.go
+++ b/backend/pkg/ticketing/ticketing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 package ticketing
 

--- a/backend/pkg/validation/validator.go
+++ b/backend/pkg/validation/validator.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package validation
 

--- a/backend/pkg/vulnprio/vulnprio.go
+++ b/backend/pkg/vulnprio/vulnprio.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Package vulnprio is a pure, deterministic vulnerability-prioritisation engine.
 //

--- a/backend/pkg/vulnprio/vulnprio_test.go
+++ b/backend/pkg/vulnprio/vulnprio_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package vulnprio
 

--- a/backend/tests/analytics_compliance_test.go
+++ b/backend/tests/analytics_compliance_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/tests/enterprise_features_test.go
+++ b/backend/tests/enterprise_features_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package tests
 

--- a/backend/tests/permission_service_test.go
+++ b/backend/tests/permission_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/tests/rbac_integration_test.go
+++ b/backend/tests/rbac_integration_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/tests/role_service_test.go
+++ b/backend/tests/role_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/backend/tests/tenant_service_test.go
+++ b/backend/tests/tenant_service_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 //go:build integration
 // +build integration

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';

--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/frontend/src/__tests__/e2e.rbac.test.ts
+++ b/frontend/src/__tests__/e2e.rbac.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';

--- a/frontend/src/api/scoreEngineService.ts
+++ b/frontend/src/api/scoreEngineService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useAuthStore } from '../hooks/useAuthStore';
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import type { ReactNode } from 'react';
 

--- a/frontend/src/components/ViewToggle.tsx
+++ b/frontend/src/components/ViewToggle.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { LayoutGrid, List } from 'lucide-react';
 import { cn } from './ui/Button';

--- a/frontend/src/components/dashboard/AnalyticsDashboardToolbar.tsx
+++ b/frontend/src/components/dashboard/AnalyticsDashboardToolbar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { Filter, Download, RefreshCw, Settings } from 'lucide-react';

--- a/frontend/src/components/dashboard/ChartWidget.tsx
+++ b/frontend/src/components/dashboard/ChartWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { ChevronDown } from 'lucide-react';

--- a/frontend/src/components/dashboard/DashboardFilter.tsx
+++ b/frontend/src/components/dashboard/DashboardFilter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';

--- a/frontend/src/components/dashboard/DataTableWidget.tsx
+++ b/frontend/src/components/dashboard/DataTableWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { MoreVertical, TrendingUp, Users, AlertTriangle, CheckCircle } from 'lucide-react';

--- a/frontend/src/components/dashboard/MetricCard.tsx
+++ b/frontend/src/components/dashboard/MetricCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { TrendingUp, TrendingDown, AlertCircle } from 'lucide-react';

--- a/frontend/src/components/dashboard/RBACDashboardWidget.tsx
+++ b/frontend/src/components/dashboard/RBACDashboardWidget.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { Shield, Users, Zap } from 'lucide-react';

--- a/frontend/src/components/gamification/AchievementTrackingUI.tsx
+++ b/frontend/src/components/gamification/AchievementTrackingUI.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
+++ b/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/components/gamification/GamificationDashboard.tsx
+++ b/frontend/src/components/gamification/GamificationDashboard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Global glass header (OpenRisk.dc.html §5): breadcrumb · ⌘K search · realtime
 // dot · language · voice · notifications · theme. Sticky, backdrop-blurred, sits

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // ⌘K / Ctrl+K command palette (OpenRisk.dc.html §8). Glass overlay, autofocused
 // input, grouped Navigation + Quick actions filtered as you type. Esc / backdrop

--- a/frontend/src/components/layout/NotificationCenter.tsx
+++ b/frontend/src/components/layout/NotificationCenter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { Bell, X, Check, AlertCircle, Info, AlertTriangle } from 'lucide-react';

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { Plus, Bell, Search, ChevronLeft, ChevronRight, Filter } from 'lucide-react';
 import { Button } from '../ui/Button';

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';

--- a/frontend/src/components/notifications/NotificationBadge.tsx
+++ b/frontend/src/components/notifications/NotificationBadge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState } from 'react';
 import './NotificationBadge.css';

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState, useCallback } from 'react';
 import axios from 'axios';

--- a/frontend/src/components/notifications/NotificationPreferences.tsx
+++ b/frontend/src/components/notifications/NotificationPreferences.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';

--- a/frontend/src/components/notifications/__tests__/notifications.test.tsx
+++ b/frontend/src/components/notifications/__tests__/notifications.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';

--- a/frontend/src/components/notifications/index.ts
+++ b/frontend/src/components/notifications/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Notification System Component Exports
 export { default as NotificationBadge } from './NotificationBadge';

--- a/frontend/src/components/rbac/PermissionGates.tsx
+++ b/frontend/src/components/rbac/PermissionGates.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { usePermissions } from '../../hooks/usePermissions';

--- a/frontend/src/components/rbac/PermissionRoutes.tsx
+++ b/frontend/src/components/rbac/PermissionRoutes.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { useAuthStore } from '../../hooks/useAuthStore';

--- a/frontend/src/components/rbac/RoleTemplateBuilder.tsx
+++ b/frontend/src/components/rbac/RoleTemplateBuilder.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useMemo, useState } from 'react';
 import { ChevronRight, Copy, Plus, Shield, Trash2 } from 'lucide-react';

--- a/frontend/src/components/rbac/__tests__/PermissionGates.test.tsx
+++ b/frontend/src/components/rbac/__tests__/PermissionGates.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';

--- a/frontend/src/components/search/AdvancedSearch.tsx
+++ b/frontend/src/components/search/AdvancedSearch.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Advanced Search/Typeahead Component

--- a/frontend/src/components/shared/AutoDetectedBadge.tsx
+++ b/frontend/src/components/shared/AutoDetectedBadge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { Zap } from 'lucide-react';

--- a/frontend/src/components/shared/EmptyState.tsx
+++ b/frontend/src/components/shared/EmptyState.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { Button } from '../ui/Button';

--- a/frontend/src/components/shared/FloatingBulkBar.tsx
+++ b/frontend/src/components/shared/FloatingBulkBar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Trash2, Check } from 'lucide-react';

--- a/frontend/src/components/shared/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/shared/RiskBadge.tsx
+++ b/frontend/src/components/shared/RiskBadge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { AlertCircle, AlertTriangle, Info, AlertOctagon } from 'lucide-react';

--- a/frontend/src/components/shared/ScoreMeter.tsx
+++ b/frontend/src/components/shared/ScoreMeter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/shared/SkeletonTable.tsx
+++ b/frontend/src/components/shared/SkeletonTable.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion, type Variants } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/shared/StatusDot.tsx
+++ b/frontend/src/components/shared/StatusDot.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/shared/UserAvatar.tsx
+++ b/frontend/src/components/shared/UserAvatar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Design System Components
 export { RiskBadge } from './RiskBadge';

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { type ButtonHTMLAttributes, forwardRef } from 'react';
 import { clsx, type ClassValue } from 'clsx';

--- a/frontend/src/components/ui/Drawer.tsx
+++ b/frontend/src/components/ui/Drawer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { type InputHTMLAttributes, forwardRef } from 'react';
 import { cn } from './Button';

--- a/frontend/src/config/rbacConfig.ts
+++ b/frontend/src/config/rbacConfig.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Centralized RBAC Configuration

--- a/frontend/src/features/ai/AiAdvisor.tsx
+++ b/frontend/src/features/ai/AiAdvisor.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // IA Advisor (spec §12.3 — Assistant en langage naturel). A centered conversational
 // UI wired to the LIVE backend (/ai/assistant/query): the assistant answers over the

--- a/frontend/src/features/ai/AiAuditReportButton.tsx
+++ b/frontend/src/features/ai/AiAuditReportButton.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // "Rapport IA" button + modal (spec §12.4): generates an executive audit report
 // from an audit campaign via POST /ai/audits/:id/report. Composes the audit, a

--- a/frontend/src/features/ai/AiEvidenceAnalysis.tsx
+++ b/frontend/src/features/ai/AiEvidenceAnalysis.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Inline AI evidence analysis (spec §12.5): a compact "Analyser (IA)" control
 // under an uploaded evidence that checks, via POST /ai/evidence/:id/analyze,

--- a/frontend/src/features/ai/EmergingRisksPage.tsx
+++ b/frontend/src/features/ai/EmergingRisksPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Emerging-risk detection (spec §12.2): paste a threat-intel report, a news
 // snippet or logs, and the AI extracts candidate new risks (title, severity,

--- a/frontend/src/features/ai/aiService.ts
+++ b/frontend/src/features/ai/aiService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Typed client for the GRC AI assistant (/ai/*). Shapes mirror
 // backend/pkg/ai/assistant.go and internal/application/ai. Every endpoint is

--- a/frontend/src/features/ai/useAi.ts
+++ b/frontend/src/features/ai/useAi.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // React Query hooks for the GRC AI assistant.
 

--- a/frontend/src/features/analytics/ExecutiveDashboard.tsx
+++ b/frontend/src/features/analytics/ExecutiveDashboard.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
 //
 // Executive dashboard (spec §11 « Tableau de bord exécutif ») — a board-level view
 // of the whole security posture: a cyber-score grade, financial exposure, key risk

--- a/frontend/src/features/analytics/executiveService.ts
+++ b/frontend/src/features/analytics/executiveService.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
 //
 // Typed client for the Executive Dashboard API (spec §11 « Tableau de bord
 // exécutif »). Mirrors internal/application/dashboard.ExecutiveDashboard — one

--- a/frontend/src/features/analytics/useExecutive.ts
+++ b/frontend/src/features/analytics/useExecutive.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
 
 import { useQuery } from '@tanstack/react-query';
 import { executiveService } from './executiveService';

--- a/frontend/src/features/assets/AssetHistoryDrawer.tsx
+++ b/frontend/src/features/assets/AssetHistoryDrawer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { Clock, History, User } from 'lucide-react';
 import { Drawer } from '../../components/ui/Drawer';

--- a/frontend/src/features/assets/AssetsPage.tsx
+++ b/frontend/src/features/assets/AssetsPage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { Database, Edit2, History, HardDrive, Laptop, Plus, Server, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/assets/CreateAssetModal.tsx
+++ b/frontend/src/features/assets/CreateAssetModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';

--- a/frontend/src/features/assets/CriticalityBadge.tsx
+++ b/frontend/src/features/assets/CriticalityBadge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 const COLORS: Record<string, string> = {
   CRITICAL: 'bg-red-500/10 text-red-500 border-red-500/20',

--- a/frontend/src/features/assets/EditAssetModal.tsx
+++ b/frontend/src/features/assets/EditAssetModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/assets/InventoryPage.tsx
+++ b/frontend/src/features/assets/InventoryPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Inventory (OpenRisk.dc.html §6.12) — wired to the real /assets store. Asset table
 // with type-icon, criticality badge, derived score (max of linked risks), linked-risk

--- a/frontend/src/features/assets/store.ts
+++ b/frontend/src/features/assets/store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 

--- a/frontend/src/features/assets/useAssetDependencies.ts
+++ b/frontend/src/features/assets/useAssetDependencies.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks over the real /asset-dependencies endpoints. Backs the
 // dependency cartography (Asset Universe) and the per-asset dependency editor.

--- a/frontend/src/features/assets/useAssets.ts
+++ b/frontend/src/features/assets/useAssets.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';

--- a/frontend/src/features/auth/AuthScreen.tsx
+++ b/frontend/src/features/auth/AuthScreen.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Auth (OpenRisk.dc.html §6.1): split-screen 45/55 — animated orbit + Schneier
 // quote on the left, Login / Register / MFA forms on the right. The Login form is

--- a/frontend/src/features/automation/AutomationPage.tsx
+++ b/frontend/src/features/automation/AutomationPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Security Automation / SOAR (spec §10 « Automatisation »). Four views:
 //  - Rules: the workflow builder — each rule shows its trigger → action chain.

--- a/frontend/src/features/automation/RuleEditorModal.tsx
+++ b/frontend/src/features/automation/RuleEditorModal.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Create / edit an automation rule: trigger + conditions + an ordered action
 // chain + an optional SLA policy. This is the visual workflow builder for §10.

--- a/frontend/src/features/automation/automationMeta.ts
+++ b/frontend/src/features/automation/automationMeta.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Display metadata for the automation module: triggers, action types, notify
 // channels, execution + SLA statuses. Kept separate so the page/editor share it.

--- a/frontend/src/features/automation/automationService.ts
+++ b/frontend/src/features/automation/automationService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Typed client for the Security Automation / SOAR module (/automation/*).
 // Shapes mirror backend/internal/domain/automation.go. Rules bind a trigger to

--- a/frontend/src/features/automation/useAutomation.ts
+++ b/frontend/src/features/automation/useAutomation.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // React Query hooks for the Security Automation / SOAR module.
 

--- a/frontend/src/features/compliance/AuditRemediationModals.tsx
+++ b/frontend/src/features/compliance/AuditRemediationModals.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Dialogs for compliance audits and remediation plans, in the dc.html design
 // language. Reuse the shared modal primitives from ComplianceModals.tsx.

--- a/frontend/src/features/compliance/AuditsPage.tsx
+++ b/frontend/src/features/compliance/AuditsPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Compliance audits ("Audits" — planification, exécution, historique). Wired to
 // GET/POST/PATCH/DELETE /compliance/audits. Schedule an audit, move it through

--- a/frontend/src/features/compliance/ComplianceGauge.tsx
+++ b/frontend/src/features/compliance/ComplianceGauge.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { ProgressBar } from '../../components/shared/ProgressBar';

--- a/frontend/src/features/compliance/ComplianceModals.tsx
+++ b/frontend/src/features/compliance/ComplianceModals.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Compliance dialogs in the dc.html design language (co-located with the
 // EvidenceDrawer they sit next to): create a blank framework, import a

--- a/frontend/src/features/compliance/CompliancePage.tsx
+++ b/frontend/src/features/compliance/CompliancePage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/compliance/ComplianceScreen.tsx
+++ b/frontend/src/features/compliance/ComplianceScreen.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Compliance (OpenRisk.dc.html §6.10) — wired to real /compliance/frameworks +
 // per-framework progress. Posture hero (aggregate radial + copy + CTAs) and a grid

--- a/frontend/src/features/compliance/ControlDrawer.tsx
+++ b/frontend/src/features/compliance/ControlDrawer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/compliance/ControlMappingsSection.tsx
+++ b/frontend/src/features/compliance/ControlMappingsSection.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Cross-framework control mappings ("cross-mapping entre référentiels") shown
 // inside a control's drawer: the crosswalks that tie this control to equivalent

--- a/frontend/src/features/compliance/ControlTable.tsx
+++ b/frontend/src/features/compliance/ControlTable.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { motion } from 'framer-motion';
 import { useI18n } from '../../hooks/useI18n';

--- a/frontend/src/features/compliance/CreateControlModal.tsx
+++ b/frontend/src/features/compliance/CreateControlModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';

--- a/frontend/src/features/compliance/CreateFrameworkModal.tsx
+++ b/frontend/src/features/compliance/CreateFrameworkModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';

--- a/frontend/src/features/compliance/FrameworkDetail.tsx
+++ b/frontend/src/features/compliance/FrameworkDetail.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Framework detail (opened from the Compliance grid): the framework's real controls
 // with reference code, source citation and an editable status. Header carries the

--- a/frontend/src/features/compliance/GapAnalysisPage.tsx
+++ b/frontend/src/features/compliance/GapAnalysisPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Gap analysis ("analyse d'écarts") — every unsatisfied control across the
 // tenant's frameworks, grouped by framework, with per-framework roll-ups. Wired

--- a/frontend/src/features/compliance/ImportCatalogModal.tsx
+++ b/frontend/src/features/compliance/ImportCatalogModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { X, Library, Clock, Loader2 } from 'lucide-react';

--- a/frontend/src/features/compliance/RemediationPage.tsx
+++ b/frontend/src/features/compliance/RemediationPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Remediation plans ("Plans de remédiation") — the actions that close compliance
 // gaps. Wired to /compliance/remediations. Create, assign a priority + due date,

--- a/frontend/src/features/compliance/complianceOverview.ts
+++ b/frontend/src/features/compliance/complianceOverview.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Combined compliance overview (frameworks + per-framework progress in one query)
 // shaped for the dc.html Compliance screen. Complements the per-framework hooks in

--- a/frontend/src/features/compliance/store.ts
+++ b/frontend/src/features/compliance/store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 

--- a/frontend/src/features/compliance/useCompliance.ts
+++ b/frontend/src/features/compliance/useCompliance.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';

--- a/frontend/src/features/compliance/utils.ts
+++ b/frontend/src/features/compliance/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import type { ComplianceControl, ComplianceProgress, ControlStatus } from '../../types/compliance';
 

--- a/frontend/src/features/cti/ThreatIntel.tsx
+++ b/frontend/src/features/cti/ThreatIntel.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Threat Intel (OpenRisk.dc.html §6.11): headline stats + a LIVE CVE feed from
 // NVD + CISA KEV (enriched with MITRE ATT&CK). "Sync feed" pulls the sources;

--- a/frontend/src/features/cti/ctiService.ts
+++ b/frontend/src/features/cti/ctiService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Typed client for the CTI / Intel Threat engine (/cti/*). Shapes mirror
 // backend/pkg/cti/model.go (CTIVulnerability) and the cti_handler responses.

--- a/frontend/src/features/cti/useCTI.ts
+++ b/frontend/src/features/cti/useCTI.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks for the CTI / Intel Threat engine. Sync + match mutations
 // invalidate the feed and stats so the page stays live.

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Signature Dashboard (OpenRisk.dc.html §6.2). Score hero gauge + count-up KPIs,
 // 5×5 probability×impact heatmap, risk-trend sparklines, recent activity and the

--- a/frontend/src/features/dashboard/components/AssetStatistics.tsx
+++ b/frontend/src/features/dashboard/components/AssetStatistics.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Cell } from 'recharts';

--- a/frontend/src/features/dashboard/components/AverageMitigationTime.tsx
+++ b/frontend/src/features/dashboard/components/AverageMitigationTime.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';

--- a/frontend/src/features/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/features/dashboard/components/DashboardGrid.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState } from 'react';
 import { ShieldAlert, CheckCircle2, Server, TrendingUp, AlertTriangle, ChevronRight, Loader2, FileDown, GripVertical, Clock, TrendingDown, Settings, BookOpen } from 'lucide-react';

--- a/frontend/src/features/dashboard/components/DashboardSettings.tsx
+++ b/frontend/src/features/dashboard/components/DashboardSettings.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { Save, RotateCcw, Eye, EyeOff, Settings } from 'lucide-react';

--- a/frontend/src/features/dashboard/components/FrameworkAnalytics.tsx
+++ b/frontend/src/features/dashboard/components/FrameworkAnalytics.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';

--- a/frontend/src/features/dashboard/components/RiskDistribution.tsx
+++ b/frontend/src/features/dashboard/components/RiskDistribution.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';

--- a/frontend/src/features/dashboard/components/RiskMatrix.tsx
+++ b/frontend/src/features/dashboard/components/RiskMatrix.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState, useMemo } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/dashboard/components/RiskTrendChart.tsx
+++ b/frontend/src/features/dashboard/components/RiskTrendChart.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';

--- a/frontend/src/features/dashboard/components/RiskTrendMultiPeriod.tsx
+++ b/frontend/src/features/dashboard/components/RiskTrendMultiPeriod.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';

--- a/frontend/src/features/dashboard/components/SecurityScore.tsx
+++ b/frontend/src/features/dashboard/components/SecurityScore.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';

--- a/frontend/src/features/dashboard/components/TopVulnerabilities.tsx
+++ b/frontend/src/features/dashboard/components/TopVulnerabilities.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/dashboard/useStats.ts
+++ b/frontend/src/features/dashboard/useStats.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Dashboard headline stats from the real /stats endpoint (tenant-scoped).
 

--- a/frontend/src/features/dashboard/widgets/GlobalScore.tsx
+++ b/frontend/src/features/dashboard/widgets/GlobalScore.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { CircularProgressbarWithChildren, buildStyles } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';

--- a/frontend/src/features/dashboard/widgets/RiskHeatmap.tsx
+++ b/frontend/src/features/dashboard/widgets/RiskHeatmap.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { ResponsiveContainer, ScatterChart, Scatter, XAxis, YAxis, ZAxis, Tooltip, Cell } from 'recharts';
 

--- a/frontend/src/features/financial/FinancialDashboard.tsx
+++ b/frontend/src/features/financial/FinancialDashboard.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
 //
 // Financial Risk Quantification dashboard (spec §9) — a CFO/CISO view of the
 // tenant's cyber exposure in money: portfolio ALE, worst-case, remediation

--- a/frontend/src/features/financial/financialService.ts
+++ b/frontend/src/features/financial/financialService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 //
 // Typed client for the Financial Risk Quantification API (spec §9). Mirrors
 // pkg/crq's FinancialAssessment / FinancialSummary. Zero `any`.

--- a/frontend/src/features/financial/useFinancial.ts
+++ b/frontend/src/features/financial/useFinancial.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { financialService, type SimulateInput } from './financialService';

--- a/frontend/src/features/gamification/LeaderboardPage.tsx
+++ b/frontend/src/features/gamification/LeaderboardPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Risk Champions Leaderboard (OpenRisk.dc.html §6.8): animated top-3 podium
 // (crowned #1 centre-raised), a ranks 4→N table and a "your position" card.

--- a/frontend/src/features/gamification/UserLevelCard.tsx
+++ b/frontend/src/features/gamification/UserLevelCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { Trophy, Star, Target, Crown, AlertCircle } from 'lucide-react';

--- a/frontend/src/features/governance/GovernancePage.tsx
+++ b/frontend/src/features/governance/GovernancePage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Governance (spec §15). Four views:
 //  - Audit trail: an interactive, filterable journal with before→after diffs + CSV export.

--- a/frontend/src/features/governance/governanceService.ts
+++ b/frontend/src/features/governance/governanceService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Typed client for the Governance module (/governance/*, spec §15). Shapes mirror
 // backend/internal/domain/governance.go: the immutable audit trail, time-boxed

--- a/frontend/src/features/governance/useGovernance.ts
+++ b/frontend/src/features/governance/useGovernance.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks for the Governance module.
 

--- a/frontend/src/features/incidents/IncidentDrawer.tsx
+++ b/frontend/src/features/incidents/IncidentDrawer.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Incident detail / edit drawer — slides in when a register row is clicked.
 // View and modify the incident (title, description, severity, status, assignee,

--- a/frontend/src/features/incidents/IncidentsScreen.tsx
+++ b/frontend/src/features/incidents/IncidentsScreen.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Incidents register (routed at /incidents) — the real, backend-wired incident
 // hub: KPI header (from /incidents/stats), status filter chips, a table with

--- a/frontend/src/features/incidents/WarRoom.tsx
+++ b/frontend/src/features/incidents/WarRoom.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // War Room (OpenRisk.dc.html §6.5): full-screen incident console for reviewing a
 // REAL incident (/incidents/:id/war-room) — top bar with its live elapsed timer,

--- a/frontend/src/features/incidents/incidentMeta.ts
+++ b/frontend/src/features/incidents/incidentMeta.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Shared incident vocabulary (severity/status labels + colors) so the register,
 // the detail drawer and the War Room all render the same badges.

--- a/frontend/src/features/incidents/incidentService.ts
+++ b/frontend/src/features/incidents/incidentService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Typed client for the incident register (/incidents). Hand-written (like the
 // mitigations service) — incidents aren't in the generated OpenAPI client. The

--- a/frontend/src/features/incidents/useIncidents.ts
+++ b/frontend/src/features/incidents/useIncidents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks for the incident register. Mutations invalidate both the
 // list and the stats so the KPI header and the table stay in sync.

--- a/frontend/src/features/infrastructure/AgentDeployModal.tsx
+++ b/frontend/src/features/infrastructure/AgentDeployModal.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // "Deploy Agent" modal for an on-premise scan config. Mints a 24h registration
 // token and shows the per-OS downloads + a ready-to-run command with the token

--- a/frontend/src/features/infrastructure/InfrastructurePage.tsx
+++ b/frontend/src/features/infrastructure/InfrastructurePage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Infrastructure — the live scan engine console. Provider cards (AWS/Azure/GCP/
 // On-Premise), scan configurations, connected on-prem Agents, and recent scans

--- a/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
+++ b/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Slide-in drawer to create a scan configuration. Cloud providers show their
 // credential fields (encrypted server-side, never returned); on-premise shows

--- a/frontend/src/features/infrastructure/ScanPreviewPage.tsx
+++ b/frontend/src/features/infrastructure/ScanPreviewPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Scan Preview — the human-in-the-loop gate. A scan's results live only in a
 // Redis preview (48h TTL); nothing is in the DB until the user imports here.

--- a/frontend/src/features/infrastructure/scannerMeta.ts
+++ b/frontend/src/features/infrastructure/scannerMeta.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Static presentation metadata for the scan engine: provider identities,
 // per-provider credential fields, status colors and small formatting helpers.

--- a/frontend/src/features/infrastructure/scannerService.ts
+++ b/frontend/src/features/infrastructure/scannerService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // Typed client for the scan engine (/scanner/*). Hand-written (like the
 // incidents/mitigations services). Shapes mirror backend/internal/domain/

--- a/frontend/src/features/infrastructure/useScanner.ts
+++ b/frontend/src/features/infrastructure/useScanner.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
 // React Query hooks for the scan engine. The jobs query self-polls while any
 // scan is in flight (queued/claimed/running) so the UI reflects agent pushes

--- a/frontend/src/features/mitigations/CreateMitigationModal.tsx
+++ b/frontend/src/features/mitigations/CreateMitigationModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationCard.tsx
+++ b/frontend/src/features/mitigations/MitigationCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
+++ b/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationEditModal.tsx
+++ b/frontend/src/features/mitigations/MitigationEditModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationGanttView.tsx
+++ b/frontend/src/features/mitigations/MitigationGanttView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo, memo, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationKanbanPage.tsx
+++ b/frontend/src/features/mitigations/MitigationKanbanPage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationTableView.tsx
+++ b/frontend/src/features/mitigations/MitigationTableView.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useMemo, memo } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/MitigationsBoard.tsx
+++ b/frontend/src/features/mitigations/MitigationsBoard.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Mitigations (OpenRisk.dc.html §6.4) — wired to the real /mitigations list, with
 // three selectable views: Kanban (To do → In progress → In review → Done), a dense

--- a/frontend/src/features/mitigations/PrioritizedMitigationsList.tsx
+++ b/frontend/src/features/mitigations/PrioritizedMitigationsList.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { api } from '../../lib/api';

--- a/frontend/src/features/mitigations/SubActionTable.tsx
+++ b/frontend/src/features/mitigations/SubActionTable.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useCallback, useMemo } from 'react';
 import {

--- a/frontend/src/features/mitigations/ViewSwitcher.tsx
+++ b/frontend/src/features/mitigations/ViewSwitcher.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { memo } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/mitigations/store.ts
+++ b/frontend/src/features/mitigations/store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import type {

--- a/frontend/src/features/mitigations/useMitigationEvents.ts
+++ b/frontend/src/features/mitigations/useMitigationEvents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Subscribes to the backend mitigation SSE stream (GET /mitigations/events).
 // When the Infrastructure Scanner auto-completes a sub-action (a CVE it can no

--- a/frontend/src/features/mitigations/useMitigations.ts
+++ b/frontend/src/features/mitigations/useMitigations.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Real /mitigations list shaped into the dc.html Kanban columns.
 

--- a/frontend/src/features/reports/BoardReportPage.tsx
+++ b/frontend/src/features/reports/BoardReportPage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
+// This file is part of the OpenRisk Enterprise Edition and is NOT covered by the
+// AGPL; it is licensed under the OpenRisk Commercial License (see LICENSE.commercial).
 
 import { useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/features/reports/ReportsScreen.tsx
+++ b/frontend/src/features/reports/ReportsScreen.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Reports (OpenRisk.dc.html §6.14): a grid of report templates wired to real
 // destinations/exports (Board report, Compliance PDFs, risk-register CSV export…),

--- a/frontend/src/features/reports/useBoardReports.ts
+++ b/frontend/src/features/reports/useBoardReports.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/risks/ImportRisksPage.tsx
+++ b/frontend/src/features/risks/ImportRisksPage.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 export { default as ImportRisksPage } from '../../pages/ImportRisks';

--- a/frontend/src/features/risks/RiskDrawer.tsx
+++ b/frontend/src/features/risks/RiskDrawer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo, useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/risks/RiskListPage.tsx
+++ b/frontend/src/features/risks/RiskListPage.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Risk Register (OpenRisk.dc.html §6.3) — wired to the real /risks store. Criticality
 // chips, a filter/search bar, a dense table with multi-select + floating bulk bar

--- a/frontend/src/features/risks/RiskWeightsSettings.tsx
+++ b/frontend/src/features/risks/RiskWeightsSettings.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 //
 // RiskWeightsSettings — admin screen to tune the eight factor weights of the
 // multifactor smart-risk model (spec §8). Weights are relative; the panel shows

--- a/frontend/src/features/risks/__tests__/CreateRiskModal.test.tsx
+++ b/frontend/src/features/risks/__tests__/CreateRiskModal.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /** @vitest-environment jsdom */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';

--- a/frontend/src/features/risks/__tests__/EditRiskModal.test.tsx
+++ b/frontend/src/features/risks/__tests__/EditRiskModal.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /** @vitest-environment jsdom */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';

--- a/frontend/src/features/risks/components/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/components/CreateRiskModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/risks/components/EditRiskModal.tsx
+++ b/frontend/src/features/risks/components/EditRiskModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';

--- a/frontend/src/features/risks/components/RiskCard.tsx
+++ b/frontend/src/features/risks/components/RiskCard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { User, Database, ShieldAlert, Box } from 'lucide-react';
 import type { Risk } from '../../../hooks/useRiskStore';

--- a/frontend/src/features/risks/components/SmartRiskRadar.tsx
+++ b/frontend/src/features/risks/components/SmartRiskRadar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 //
 // SmartRiskRadar — the visual for the multifactor smart risk score (spec §8):
 // a radar chart of the eight factor risk-contributions plus a ranked breakdown

--- a/frontend/src/features/risks/riskMap.ts
+++ b/frontend/src/features/risks/riskMap.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Maps the backend Risk shape onto the display shape the dc.html Risk Register /
 // drawer render. Normalizes the two live status vocabularies (DRAFT/ACTIVE/… and

--- a/frontend/src/features/risks/smartScoreService.ts
+++ b/frontend/src/features/risks/smartScoreService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 //
 // Typed client for the Smart Risk Calculation API (spec §8). Mirrors
 // pkg/scoring's SmartResult / FactorScore and domain.RiskScoringWeights. Zero `any`.

--- a/frontend/src/features/risks/store.ts
+++ b/frontend/src/features/risks/store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 

--- a/frontend/src/features/risks/useRisks.ts
+++ b/frontend/src/features/risks/useRisks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';

--- a/frontend/src/features/risks/useSmartScore.ts
+++ b/frontend/src/features/risks/useSmartScore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {

--- a/frontend/src/features/scoreEngine/components/ScoreEngineVisualizer.tsx
+++ b/frontend/src/features/scoreEngine/components/ScoreEngineVisualizer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/scoreEngine/pages/ScoreEngineConfiguration.tsx
+++ b/frontend/src/features/scoreEngine/pages/ScoreEngineConfiguration.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/settings/GeneralTab.tsx
+++ b/frontend/src/features/settings/GeneralTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { useAuthStore } from '../../hooks/useAuthStore';

--- a/frontend/src/features/settings/IntegrationsTab.tsx
+++ b/frontend/src/features/settings/IntegrationsTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { ShieldAlert, Database, Box, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';

--- a/frontend/src/features/settings/RBACTab.tsx
+++ b/frontend/src/features/settings/RBACTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/features/settings/SettingsScreen.tsx
+++ b/frontend/src/features/settings/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Settings (OpenRisk.dc.html §6.16) — the consolidation point for every admin
 // feature. Internal nav + tabs: General, Members (real /users), RBAC, API Tokens

--- a/frontend/src/features/settings/TeamTab.tsx
+++ b/frontend/src/features/settings/TeamTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { Shield, Plus, Trash2, Users, Edit2 } from 'lucide-react';

--- a/frontend/src/features/settings/adminData.ts
+++ b/frontend/src/features/settings/adminData.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Data hooks for the admin features consolidated into Settings. Members, API
 // Tokens and Custom Fields are live; Roles / Organizations / Audit-log endpoints

--- a/frontend/src/features/simulations/SimulationsPage.tsx
+++ b/frontend/src/features/simulations/SimulationsPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Simulations — Risk Digital Twin (OpenRisk.dc.html §6.7): impact gauge + blast
 // radius chain, AI-suggested scenarios, run history, and the "propagating…"

--- a/frontend/src/features/universe/AssetUniverse.tsx
+++ b/frontend/src/features/universe/AssetUniverse.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Asset Universe — the dependency cartography ("cartographie des dépendances
 // entre actifs"). A force-directed graph on a raw <canvas> with an IN-HOUSE

--- a/frontend/src/features/users/CreateUserModal.tsx
+++ b/frontend/src/features/users/CreateUserModal.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/features/vulnerabilities/IngestModal.tsx
+++ b/frontend/src/features/vulnerabilities/IngestModal.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Import findings from a named integration: pick the source, paste the tool's
 // native findings JSON (an array of objects, exactly as exported), submit. The

--- a/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
+++ b/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Integration configuration screen: wire each scanner (API credentials + inbound
 // webhook + live-pull schedule + auto-risk/auto-ticket toggles) and the tenant

--- a/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
+++ b/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Vulnerability Management (Module 3). A tenant-scoped register of findings
 // ingested from Nessus/OpenVAS/Qualys/Defender/Inspector/Azure Defender/

--- a/frontend/src/features/vulnerabilities/useVulnIntegrations.ts
+++ b/frontend/src/features/vulnerabilities/useVulnIntegrations.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks for vulnerability-integration + ticketing configuration.
 

--- a/frontend/src/features/vulnerabilities/useVulnerabilities.ts
+++ b/frontend/src/features/vulnerabilities/useVulnerabilities.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // React Query hooks for the vulnerability register.
 

--- a/frontend/src/features/vulnerabilities/vulnIntegrationMeta.ts
+++ b/frontend/src/features/vulnerabilities/vulnIntegrationMeta.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Per-source connector metadata for the integration config screen: which
 // credential fields each scanner needs, whether it exposes a real live-pull, and

--- a/frontend/src/features/vulnerabilities/vulnIntegrationsService.ts
+++ b/frontend/src/features/vulnerabilities/vulnIntegrationsService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Typed client for vulnerability-integration configuration:
 //   - scanner connectors (encrypted API credentials, live-pull, inbound webhook,

--- a/frontend/src/features/vulnerabilities/vulnMeta.ts
+++ b/frontend/src/features/vulnerabilities/vulnMeta.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Display metadata (colors + FR/EN labels) shared by the register, drawer and
 // ingest modal. Kept in one place so the vocabulary stays consistent.

--- a/frontend/src/features/vulnerabilities/vulnerabilityService.ts
+++ b/frontend/src/features/vulnerabilities/vulnerabilityService.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Typed client for the vulnerability-management module (/vulnerabilities/*).
 // Shapes mirror backend/internal/domain/vulnerability.go. Findings are ingested

--- a/frontend/src/hooks/__tests__/useRiskStore.test.ts
+++ b/frontend/src/hooks/__tests__/useRiskStore.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { useRiskStore } from '../useRiskStore'

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Export all notification hooks
 export { useNotificationWebSocket, type UseNotificationWebSocketOptions } from './useNotificationWebSocket';

--- a/frontend/src/hooks/useAssetStore.ts
+++ b/frontend/src/hooks/useAssetStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { api } from '../lib/api';

--- a/frontend/src/hooks/useAuthStore.ts
+++ b/frontend/src/hooks/useAuthStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { api } from '../lib/api';

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Dashboard API Hooks

--- a/frontend/src/hooks/useDashboardStore.ts
+++ b/frontend/src/hooks/useDashboardStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { api } from '../lib/api';

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState, useCallback } from 'react';
 

--- a/frontend/src/hooks/useGamificationStore.ts
+++ b/frontend/src/hooks/useGamificationStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { api } from '../lib/api';

--- a/frontend/src/hooks/useI18n.ts
+++ b/frontend/src/hooks/useI18n.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useCallback } from 'react';
 import frLocale from '../locales/fr.json';

--- a/frontend/src/hooks/useIncidentStore.ts
+++ b/frontend/src/hooks/useIncidentStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';

--- a/frontend/src/hooks/useKeyboard.ts
+++ b/frontend/src/hooks/useKeyboard.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useCallback } from 'react';
 

--- a/frontend/src/hooks/useNotificationAudio.ts
+++ b/frontend/src/hooks/useNotificationAudio.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useCallback, useRef } from 'react';
 

--- a/frontend/src/hooks/useNotificationStore.ts
+++ b/frontend/src/hooks/useNotificationStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 

--- a/frontend/src/hooks/useNotificationWebSocket.ts
+++ b/frontend/src/hooks/useNotificationWebSocket.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useRef, useCallback } from 'react';
 

--- a/frontend/src/hooks/usePermissions.ts
+++ b/frontend/src/hooks/usePermissions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useMemo } from 'react';
 import { useAuthStore } from './useAuthStore';

--- a/frontend/src/hooks/useReportStore.ts
+++ b/frontend/src/hooks/useReportStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';

--- a/frontend/src/hooks/useRiskStore.ts
+++ b/frontend/src/hooks/useRiskStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { api } from '../lib/api';

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 

--- a/frontend/src/hooks/useScoreEngine.ts
+++ b/frontend/src/hooks/useScoreEngine.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useCallback } from 'react';
 import {

--- a/frontend/src/hooks/useThreatStore.ts
+++ b/frontend/src/hooks/useThreatStore.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 import { useAuthStore } from './useAuthStore';

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useCallback } from 'react';
 import { toast as sonnerToast, Toaster } from 'sonner';

--- a/frontend/src/hooks/useTypeahead.ts
+++ b/frontend/src/hooks/useTypeahead.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Advanced Typeahead Hook

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * WebSocket Dashboard Hook

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import axios from 'axios';
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React from 'react'
 import ReactDOM from 'react-dom/client'

--- a/frontend/src/pages/AIRiskInsights.tsx
+++ b/frontend/src/pages/AIRiskInsights.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState } from 'react';
 

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useState, useEffect } from 'react';
 import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';

--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useState, useEffect } from 'react';
 import {

--- a/frontend/src/pages/Assets.tsx
+++ b/frontend/src/pages/Assets.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { AssetsPage } from '../features/assets/AssetsPage';
 

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { useAuthStore } from '../hooks/useAuthStore';

--- a/frontend/src/pages/BulkOperations.tsx
+++ b/frontend/src/pages/BulkOperations.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { CheckCircle, Clock, AlertCircle, Trash2, Play, Pause, RefreshCw, Loader } from 'lucide-react';

--- a/frontend/src/pages/ComingSoon.tsx
+++ b/frontend/src/pages/ComingSoon.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Graceful placeholder for design-language screens whose backend isn't built yet
 // (Leaderboard, Infrastructure, Simulations, Asset Universe). Keeps the shell from

--- a/frontend/src/pages/Compliance.tsx
+++ b/frontend/src/pages/Compliance.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { CompliancePage } from '../features/compliance/CompliancePage';
 

--- a/frontend/src/pages/ComplianceReportDashboard.tsx
+++ b/frontend/src/pages/ComplianceReportDashboard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useState, useEffect } from 'react';
 import {

--- a/frontend/src/pages/CustomFields.tsx
+++ b/frontend/src/pages/CustomFields.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { Plus, Trash2, Edit2, Copy, AlertCircle, CheckCircle, Loader } from 'lucide-react';

--- a/frontend/src/pages/ImportRisks.tsx
+++ b/frontend/src/pages/ImportRisks.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useRef, useCallback } from 'react';
 import { Link } from 'react-router-dom';

--- a/frontend/src/pages/Incidents.tsx
+++ b/frontend/src/pages/Incidents.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/pages/Marketplace.tsx
+++ b/frontend/src/pages/Marketplace.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { Search, Star, Download, CheckCircle, AlertCircle, Trash2, Plus, RefreshCw, Eye, Code } from 'lucide-react';

--- a/frontend/src/pages/Mitigations.tsx
+++ b/frontend/src/pages/Mitigations.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { MitigationKanbanPage } from '../features/mitigations/MitigationKanbanPage';
 

--- a/frontend/src/pages/MonitoringDashboard.tsx
+++ b/frontend/src/pages/MonitoringDashboard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useEffect, useState } from 'react';
 

--- a/frontend/src/pages/PermissionAnalytics.tsx
+++ b/frontend/src/pages/PermissionAnalytics.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useMemo, useState } from 'react';
 import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';

--- a/frontend/src/pages/RealTimeAnalyticsDashboard.tsx
+++ b/frontend/src/pages/RealTimeAnalyticsDashboard.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import React, { useState } from 'react';
 import {

--- a/frontend/src/pages/Recommendations.tsx
+++ b/frontend/src/pages/Recommendations.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { PrioritizedMitigationsList } from '../features/mitigations/PrioritizedMitigationsList';
 

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/RiskTimeline.tsx
+++ b/frontend/src/pages/RiskTimeline.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { ArrowUp, ArrowDown, Clock, User, AlertCircle, Loader, Filter } from 'lucide-react';

--- a/frontend/src/pages/Risks.tsx
+++ b/frontend/src/pages/Risks.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo, useState } from 'react';
 import { useRiskStore, type Risk } from '../hooks/useRiskStore';

--- a/frontend/src/pages/RoleManagement.tsx
+++ b/frontend/src/pages/RoleManagement.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/TenantManagement.tsx
+++ b/frontend/src/pages/TenantManagement.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/ThreatMap.tsx
+++ b/frontend/src/pages/ThreatMap.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/TokenManagement.tsx
+++ b/frontend/src/pages/TokenManagement.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/frontend/src/pages/__tests__/Register.test.tsx
+++ b/frontend/src/pages/__tests__/Register.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/frontend/src/pages/__tests__/Risks.test.tsx
+++ b/frontend/src/pages/__tests__/Risks.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /** @vitest-environment jsdom */
 

--- a/frontend/src/services/assetService.ts
+++ b/frontend/src/services/assetService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { api } from '../lib/api';
 import type {

--- a/frontend/src/services/boardService.ts
+++ b/frontend/src/services/boardService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { api } from '../lib/api';
 import type {

--- a/frontend/src/services/complianceService.ts
+++ b/frontend/src/services/complianceService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { api } from '../lib/api';
 import type {

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 export * from './riskService';

--- a/frontend/src/services/mitigationService.ts
+++ b/frontend/src/services/mitigationService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { api } from '../lib/api';
 import type {

--- a/frontend/src/services/riskService.ts
+++ b/frontend/src/services/riskService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { api } from '../lib/api';
 

--- a/frontend/src/shared/Logo.tsx
+++ b/frontend/src/shared/Logo.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // OpenRisk brand mark — a shield enclosing a radar target (ring + center dot),
 // evoking "risk radar / defense". Filled with currentColor; the ring reads as

--- a/frontend/src/shared/fixtures.ts
+++ b/frontend/src/shared/fixtures.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Design fixtures ported verbatim from OpenRisk.dc.html. The prototype is
 // fixture-driven; these mirror it so the reskinned screens match the handoff

--- a/frontend/src/shared/navModel.ts
+++ b/frontend/src/shared/navModel.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Grouped navigation model (OpenRisk.dc.html §5). Single source of truth shared
 // by the Sidebar and the ⌘K command palette. `labelKey`/`groupKey` index into

--- a/frontend/src/shared/riskColors.ts
+++ b/frontend/src/shared/riskColors.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Small color helpers mapping risk semantics to the design-token CSS variables
 // (OpenRisk.dc.html §11). Returning `var(--…)` keeps everything theme-aware.

--- a/frontend/src/shared/ui.tsx
+++ b/frontend/src/shared/ui.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Reusable design-system primitives for the dc.html reskin — the React
 // equivalents of the prototype's card()/pageHeader()/btn()/chip()/badge()/

--- a/frontend/src/shared/uiStrings.ts
+++ b/frontend/src/shared/uiStrings.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Flat FR/EN dictionary for the redesigned app shell + screens, ported verbatim
 // from the OpenRisk design handoff (OpenRisk.dc.html §10). Kept separate from the

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { create } from 'zustand';
 

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { afterEach, vi, beforeAll, afterAll } from 'vitest';
 import { cleanup } from '@testing-library/react';

--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Contract-first: aliases onto types generated from docs/openapi.yaml (see
 // `npm run generate:api-types`), not hand-written duplicates.

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Hand-written types mirroring the backend's board-report JSON (domain.BoardReport
 // + application/board snapshots). Kept in sync with backend/internal/domain/board_report.go

--- a/frontend/src/types/compliance.ts
+++ b/frontend/src/types/compliance.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Contract-first: these are aliases onto types generated from
 // docs/openapi.yaml (see `npm run generate:api-types`), not hand-written

--- a/frontend/src/types/dashboard.types.ts
+++ b/frontend/src/types/dashboard.types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Dashboard Data Types

--- a/frontend/src/types/mitigation.ts
+++ b/frontend/src/types/mitigation.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Mitigation Module Types

--- a/frontend/src/types/react-grid-layout.d.ts
+++ b/frontend/src/types/react-grid-layout.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 declare module 'react-grid-layout' {
   import React from 'react';

--- a/frontend/src/types/risk.ts
+++ b/frontend/src/types/risk.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 export interface Risk {
   id: string;

--- a/frontend/src/utils/bulkOperations.ts
+++ b/frontend/src/utils/bulkOperations.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Bulk Operations Utilities

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';

--- a/frontend/src/utils/permissionAuditLog.ts
+++ b/frontend/src/utils/permissionAuditLog.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Permission Audit Logging Utilities

--- a/frontend/src/utils/permissionCache.ts
+++ b/frontend/src/utils/permissionCache.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Permission Caching and Memoization Utilities

--- a/frontend/src/utils/rbacHelpers.ts
+++ b/frontend/src/utils/rbacHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Advanced RBAC Permission Utilities

--- a/frontend/src/utils/rbacTestUtils.ts
+++ b/frontend/src/utils/rbacTestUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * RBAC Testing Utilities

--- a/frontend/src/utils/roleTemplateUtils.ts
+++ b/frontend/src/utils/roleTemplateUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * Role Template Utilities

--- a/frontend/src/utils/userFriendlyErrors.ts
+++ b/frontend/src/utils/userFriendlyErrors.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 /**
  * User-Friendly Error Messages


### PR DESCRIPTION
Replaces the repository-wide BUSL-1.1 license with an open-core model:

- Community Edition (the core GRC platform) → GNU AGPL v3.0 (LICENSE, verbatim FSF text). The AGPL network clause keeps a competitor from offering a modified core as a closed hosted service.
- Enterprise Edition → OpenRisk Commercial License (LICENSE.commercial): advanced SSO (OAuth2/SAML2/SSO-session), AI copilot, premium connectors & SOAR (cloud discovery collectors, vulnerability live-pull, Jira/ServiceNow ticketing, Slack/Teams ChatOps, automation engine). Basic email/password + JWT login, MFA and PATs stay in the AGPL core.

Rewrote SPDX headers across the repo: 704 core files → AGPL-3.0-only, 84 EE files → LicenseRef-OpenRisk-Commercial. LICENSING.md is the authoritative core/enterprise boundary and documents the multi-tenancy caveat (tenant_id plumbing stays AGPL; only multi-org/super-admin management is enterprise) and the Phase-2 plan (physical ee/ isolation behind a Go build tag + license key).

Copyright is 100% first-party, so the relicense needs no external consent; a CLA governs future contributions to preserve the dual-licensing right. Headers are comments only — go build ./... and tsc -b remain green.