### PR TITLE
docs(security): add pre-SaaS security audit report

### DIFF
--- a/docs/security/AUDIT_2026-07.md
+++ b/docs/security/AUDIT_2026-07.md
@@ -1,0 +1,327 @@
+# Audit de sécurité pré-SaaS — OpenRisk
+
+**Date** : 2026-08-04
+**Périmètre** : hachage des mots de passe · secrets & credentials · isolation multi-tenant · durcissement (en-têtes, rate limiting, validation, fuite d'erreurs)
+**Commit de base** : `46f3650` (master)
+**Branche** : `chore/security-audit-pre-saas`
+**Statut** : reconnaissance terminée — **aucun correctif appliqué à ce stade** (sur consigne explicite)
+
+---
+
+## 0. Résumé exécutif
+
+| # | Constat | Sévérité | CVSS v3.1 | Statut |
+|---|---|---|---|---|
+| **F-01** | En-têtes de sécurité : **CSP et HSTS absents** (`helmet.New()` sans config) | **Élevée** | 6.5 | À corriger |
+| **F-02** | Le gestionnaire d'erreurs global **renvoie `err.Error()` au client** | **Élevée** | 5.3 | À corriger |
+| **F-03** | Rate limiting **uniquement sur 2 routes d'auth** ; ~287 autres non limitées ; **aucun quota par tenant** | **Élevée** | 5.3 | À corriger |
+| **F-04** | Clé de rate limiting dérivée de `X-Forwarded-For` **sans proxy de confiance** → contournement trivial | **Élevée** | 5.3 | À corriger |
+| **F-05** | Politique de mot de passe : **8 caractères**, aucune règle de complexité — le README annonce 12 | **Moyenne** | 4.8 | À corriger |
+| **F-06** | Argon2id : `iterations=2` au lieu des **3** exigées par la spécification | **Faible** | 2.4 | À décider |
+| **F-07** | Absence de test d'isolation multi-tenant **paramétré et bloquant en CI** | **Moyenne** | — | À construire |
+| **F-08** | Documentation : credentials d'exemple (`admin123`, `admin:admin`) dans les guides de déploiement | **Faible** | 2.0 | À corriger |
+| **F-09** | Helm : `grafana.adminPassword: "changeme"` en valeur par défaut | **Moyenne** | 4.3 | À corriger |
+| **F-10** | README : 3 affirmations de sécurité inexactes | **Faible** | — | À corriger |
+
+**Aucun constat critique.** Les deux risques existentiels redoutés — mots de passe en SHA-256 et secrets réels dans l'historique git — **sont écartés par la preuve** (§1 et §2).
+
+---
+
+## 1. Hachage des mots de passe — ✅ CONFORME (l'affirmation du README est vraie)
+
+### Vérification menée
+
+L'hypothèse de départ (« le README affirme Argon2id, l'analyse précédente indiquait SHA-256 ») était la préoccupation la plus grave du périmètre. **Elle est infirmée.**
+
+`backend/internal/auth/password_hasher.go` implémente `Argon2idPasswordHasher` sur `golang.org/x/crypto/argon2`, et il s'agit bien du hacheur **réellement câblé en production** :
+
+```
+backend/cmd/server/main.go:452 →  passwordHasher := coreauth.NewArgon2idPasswordHasher()
+```
+
+Ce hacheur est injecté dans `LoginUseCase` et `RegisterUseCase` — ce n'est pas du code mort. Le second point d'entrée (`internal/handler/auth_handler.go:62`, handler hérité conservé pour `/users/me`) instancie lui aussi `NewArgon2idPasswordHasher()`.
+
+### Paramètres constatés vs. exigés
+
+| Paramètre | Exigé (ticket) | Constaté | Verdict |
+|---|---|---|---|
+| memory | 64 MB | 65536 KiB = 64 MB | ✅ |
+| **iterations** | **3** | **2** | ⚠️ **F-06** |
+| parallelism | 4 | 4 | ✅ |
+| saltLen | 16 | 16 | ✅ |
+| keyLen | 32 | 32 | ✅ |
+
+Le format de stockage est le format PHC standard (`$argon2id$v=19$m=65536,t=2,p=4$<salt>$<hash>`), qui **encode ses propres paramètres**. C'est le point important : la vérification (`Verify`) relit `m`, `t`, `p` depuis le hash lui-même et ne présume pas des valeurs courantes.
+
+### F-06 — `iterations=2` au lieu de 3 · Sévérité **faible** · CVSS 2.4 (`AV:L/AC:H/PR:H/UI:N/S:U/C:L/I:N/A:N`)
+
+Écart mineur : le profil OWASP « m=64MB, t=2, p=4 » est une recommandation **valide et publiée** (c'est le second profil du cheat sheet OWASP Password Storage). Ce n'est pas une faiblesse, c'est un choix différent de celui du ticket.
+
+**Conséquence directe et favorable : la migration demandée dans le ticket (colonne `password_algo`, rehash transparent, job de rappel) est SANS OBJET.** Il n'y a aucun mot de passe SHA-256 à migrer. Construire ce dispositif reviendrait à ajouter un mécanisme de migration pour une population vide — exactement le type de complexité que la Loi n° 6 du projet interdit.
+
+Si le passage à `t=3` est souhaité, le format PHC le permet **sans aucune migration ni invalidation** : les anciens hash continuent de se vérifier avec `t=2` (paramètre lu dans le hash), les nouveaux s'écrivent en `t=3`. Un rehash opportuniste à la connexion réussie peut être ajouté en ~15 lignes si voulu — mais c'est un durcissement optionnel, pas un correctif.
+
+### Note annexe — `SimplePasswordHasher` (SHA-256)
+
+La structure existe encore (`password_hasher.go:149-171`) mais elle est **neutralisée** : `Hash()` retourne une erreur, `Verify()` retourne `false` en dur. Aucun appelant dans tout le dépôt (vérifié par grep exhaustif). C'est du code mort à supprimer par hygiène, sans impact sécurité.
+
+### Codes de secours MFA — bcrypt
+
+`internal/application/auth/mfa_usecase.go` hache les codes de récupération MFA avec **bcrypt** (`DefaultCost`). C'est adapté à l'usage (secrets courts, à forte entropie, générés par le serveur) et n'est pas concerné par l'exigence Argon2id qui vise les mots de passe choisis par l'humain.
+
+---
+
+## 2. Secrets & credentials — ✅ AUCUN SECRET RÉEL
+
+### 2.1 Historique git complet — scan gitleaks
+
+Gitleaks n'étant pas installé et le démon Docker inaccessible (permission refusée sur le socket), le binaire officiel **v8.21.2** a été téléchargé et exécuté sur **l'intégralité de l'historique** (`--log-opts="--all"`).
+
+```
+849 commits scannés · scan terminé en 4,48 s · 29 findings
+```
+
+**Les 29 findings sont tous des faux positifs de documentation.** Analyse exhaustive :
+
+| Catégorie | Nb | Exemples | Verdict |
+|---|---|---|---|
+| Placeholders de tokens dans des `curl` de doc | 16 | `YOUR_TOKEN`, `YOUR_JWT`, `INVITEE_TOKEN` | Faux positif |
+| JWT d'exemple tronqués (`...`) | 7 | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` | Faux positif |
+| Secret de test documenté | 1 | `test-secret-key-32-characters-min` | Faux positif |
+| Clé API d'exemple | 2 | `opnrsk_abcd1234efgh5678ijkl9012` | Faux positif |
+| Secret TOTP d'exemple (RFC 6238) | 1 | `JBSWY3DPEBLW64TMMQQQ====` | Faux positif |
+| Variable d'env non secrète | 1 | `JWT_EXPIRATION_HOURS=24` | Faux positif |
+| `k8s/secret.yaml` | 1 | valeur littérale : `MONGO_URI: base64encoded` | Faux positif |
+| Exemple Grafana | 1 | `admin:admin` (voir F-08) | Doc à corriger |
+
+**Aucune rotation de secret n'est requise. Aucune réécriture d'historique n'est nécessaire** — ce qui est la meilleure issue possible, la réécriture d'un historique de 904 commits étant une opération à fort risque.
+
+Vérification complémentaire : **aucune clé privée RSA n'est suivie par git** (`git ls-files | grep -E '\.pem$|private_key|id_rsa'` → vide). Les clés de `backend/keys/` sont générées localement et non versionnées.
+
+### 2.2 Credentials par défaut
+
+`.env.example` ne contient que des placeholders explicites (`your-brevo-password`, `your-api-key`). Les `docker-compose` utilisent la substitution `${VAR:-defaut}` avec des défauts auto-descriptifs (`staging_password_change_me`) — acceptable pour du non-production.
+
+#### F-09 — Helm : mot de passe Grafana par défaut · Sévérité **moyenne** · CVSS 4.3 (`AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`)
+
+```yaml
+helm/openrisk/values.yaml:198   grafana.adminPassword: "changeme"
+helm/values-prod.yaml:143       grafana.adminPassword: "changeme-in-production"
+```
+
+`values-prod.yaml` est **explicitement destiné à la production**. Un déploiement Helm au fil de l'eau expose une console Grafana (métriques d'infrastructure, potentiellement des données métier) avec un mot de passe public. **Correctif** : retirer la valeur par défaut et faire échouer le chart si le secret n'est pas fourni (`required` de Helm).
+
+#### F-08 — Credentials dans la documentation · Sévérité **faible** · CVSS 2.0
+
+```
+deployment/configs/README.md:164   -d '{"email":"admin@openrisk.local","password":"admin123"}'
+docs/PHASE_5_QUICK_REFERENCE.md:210   curl -u admin:admin http://localhost:3000
+```
+
+Ce sont des exemples pédagogiques, pas des credentials actifs. Le risque réel est **l'induction en erreur** : un opérateur pressé recopie `admin123`. Le README interdit par ailleurs explicitement les credentials par défaut — la doc doit être cohérente avec sa propre règle.
+
+Aucun compte administrateur n'est amorcé avec un mot de passe en dur dans le code (`backend/cmd/` : aucune assignation littérale de mot de passe).
+
+---
+
+## 3. Isolation multi-tenant — le point le plus critique
+
+### 3.1 Surface d'attaque cartographiée
+
+**289 enregistrements de routes** extraits de `backend/cmd/server/main.go` (287 chemins uniques), dont **131 routes paramétrées par identifiant** — la surface IDOR à couvrir.
+
+Répartition par groupe de routage :
+
+| Groupe | Routes | Authentification |
+|---|---|---|
+| `protected` | 223 | JWT RS256 (+ PAT) |
+| `api` | 20 | mixte — voir §3.2 |
+| `incidentsGroup` / `notificationsGroup` / `scoreEngineRoutes` / `rbac*` | 40 | héritée de `protected` |
+| `app` | 6 | auth propre (agents scanner, webhooks) |
+
+### 3.2 ✅ Vérification empirique : pas de contournement d'authentification
+
+Sept routes (`/stats/risk-matrix`, `/stats/risk-distribution`, `/stats/mitigation-metrics`, `/stats/top-vulnerabilities`, `/export/pdf`, `/users/me`, `/gamification/me`) sont enregistrées via la variable `api` **sans middleware `Protected` inline**, alors qu'elles manipulent des données de tenant. Cela ressemble à un défaut d'authentification majeur.
+
+Plutôt que de raisonner sur la sémantique de Fiber, **le comportement a été prouvé expérimentalement** avec la version exacte du projet (`fiber v2.52.12`), en répliquant le motif de `main.go` :
+
+```go
+api := app.Group("/api/v1")
+api.Get("/before", ok)              // enregistrée AVANT Use()
+protected := api.Use(reject)        // reject renvoie toujours 401
+api.Get("/after-via-api", ok)       // enregistrée APRÈS Use(), via `api`
+protected.Get("/after-via-protected", ok)
+```
+
+Résultat :
+
+```
+/api/v1/before             → 200   (non protégée, attendu)
+/api/v1/after-via-api      → 401   ← protégée malgré l'absence de middleware inline
+/api/v1/after-via-protected→ 401
+```
+
+**Conclusion : `api.Use()` s'applique à toutes les routes enregistrées après lui, quelle que soit la variable utilisée. `api` et `protected` désignent le même routeur.** Les 7 routes suspectes (toutes déclarées après la ligne 625) sont bien authentifiées. **Pas de vulnérabilité.**
+
+Cette même sémantique est cependant une **arme à double tranchant déjà documentée dans le projet** : c'est elle qui avait causé la fuite de garde `RequireRole("admin","analyst")` de la marketplace sur tout `protected` (corrigée, cf. CLAUDE.md). Le style d'enregistrement actuel rend l'intention illisible — un futur contributeur ne peut pas distinguer une route volontairement publique d'un oubli. **Recommandation (hygiène, non-bloquante)** : n'utiliser que la variable `protected` après la ligne 625, et regrouper les routes réellement publiques avant.
+
+### 3.3 État des lieux de l'isolation
+
+Un balayage complet a déjà été mené le 2026-07-23 (`audit/tenant-isolation-sweep`, cf. CLAUDE.md item 36) : **6 fuites cross-tenant réelles trouvées et corrigées**, chacune avec un test de régression (incidents/IDOR, timeline de risque, custom fields, teams, `/users` hérité, score-engine + fail-open du dashboard).
+
+Vérifications indépendantes menées durant cet audit :
+
+- **25 fichiers de test** portent des assertions d'isolation cross-tenant. Elles sont réelles et passent.
+- **Suite backend complète : verte.** Seuls 3 tests échouent (`TestCacheService_*`), tous par `connection refused` sur Redis — dépendance d'environnement absente, pas un défaut de code.
+- **Marketplace** : les findings IDOR latents (`GetApp`/`UpdateApp`/`EnableApp`… filtrant par `id` seul) sont confirmés **injoignables** — les modèles sont volontairement exclus d'`AutoMigrate` (`main.go:188-191`, absence de tags `gorm:`), donc les tables n'existent pas et chaque route retourne 500 avant d'atteindre la requête. Risque théorique, à corriger si le module est réactivé.
+- **Balayage heuristique** des lectures par identifiant sans filtre tenant : les occurrences restantes sont soit des **auto-lectures** (`claims.Sub` / `claims.ID` — l'utilisateur lit son propre enregistrement, l'ID vient du jeton signé), soit des **re-lectures après validation** (ex. `risk_handler.go:267` recharge un risque qui vient d'être créé par un use case déjà scopé). Aucune nouvelle fuite identifiée.
+
+### 3.4 F-07 — Absence de test d'isolation paramétré et bloquant · Sévérité **moyenne**
+
+Le dispositif actuel est **une mosaïque de tests par module**, écrits à la main, au fil des correctifs. Sa faiblesse n'est pas ce qu'il couvre, mais **sa façon de croître** : une nouvelle route ajoutée demain n'est couverte par rien tant que quelqu'un ne pense pas à écrire son test. Les 6 fuites de juillet ont précisément été trouvées par un balayage manuel — pas par la CI.
+
+C'est le livrable n° 3 demandé, et **il reste à construire**. Conception proposée :
+
+1. **Génération depuis la source de vérité** — extraction des 289 routes de `main.go` par analyse AST (`go/ast`), pas par recopie manuelle : le test ne peut pas prendre de retard sur les routes.
+2. **Harnais à deux tenants** — tenant A et tenant B, chacun avec un jeu complet de ressources, un utilisateur authentifié par tenant.
+3. **Matrice d'attaque par route** — pour chaque route paramétrée : lecture, modification et suppression de la ressource de B avec le jeton de A ; assertion **404 ou 403, jamais 200**.
+4. **Couverture des fuites indirectes** — listes, recherches, exports, agrégats de dashboard : assertion que **le compteur de A n'inclut aucune ressource de B** (c'est la classe de fuite la plus insidieuse : ne pas exposer la donnée, mais la révéler par un total).
+5. **Liste d'exclusion explicite et justifiée** — les routes légitimement non tenant-scopées (`/health`, `/auth/*`, endpoints agents) sont déclarées dans une liste commentée. **Une route inconnue de la liste et non testée fait échouer le test** — c'est ce qui rend le dispositif bloquant plutôt que décoratif.
+6. **Intégration CI** en tâche bloquante.
+
+---
+
+## 4. Durcissement
+
+### F-01 — En-têtes de sécurité : CSP et HSTS absents · Sévérité **élevée** · CVSS 6.5 (`AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N`)
+
+`main.go:405` appelle `app.Use(helmet.New())` **sans configuration**. Inspection du code de `fiber/middleware/helmet@v2.52.12` :
+
+| En-tête | Défaut helmet | Effectif ? |
+|---|---|---|
+| `X-Frame-Options` | `SAMEORIGIN` | ✅ |
+| `Referrer-Policy` | `no-referrer` | ✅ |
+| `X-Content-Type-Options` | `nosniff` | ✅ |
+| `Cross-Origin-*-Policy` | définis | ✅ |
+| **`Content-Security-Policy`** | **`""`** | ❌ **non émis** |
+| **`Strict-Transport-Security`** | **`HSTSMaxAge: 0`** | ❌ **non émis** |
+
+Preuve dans `helmet.go` : `if cfg.ContentSecurityPolicy != ""` (l.79) et `if c.Protocol() == "https" && cfg.HSTSMaxAge != 0` (l.67) — les deux conditions sont fausses par défaut.
+
+**Impact.** Sans CSP, aucune défense en profondeur contre le XSS : toute injection réussie dans le frontend React s'exécute sans contrainte d'origine. Sans HSTS, un utilisateur atteignant le service en HTTP reste vulnérable au downgrade (SSL-strip). Pour une plateforme GRC qui héberge le registre de risques et les preuves d'audit de ses clients, c'est le manque de durcissement le plus conséquent identifié.
+
+**Correctif** : configurer `helmet.Config{ContentSecurityPolicy: ..., HSTSMaxAge: 31536000, HSTSIncludeSubdomains: true}`. La CSP doit être construite avec le frontend (Vite/React) pour ne pas casser l'application — à établir en mode `report-only` d'abord.
+
+### F-02 — Fuite d'informations par le gestionnaire d'erreurs · Sévérité **élevée** · CVSS 5.3 (`AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`)
+
+```go
+// main.go:387-396
+ErrorHandler: func(c *fiber.Ctx, err error) error {
+    code := fiber.StatusInternalServerError
+    if e, ok := err.(*fiber.Error); ok { code = e.Code }
+    return c.Status(code).JSON(fiber.Map{
+        "error": true,
+        "msg":   err.Error(),   // ← renvoyé au client, en production comme ailleurs
+    })
+}
+```
+
+Toute erreur non interceptée est retournée verbatim. Avec GORM, `err.Error()` contient couramment le **texte de la requête SQL, les noms de tables et de colonnes**, voire des fragments de valeurs. Aggravant : **94 sites de handlers touchent `database.DB` directement** (contournement de la Clean Architecture) et **95 sites renvoient `err.Error()`** dans leur propre réponse JSON — la surface dépasse le seul gestionnaire global.
+
+Aucune distinction selon `APP_ENV` : le comportement de développement est celui de la production.
+
+**Correctif** : en production, journaliser l'erreur complète côté serveur avec un identifiant de corrélation, et ne renvoyer au client qu'un message générique accompagné de cet identifiant. Conserver le détail en développement.
+
+### F-03 — Rate limiting quasi inexistant · Sévérité **élevée** · CVSS 5.3 (`AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L`)
+
+Le rate limiting n'est appliqué qu'à **2 routes sur 289** :
+
+```go
+api.Post("/auth/login",    authRateLimit, ...)   // 15 req / 5 min
+api.Post("/auth/register", authRateLimit, ...)
+```
+
+Les helpers `APIRateLimit()` (1000/h par utilisateur) et `PublicRateLimit()` (100/min par IP) existent dans `middleware/ratelimit.go` mais **ne sont câblés nulle part** (grep exhaustif → aucune occurrence dans `main.go`). Les 287 autres routes — dont les exports, les agrégats de dashboard et les endpoints IA — n'ont aucun quota.
+
+**Aucun rate limiting par tenant n'existe**, alors que le ticket l'exige explicitement et que c'est la protection élémentaire d'un SaaS mutualisé : un tenant peut aujourd'hui saturer les ressources partagées au détriment des autres.
+
+### F-04 — Rate limiting contournable via `X-Forwarded-For` · Sévérité **élevée** · CVSS 5.3 (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`)
+
+```go
+// middleware/ratelimit.go
+key := c.IP()
+if forwarded := c.Get("X-Forwarded-For"); forwarded != "" {
+    key = forwarded   // en-tête contrôlé par le client, sans validation
+}
+```
+
+L'application Fiber est instanciée **sans `EnableTrustedProxyCheck` ni `TrustedProxies`** (vérifié : aucune occurrence dans `main.go`). L'en-tête `X-Forwarded-For` est donc accepté depuis n'importe quelle source et utilisé tel quel comme clé de limitation.
+
+**Un attaquant qui fait varier cet en-tête à chaque requête obtient un compteur neuf à chaque fois** — le rate limiting sur le login, seule protection contre le bruteforce de mots de passe, est **entièrement contournable**. C'est ce qui fait passer F-03 d'une carence de robustesse à une faiblesse exploitable.
+
+**Correctif** : activer `EnableTrustedProxyCheck: true` avec la liste des proxys de confiance, et ne dériver la clé de `X-Forwarded-For` que lorsque la requête provient effectivement d'un proxy de confiance.
+
+### F-05 — Politique de mot de passe insuffisante · Sévérité **moyenne** · CVSS 4.8 (`AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N`)
+
+Minimum **8 caractères**, appliqué en 6 endroits (`register.go:174`, `auth/handler.go:150`, `auth_handler.go:23/28/85/226`). **Aucune règle de complexité, aucune vérification zxcvbn, aucun contrôle contre HaveIBeenPwned.**
+
+Le README annonce pourtant « Minimum 12 characters » (l.120) — **la documentation et le code divergent**. La roadmap V6 tranche à 12 avec zxcvbn ≥ 3 (décision §7.2, ticket OR-006).
+
+Note : la validation de 8 caractères sur le **login** (`auth_handler.go:85`) est inutile et légèrement contre-productive — elle renvoie une erreur distincte avant même la vérification des identifiants.
+
+### Validation d'entrée — état correct
+
+Les DTO utilisent systématiquement les tags `validate:` de `go-playground/validator`. Les bornes métier (probabilité ∈ [0,1], impact ∈ [0,10], criticité ∈ [0.1,3.0]) sont vérifiées côté serveur. Pas de constat.
+
+### F-10 — Affirmations inexactes du README · Sévérité **faible**
+
+| Ligne | Affirmation | Réalité |
+|---|---|---|
+| 394 | « Password Hashing: Argon2id — never SHA256 » | ✅ **vraie** (§1) |
+| 120 | « Minimum 12 characters » | ❌ le code impose **8** (F-05) |
+| 397 | « Rate Limiting: API rate limiting middleware » | ❌ **2 routes sur 289** (F-03) |
+| 399 | « Input Validation: Request validation with **Zod** » | ❌ Zod est côté frontend ; le backend utilise `go-playground/validator` |
+
+La première affirmation, la plus importante, est exacte. Les trois autres doivent être corrigées — un outil GRC dont le README surestime les contrôles perd sa crédibilité au premier audit client.
+
+---
+
+## 5. Plan de correction proposé
+
+**Lot 1 — durcissement (élevé, sans dépendance)**
+1. **F-04** proxys de confiance — *préalable à F-03, sinon tout quota reste contournable*
+2. **F-01** CSP (report-only puis appliquée) + HSTS
+3. **F-02** erreurs génériques en production + identifiant de corrélation
+4. **F-03** rate limiting global par IP **et** par tenant
+
+**Lot 2 — isolation (le livrable structurant)**
+
+5. **F-07** test d'isolation paramétré, généré par AST depuis `main.go`, bloquant en CI
+
+**Lot 3 — hygiène**
+
+6. **F-05** politique à 12 caractères + zxcvbn (ticket OR-006)
+7. **F-09** Helm : supprimer les mots de passe par défaut
+8. **F-08** / **F-10** corriger documentation et README
+9. Supprimer `SimplePasswordHasher` (code mort)
+10. **F-06** `iterations=3` — à décider (optionnel, sans migration)
+
+---
+
+## 6. Méthode et limites
+
+**Vérifié par exécution :**
+- gitleaks v8.21.2 sur 849 commits (`--log-opts="--all"`)
+- `go build ./...` → succès
+- `go test ./...` → vert, hors 3 tests cache nécessitant Redis
+- test Fiber isolé prouvant la sémantique de `api.Use()` (§3.2)
+- lecture du code source de `helmet@v2.52.12` pour établir les défauts d'en-têtes
+
+**Vérifié par lecture de code :** câblage du hacheur, politique de mot de passe, gestionnaire d'erreurs, rate limiting, dérivation de la clé de limitation, exclusion marketplace d'`AutoMigrate`.
+
+**Non vérifié — limites à assumer :**
+- **Aucun test dynamique contre une instance en fonctionnement.** Les constats d'isolation reposent sur la lecture du code, les tests existants et l'audit de juillet — pas sur une exploitation réelle. C'est précisément la lacune que F-07 doit combler.
+- Les en-têtes de sécurité n'ont pas été observés sur une réponse HTTP réelle (dérivés du code de helmet et de sa configuration).
+- Le contournement de `X-Forwarded-For` (F-04) est établi par lecture du code, non exploité en pratique.
+- Périmètre limité au backend. **Le frontend n'a pas été audité** (XSS, stockage de jetons, dépendances npm).
+- Aucune analyse de composition logicielle (`govulncheck`, `npm audit`) — hors périmètre demandé, à planifier.


### PR DESCRIPTION
Reconnaissance-only audit across password hashing, secrets, tenant isolation and hardening. No production code changed.

Key results:
- Argon2id confirmed as the wired hasher (README claim is accurate); the SHA-256 migration path in the brief is moot.
- gitleaks over all 849 commits: 29 findings, all documentation placeholders. No real secret, no history rewrite needed.
- Proved empirically that api.Use() covers routes registered after it, clearing 7 seemingly unauthenticated /stats and /export routes.
- 10 findings recorded with CVSS. Highest: missing CSP/HSTS, error handler leaking err.Error(), rate limiting on 2 of 289 routes and bypassable via unvalidated X-Forwarded-For.