### PR TITLE
fix(security): stop leaking raw errors from explicitly-built 5xx responses

### DIFF
--- a/backend/internal/handler/automation_handler.go
+++ b/backend/internal/handler/automation_handler.go
@@ -79,7 +79,7 @@ func (b ruleBody) toInput() appauto.RuleInput {
 func (h *AutomationHandler) ListRules(c *fiber.Ctx) error {
 	items, err := h.rules.List(c.UserContext(), h.tenant(c))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list rules", "details": err.Error()})
+		return serverError(c, "could not list rules", err)
 	}
 	return c.JSON(fiber.Map{"items": items})
 }
@@ -189,7 +189,7 @@ func (h *AutomationHandler) ListExecutions(c *fiber.Ctx) error {
 	offset := c.QueryInt("offset", 0)
 	items, err := h.executions.List(c.UserContext(), h.tenant(c), limit, offset)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list executions", "details": err.Error()})
+		return serverError(c, "could not list executions", err)
 	}
 	return c.JSON(fiber.Map{"items": items})
 }
@@ -202,7 +202,7 @@ func (h *AutomationHandler) ListRuleExecutions(c *fiber.Ctx) error {
 	}
 	items, err := h.executions.ListByRule(c.UserContext(), h.tenant(c), id, c.QueryInt("limit", 50))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list executions", "details": err.Error()})
+		return serverError(c, "could not list executions", err)
 	}
 	return c.JSON(fiber.Map{"items": items})
 }
@@ -211,7 +211,7 @@ func (h *AutomationHandler) ListRuleExecutions(c *fiber.Ctx) error {
 func (h *AutomationHandler) ListSLA(c *fiber.Ctx) error {
 	items, err := h.sla.ListOpen(c.UserContext(), h.tenant(c))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list SLA trackers", "details": err.Error()})
+		return serverError(c, "could not list SLA trackers", err)
 	}
 	return c.JSON(fiber.Map{"items": items})
 }
@@ -220,7 +220,7 @@ func (h *AutomationHandler) ListSLA(c *fiber.Ctx) error {
 func (h *AutomationHandler) SLAStats(c *fiber.Ctx) error {
 	stats, err := h.sla.Stats(c.UserContext(), h.tenant(c))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not compute SLA stats", "details": err.Error()})
+		return serverError(c, "could not compute SLA stats", err)
 	}
 	return c.JSON(stats)
 }

--- a/backend/internal/handler/risk_handler.go
+++ b/backend/internal/handler/risk_handler.go
@@ -339,7 +339,7 @@ func (h *RiskHandler) GetRisks(c *fiber.Ctx) error {
 
 	result, err := h.listRisksUseCase.Execute(c.UserContext(), orgID, query)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Could not fetch risks", "details": err.Error()})
+		return serverError(c, "Could not fetch risks", err)
 	}
 
 	for i := range result.Data {

--- a/backend/internal/handler/score_engine_handler.go
+++ b/backend/internal/handler/score_engine_handler.go
@@ -129,7 +129,7 @@ func (h *ScoreEngineHandler) CreateScoringConfig(c *fiber.Ctx) error {
 
 	// Create in service
 	if err := h.service.CreateConfig(config); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		return serverError(c, "score engine request failed", err)
 	}
 
 	return c.Status(201).JSON(config)
@@ -179,7 +179,7 @@ func (h *ScoreEngineHandler) UpdateScoringConfig(c *fiber.Ctx) error {
 
 	// Apply updates
 	if err := h.service.UpdateConfig(id, updates); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		return serverError(c, "score engine request failed", err)
 	}
 
 	updated := h.service.GetConfig(id)

--- a/backend/internal/handler/server_error.go
+++ b/backend/internal/handler/server_error.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"log"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/middleware"
+)
+
+// serverError returns a 500 without disclosing the underlying error.
+//
+// Audit finding F-02 was fixed in the global Fiber error handler, but that only
+// catches errors a handler *returns*. Handlers that build a 500 response
+// themselves — `c.Status(500).JSON(fiber.Map{"error": ..., "details": err.Error()})`
+// — never reach it, so the raw error still went out over the wire. With GORM in
+// the stack that string routinely carries the SQL statement, table and column
+// names, and fragments of row values.
+//
+// This restores the same contract as the global handler: the full error is
+// logged server-side against a correlation id, and the client gets a stable
+// message plus that id. Outside production the detail is returned inline, since
+// hiding it locally makes debugging worse for no security gain.
+//
+// Use it for genuine server faults. Failures that map to a typed domain error
+// (not-found, forbidden, conflict, validation) should go through writeAppError
+// instead, which preserves their status code.
+func serverError(c *fiber.Ctx, publicMessage string, err error) error {
+	if !middleware.IsProductionEnv() {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error":   publicMessage,
+			"details": err.Error(),
+		})
+	}
+
+	reference := uuid.NewString()
+	log.Printf("[error][ref=%s] %s %s: %v", reference, c.Method(), c.Path(), err)
+
+	return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+		"error":     publicMessage,
+		"reference": reference,
+	})
+}

