### PR TITLE
chore(repo): stop tracking build binaries and ignore backend/openrisk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 /dist/
 /build/
 *.exe
-backend/openrisk-api
+/backend/openrisk
+/backend/openrisk-api
+/backend/main
 /backend/server
 /backend/orserver
 


### PR DESCRIPTION
## What

Repository hygiene: stop tracking a stray committed build binary and make sure local build artifacts can never be re-committed.

- **Untrack `backend/main`** — a 26 MB committed ELF executable. No build target produces it (`make build` outputs `backend/openrisk` via `go build -o openrisk ./cmd/server`); it's an orphaned local build accidentally committed. Removed with `git rm --cached` — the file stays on disk and in history, **no history rewrite**.
- **`.gitignore`** — add `/backend/openrisk` (the actual `make build` output) and `/backend/main`. The 208 MB `backend/openrisk` binary was previously untracked *and* un-ignored, i.e. one `git add .` away from entering history.

## Why

`.gitignore` already ignored `openrisk-api`, `server`, `orserver` but not the current binary name `openrisk`, and `backend/main` slipped into the tree. This closes the gap.

## Verification

- `git check-ignore backend/main backend/openrisk` → both ignored.
- `git status` clean after the change; the 208 MB `backend/openrisk` no longer appears as untracked.
- Grep of Makefile / Dockerfiles / CI / compose / scripts: **no references** to `backend/main`, so untracking cannot break any build or run step.
- Diff touches only `.gitignore` + the index — **no source code**, so no runtime behavior changes.