--- a/backend/internal/handler/server_error_test.go
+++ b/backend/internal/handler/server_error_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// gormStyleError mimics what GORM surfaces on a failed query: the statement,
+// table and column names, and fragments of values.
+var gormStyleError = errors.New(
+	`ERROR: column "tenant_id" does not exist (SQLSTATE 42703) ` +
+		`[SQL: SELECT * FROM "risks" WHERE tenant_id = '9f1c...' AND deleted_at IS NULL]`,
+)
+
+func callServerError(t *testing.T, production bool) (int, map[string]any, string) {
+	t.Helper()
+
+	if production {
+		t.Setenv("APP_ENV", "production")
+	} else {
+		t.Setenv("APP_ENV", "development")
+	}
+
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(io.Discard) })
+
+	app := fiber.New()
+	app.Get("/boom", func(c *fiber.Ctx) error {
+		return serverError(c, "could not fetch risks", gormStyleError)
+	})
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/boom", nil))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	return resp.StatusCode, body, logged.String()
+}
+
+// TestServerError_ProductionHidesInternals is the regression test for the
+// explicit-response half of audit finding F-02.
+func TestServerError_ProductionHidesInternals(t *testing.T) {
+	status, body, logged := callServerError(t, true)
+
+	require.Equal(t, fiber.StatusInternalServerError, status)
+	require.Equal(t, "could not fetch risks", body["error"])
+
+	rawBody, err := json.Marshal(body)
+	require.NoError(t, err)
+	serialised := string(rawBody)
+	// Markers that only appear if the driver error escaped. The chosen public
+	// message may legitimately name the resource ("could not fetch risks"), so
+	// asserting on a bare table name would flag its own copy.
+	for _, leaked := range []string{"SELECT", "SQLSTATE", "tenant_id", "deleted_at", "42703"} {
+		require.NotContains(t, serialised, leaked, "response leaks internal detail %q", leaked)
+	}
+	require.NotContains(t, body, "details", "the details field is what carried the raw error")
+
+	reference, _ := body["reference"].(string)
+	require.NotEmpty(t, reference, "production response must carry a correlation reference")
+	require.Contains(t, logged, reference, "log must record the correlation id")
+	require.Contains(t, logged, "SELECT", "log must retain the full error for debugging")
+}
+
+// TestServerError_DevelopmentKeepsDetail guards the other side of the trade.
+func TestServerError_DevelopmentKeepsDetail(t *testing.T) {
+	status, body, _ := callServerError(t, false)
+
+	require.Equal(t, fiber.StatusInternalServerError, status)
+	require.Contains(t, body["details"], "SELECT", "development should surface the real error")
+	require.NotContains(t, body, "reference")
+}
+
+// TestNoHandlerReturnsRawErrorOn5xx is the guard that keeps this fixed.
+//
+// The global Fiber error handler only sees errors a handler *returns*; a 500
+// built inline never reaches it. Rather than trusting reviewers to notice, this
+// scans the handler package for the pattern and fails on any new occurrence.
+func TestNoHandlerReturnsRawErrorOn5xx(t *testing.T) {
+	// c.Status(5xx) ... err.Error() on the same line.
+	pattern := regexp.MustCompile(`Status\(5\d\d\)[^\n]*err\.Error\(\)`)
+
+	var offenders []string
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// server_error.go documents the anti-pattern in a comment.
+		if filepath.Base(path) == "server_error.go" {
+			return nil
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if pattern.MatchString(line) {
+				offenders = append(offenders, fmt.Sprintf("%s:%d", filepath.ToSlash(path), i+1))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, offenders,
+		"these 5xx responses return the raw error to the client, bypassing the global handler.\n"+
+			"Use serverError(c, publicMessage, err) instead:\n  %s", strings.Join(offenders, "\n  "))
+}

--- a/backend/internal/handler/vuln_integration_handler.go
+++ b/backend/internal/handler/vuln_integration_handler.go
@@ -103,7 +103,7 @@ func (h *VulnIntegrationHandler) SaveIntegration(c *fiber.Ctx) error {
 func (h *VulnIntegrationHandler) ListIntegrations(c *fiber.Ctx) error {
 	items, err := h.list.Execute(c.UserContext(), h.tenant(c))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list integrations", "details": err.Error()})
+		return serverError(c, "could not list integrations", err)
 	}
 	return c.JSON(fiber.Map{"items": items})
 }

--- a/backend/internal/handler/vulnerability_handler.go
+++ b/backend/internal/handler/vulnerability_handler.go
@@ -134,7 +134,7 @@ func (h *VulnerabilityHandler) List(c *fiber.Ctx) error {
 
 	res, err := h.list.Execute(c.UserContext(), h.tenant(c), q)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not list vulnerabilities", "details": err.Error()})
+		return serverError(c, "could not list vulnerabilities", err)
 	}
 	return c.JSON(fiber.Map{"items": res.Data, "total": res.Total, "page": res.Page, "limit": res.Limit})
 }
@@ -156,7 +156,7 @@ func (h *VulnerabilityHandler) Get(c *fiber.Ctx) error {
 func (h *VulnerabilityHandler) Stats(c *fiber.Ctx) error {
 	s, err := h.stats.Execute(c.UserContext(), h.tenant(c))
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "could not compute stats", "details": err.Error()})
+		return serverError(c, "could not compute stats", err)
 	}
 	return c.JSON(s)
 }


### PR DESCRIPTION
The global Fiber error handler was hardened earlier (F-02), but it only sees errors a handler *returns*. Eleven sites built their 500 response inline - c.Status(500).JSON(fiber.Map{"error": ..., "details": err.Error()}) - so the raw error never passed through it and went straight to the client. With GORM in the stack that string routinely carries the SQL statement, table and column names, and fragments of row values.

serverError() restores the same contract as the global handler: the full error is logged server-side against a correlation id and the client gets a stable message plus that id, while development keeps the detail inline so local debugging is unaffected.

Converted across risk, vulnerability, automation, score-engine and vuln-integration handlers.

A guard test scans the package for the pattern and fails on any new occurrence, reporting file and line. Reviewers cannot be relied on to spot the difference between a returned error and an inline 500, which is exactly how these eleven survived the first pass. Verified by reintroducing one and confirming the guard flags it.

Typed failures (not-found, forbidden, conflict, validation) still go through writeAppError, which preserves their status code - collapsing them into 500 would be a functional regression.