### PR TITLE
feat(financial): FAIR-lite quantification — P10/P50/P90, currency, explainability, ROSI simulator

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -965,6 +965,16 @@ func main() {
 		}
 	}
 	riskQuantifier := crq.NewQuantifier(xafPerUSD, crq.DefaultReference())
+	// Daily FX rate job (spec §3): keeps a dated rate table so every converted
+	// amount can show its reference date. Defaults to the static reference source
+	// (honest fallback) until a live feed is plugged into FXRateSource.
+	fxWorker := workers.NewFXRateWorker(workers.StaticFXSource{}, zeroLogger)
+	go fxWorker.Start(context.Background())
+	// Currency/FX presenter factory: resolves each tenant's display currency (org
+	// settings) + the live rate table so financial figures convert consistently.
+	financialPresenters := risk.NewFinancialPresenterFactory(riskQuantifier).
+		WithCurrency(orgRepo).
+		WithRates(fxWorker)
 	markReviewedUseCase := risk.NewMarkRiskReviewedUseCase(riskRepo)
 	// The lifecycle FSM enforces its guards server-side. Its two inspectors are
 	// wired here so "IN_TREATMENT needs an active mitigation", "MITIGATED needs
@@ -976,13 +986,19 @@ func main() {
 			repository.NewGormMitigationSubActionRepository(database.DB),
 		)).
 		WithApprovals(newApprovalChecker(repository.NewGormApprovalRepository(database.DB)))
-	riskHandler := handlers.NewRiskHandler(createRiskUseCase, getRiskUseCase, listRisksUseCase, updateRiskUseCase, deleteRiskUseCase, markReviewedUseCase, transitionStateUseCase, redisClientInstance, riskQuantifier)
+	riskHandler := handlers.NewRiskHandler(createRiskUseCase, getRiskUseCase, listRisksUseCase, updateRiskUseCase, deleteRiskUseCase, markReviewedUseCase, transitionStateUseCase, redisClientInstance, riskQuantifier).
+		WithFinancialPresenters(financialPresenters)
 
 	// Financial Risk Quantification (spec §9): tenant-wide CFO/CISO dashboard
-	// (portfolio ALE, worst-case, residual, remediation budget, ROSI). Reuses the
-	// same quantifier as per-risk CRQ so figures agree.
-	financialSummaryUseCase := risk.NewFinancialSummaryUseCase(riskRepo, riskQuantifier)
-	financialAnalyticsHandler := handlers.NewFinancialAnalyticsHandler(financialSummaryUseCase)
+	// (portfolio FAIR-lite P10/P50/P90, ALE, worst-case, residual, remediation
+	// budget, ROSI). Reuses the same quantifier as per-risk CRQ so figures agree;
+	// the coverage counter makes "N/M quantified" a SQL fact, and the presenter
+	// factory converts every figure into the tenant's currency at a dated rate.
+	financialSummaryUseCase := risk.NewFinancialSummaryUseCase(riskRepo, riskQuantifier).
+		WithPresenters(financialPresenters).
+		WithCoverageCounter(riskRepo)
+	financialAnalyticsHandler := handlers.NewFinancialAnalyticsHandler(financialSummaryUseCase).
+		WithCurrencyWriter(orgRepo)
 
 	// NOTE: same bug class as compliance (see comment above complianceFrameworkRead) —
 	// middleware.RequirePermissions reads the legacy *domain.UserClaims, which the RS256
@@ -1839,6 +1855,9 @@ func main() {
 	// ALE / worst-case / residual / remediation budget / ROSI for the CFO/CISO screen.
 	protected.Get("/analytics/financial",
 		middleware.RequirePermission("risks:read"), financialAnalyticsHandler.GetFinancialSummary)
+	// Tenant display currency — chosen at onboarding, changeable here (admin).
+	protected.Put("/analytics/financial/currency",
+		middleware.RequireRole("admin", "root"), financialAnalyticsHandler.SetCurrency)
 
 	// Executive dashboard (spec §11) — ONE consolidated, tenant-scoped aggregation
 	// (cyber score, financial exposure, KRIs, top-10 risks, risk & incident trends,
@@ -2216,6 +2235,7 @@ func main() {
 	// =========================================================================
 	onboardingUC := appactivation.NewOnboardingUseCase(activationRepo, activationRecorder).
 		WithOrgUpdater(orgRepo).
+		WithOrgCurrencyUpdater(orgRepo).
 		WithProfileUpdater(userRepo)
 	activationHandler := handlers.NewActivationHandler(
 		appactivation.NewGetStateUseCase(activationRepo),

--- a/backend/internal/application/activation/onboarding.go
+++ b/backend/internal/application/activation/onboarding.go
@@ -32,6 +32,13 @@ type OrgUpdater interface {
 	UpdateOrganizationProfile(ctx context.Context, orgID uuid.UUID, name, industry, size string) error
 }
 
+// OrgCurrencyUpdater persists the tenant's display currency (onboarding step, and
+// later the settings screen). Optional (nil-safe), kept off OrgUpdater so callers
+// without a currency path are unaffected.
+type OrgCurrencyUpdater interface {
+	SetOrganizationCurrency(ctx context.Context, orgID uuid.UUID, currency string) error
+}
+
 // ProfileUpdater applies the profile step to the User row. Optional.
 type ProfileUpdater interface {
 	UpdateUserProfile(ctx context.Context, userID uuid.UUID, fullName, jobTitle, avatarURL string) error
@@ -59,8 +66,15 @@ type OnboardingUseCase struct {
 	repo     domain.OnboardingRepository
 	recorder *Recorder
 	orgs     OrgUpdater
+	orgCur   OrgCurrencyUpdater
 	profiles ProfileUpdater
 	now      func() time.Time
+}
+
+// WithOrgCurrencyUpdater attaches the optional tenant-currency writer.
+func (uc *OnboardingUseCase) WithOrgCurrencyUpdater(u OrgCurrencyUpdater) *OnboardingUseCase {
+	uc.orgCur = u
+	return uc
 }
 
 // NewOnboardingUseCase builds the use case with the required repository.
@@ -156,6 +170,11 @@ func (uc *OnboardingUseCase) SaveStep(ctx context.Context, tenantID, userID uuid
 				progress.Industry,
 				stringAnswer(input.Answers, "size"),
 			)
+		}
+		if uc.orgCur != nil && input.CanEditOrganization {
+			// Persist the chosen display currency so the financial engine converts
+			// every figure into it. Best-effort — never blocks the wizard.
+			_ = uc.orgCur.SetOrganizationCurrency(ctx, tenantID, stringAnswer(input.Answers, "currency"))
 		}
 	case domain.OnboardingStepProfile:
 		if uc.profiles != nil {

--- a/backend/internal/application/risk/financial_presenter.go
+++ b/backend/internal/application/risk/financial_presenter.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package risk
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/opendefender/openrisk/pkg/crq"
+)
+
+// OrgCurrencyReader resolves a tenant's chosen display currency (from org
+// settings). Optional/nil-safe: absent → XAF (the base). GormOrganizationRepository
+// satisfies it via its concrete OrgCurrency method.
+type OrgCurrencyReader interface {
+	OrgCurrency(ctx context.Context, tenantID uuid.UUID) (string, error)
+}
+
+// RatesProvider hands out the current FX rate table (with its AsOf date). Optional:
+// absent → the built-in static reference table. The daily FX worker implements it.
+type RatesProvider interface {
+	Current() *crq.RateTable
+}
+
+// FinancialPresenterFactory builds a per-request crq.Presenter for a tenant: it
+// resolves the tenant's display currency and the live rate table so every figure
+// is converted consistently and can show its reference date.
+type FinancialPresenterFactory struct {
+	q        *crq.Quantifier
+	currency OrgCurrencyReader // optional
+	rates    RatesProvider     // optional
+}
+
+// NewFinancialPresenterFactory builds the factory around the shared quantifier.
+func NewFinancialPresenterFactory(q *crq.Quantifier) *FinancialPresenterFactory {
+	return &FinancialPresenterFactory{q: q}
+}
+
+// WithCurrency attaches the tenant-currency resolver.
+func (f *FinancialPresenterFactory) WithCurrency(r OrgCurrencyReader) *FinancialPresenterFactory {
+	f.currency = r
+	return f
+}
+
+// WithRates attaches the live FX rate provider.
+func (f *FinancialPresenterFactory) WithRates(r RatesProvider) *FinancialPresenterFactory {
+	f.rates = r
+	return f
+}
+
+// RateTable returns the current rate table (live provider or static fallback).
+func (f *FinancialPresenterFactory) RateTable() *crq.RateTable {
+	if f != nil && f.rates != nil {
+		if t := f.rates.Current(); t != nil {
+			return t
+		}
+	}
+	return crq.DefaultRateTable()
+}
+
+// CurrencyFor resolves the tenant's display currency (best-effort → XAF).
+func (f *FinancialPresenterFactory) CurrencyFor(ctx context.Context, tenantID uuid.UUID) crq.Currency {
+	if f != nil && f.currency != nil {
+		if code, err := f.currency.OrgCurrency(ctx, tenantID); err == nil {
+			return crq.NormalizeCurrency(code)
+		}
+	}
+	return crq.CurrencyXAF
+}
+
+// For builds the presenter for a tenant.
+func (f *FinancialPresenterFactory) For(ctx context.Context, tenantID uuid.UUID) crq.Presenter {
+	xafPerUSD := crq.DefaultXAFPerUSD
+	if f != nil && f.q != nil && f.q.XAFPerUSD > 0 {
+		xafPerUSD = f.q.XAFPerUSD
+	}
+	return crq.NewPresenter(f.CurrencyFor(ctx, tenantID), f.RateTable(), xafPerUSD)
+}

--- a/backend/internal/application/risk/financial_summary.go
+++ b/backend/internal/application/risk/financial_summary.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/opendefender/openrisk/internal/domain"
@@ -21,6 +22,13 @@ import (
 // RiskRepository stay valid).
 type FinancialRiskLister interface {
 	ListRisksForFinancial(ctx context.Context, tenantID uuid.UUID) ([]domain.Risk, error)
+}
+
+// FinancialCoverageCounter returns the tenant's total + quantified risk counts
+// from a single SQL aggregate, so the "N/M quantified" figure is a server fact
+// rather than a client-side filter (spec §6). Optional/nil-safe.
+type FinancialCoverageCounter interface {
+	CountFinancialCoverage(ctx context.Context, tenantID uuid.UUID) (total, quantified int, err error)
 }
 
 // CriticalityBucket is the aggregated annual loss for one criticality band.
@@ -45,30 +53,59 @@ type TopRiskFinancial struct {
 // dashboard: portfolio ALE (current, worst-case, residual), remediation budget,
 // portfolio ROSI, a breakdown by criticality and the top exposures.
 type FinancialSummary struct {
-	Currency           string              `json:"currency"`
-	XAFPerUSD          float64             `json:"xaf_per_usd"`
-	TotalRisks         int                 `json:"total_risks"`
-	QuantifiedRisks    int                 `json:"quantified_risks"` // risks with explicit SLE or components
-	TotalALE           crq.Money           `json:"total_ale"`
-	TotalALEWorst      crq.Money           `json:"total_ale_worst"`
-	TotalALEAfter      crq.Money           `json:"total_ale_after"`      // residual after modeled controls
-	TotalRiskReduction crq.Money           `json:"total_risk_reduction"` // benefit of modeled controls
-	TotalRemediation   crq.Money           `json:"total_remediation"`
-	PortfolioROSI      float64             `json:"portfolio_rosi"`
-	PortfolioROSIOK    bool                `json:"portfolio_rosi_computable"`
-	ByCriticality      []CriticalityBucket `json:"by_criticality"`
-	TopRisks           []TopRiskFinancial  `json:"top_risks"`
+	Currency        string    `json:"currency"`    // tenant display currency
+	FXRateXAF       float64   `json:"fx_rate_xaf"` // XAF per 1 unit of Currency
+	FXAsOf          time.Time `json:"fx_as_of"`    // reference date of the rate
+	XAFPerUSD       float64   `json:"xaf_per_usd"`
+	ComputedAt      time.Time `json:"computed_at"` // when this snapshot was computed
+	FormulaVersion  string    `json:"formula_version"`
+	Iterations      int       `json:"iterations"`
+	TotalRisks      int       `json:"total_risks"`
+	QuantifiedRisks int       `json:"quantified_risks"` // from SQL aggregate, not a client filter
+	// PortfolioLoss is the FAIR-lite P10/P50/P90 band of TOTAL annual exposure —
+	// the headline figure. A single number is a false certainty (spec §2).
+	PortfolioLoss      crq.DistributionAmounts `json:"portfolio_loss"`
+	TotalALE           crq.Money               `json:"total_ale"`
+	TotalALEWorst      crq.Money               `json:"total_ale_worst"`
+	TotalALEAfter      crq.Money               `json:"total_ale_after"`      // residual after modeled controls
+	TotalRiskReduction crq.Money               `json:"total_risk_reduction"` // benefit of modeled controls
+	TotalRemediation   crq.Money               `json:"total_remediation"`
+	PortfolioROSI      float64                 `json:"portfolio_rosi"`
+	PortfolioROSIOK    bool                    `json:"portfolio_rosi_computable"`
+	ByCriticality      []CriticalityBucket     `json:"by_criticality"`
+	TopRisks           []TopRiskFinancial      `json:"top_risks"`
 }
 
 // FinancialSummaryUseCase aggregates the CRQ model across a tenant's register.
 type FinancialSummaryUseCase struct {
 	lister     FinancialRiskLister
 	quantifier *crq.Quantifier
+	presenters *FinancialPresenterFactory // optional; nil → XAF/static
+	coverage   FinancialCoverageCounter   // optional; nil → derived from the list
+	now        func() time.Time
 }
 
 // NewFinancialSummaryUseCase builds the use case.
 func NewFinancialSummaryUseCase(lister FinancialRiskLister, quantifier *crq.Quantifier) *FinancialSummaryUseCase {
-	return &FinancialSummaryUseCase{lister: lister, quantifier: quantifier}
+	return &FinancialSummaryUseCase{lister: lister, quantifier: quantifier, now: time.Now}
+}
+
+// WithPresenters attaches the currency/FX presenter factory.
+func (uc *FinancialSummaryUseCase) WithPresenters(f *FinancialPresenterFactory) *FinancialSummaryUseCase {
+	uc.presenters = f
+	return uc
+}
+
+// WithCoverageCounter attaches the SQL coverage aggregate.
+func (uc *FinancialSummaryUseCase) WithCoverageCounter(c FinancialCoverageCounter) *FinancialSummaryUseCase {
+	uc.coverage = c
+	return uc
+}
+
+// WithClock overrides the clock (tests).
+func (uc *FinancialSummaryUseCase) WithClock(now func() time.Time) *FinancialSummaryUseCase {
+	uc.now = now
+	return uc
 }
 
 // topRiskLimit caps the "biggest exposures" table.
@@ -82,14 +119,23 @@ func (uc *FinancialSummaryUseCase) Execute(ctx context.Context, tenantID uuid.UU
 	}
 
 	q := uc.quantifier
+	pres := uc.presenter(ctx, tenantID)
+	rates := pres.Rates
+
 	sum := &FinancialSummary{
-		Currency:   "XAF",
-		XAFPerUSD:  q.XAFPerUSD,
-		TotalRisks: len(risks),
+		Currency:       string(pres.Currency),
+		FXRateXAF:      rates.RateFor(pres.Currency),
+		FXAsOf:         rates.AsOf,
+		XAFPerUSD:      q.XAFPerUSD,
+		ComputedAt:     uc.clock()(),
+		FormulaVersion: crq.FormulaVersion,
+		Iterations:     crq.DefaultIterations,
+		TotalRisks:     len(risks),
 	}
 
 	// Running XAF totals; USD is derived once at the end for consistent rounding.
 	var totalALE, totalWorst, totalAfter, totalReduction, totalRemediation float64
+	var derivedQuantified int
 	bands := map[string]*CriticalityBucket{}
 	bandOrder := []string{"critical", "high", "medium", "low"}
 	for _, b := range bandOrder {
@@ -97,11 +143,15 @@ func (uc *FinancialSummaryUseCase) Execute(ctx context.Context, tenantID uuid.UU
 	}
 
 	tops := make([]TopRiskFinancial, 0, len(risks))
+	sims := make([]crq.SimulationInput, 0, len(risks))
 
 	for i := range risks {
 		r := &risks[i]
 		in := financialInputs(r)
-		a := q.Assess(in, string(r.Criticality))
+		// Deterministic per-risk figures (no per-risk Monte Carlo); the band comes
+		// from ONE shared portfolio simulation below.
+		a := q.AssessDeterministic(in, string(r.Criticality))
+		sims = append(sims, q.SimulationInputFor(in, string(r.Criticality)))
 
 		totalALE += a.ALE.XAF
 		totalWorst += a.ALEWorst.XAF
@@ -110,7 +160,7 @@ func (uc *FinancialSummaryUseCase) Execute(ctx context.Context, tenantID uuid.UU
 		totalRemediation += a.RemediationCost.XAF
 
 		if a.SLEBasis == crq.BasisExplicit || a.SLEBasis == crq.BasisComposed {
-			sum.QuantifiedRisks++
+			derivedQuantified++
 		}
 
 		band := strings.ToLower(strings.TrimSpace(string(r.Criticality)))
@@ -129,6 +179,18 @@ func (uc *FinancialSummaryUseCase) Execute(ctx context.Context, tenantID uuid.UU
 			ROSIOK:      a.ROSIComputable,
 		})
 	}
+
+	// Quantified count: prefer the SQL aggregate (server fact); fall back to the
+	// per-risk derivation only if no counter is wired.
+	sum.TotalRisks, sum.QuantifiedRisks = len(risks), derivedQuantified
+	if uc.coverage != nil {
+		if total, quantified, cErr := uc.coverage.CountFinancialCoverage(ctx, tenantID); cErr == nil {
+			sum.TotalRisks, sum.QuantifiedRisks = total, quantified
+		}
+	}
+
+	// Headline: one shared portfolio Monte Carlo → P10/P50/P90 of total exposure.
+	sum.PortfolioLoss = pres.Present(crq.SimulatePortfolio(sims, crq.DefaultIterations, crq.DefaultSeed))
 
 	sum.TotalALE = q.Money(totalALE)
 	sum.TotalALEWorst = q.Money(totalWorst)
@@ -154,6 +216,22 @@ func (uc *FinancialSummaryUseCase) Execute(ctx context.Context, tenantID uuid.UU
 	sum.TopRisks = tops
 
 	return sum, nil
+}
+
+// presenter resolves the tenant currency + rate table (XAF/static fallback).
+func (uc *FinancialSummaryUseCase) presenter(ctx context.Context, tenantID uuid.UUID) crq.Presenter {
+	if uc.presenters != nil {
+		return uc.presenters.For(ctx, tenantID)
+	}
+	return crq.NewPresenter(crq.CurrencyXAF, crq.DefaultRateTable(), uc.quantifier.XAFPerUSD)
+}
+
+// clock returns the injected clock (defaulting to time.Now).
+func (uc *FinancialSummaryUseCase) clock() func() time.Time {
+	if uc.now != nil {
+		return uc.now
+	}
+	return time.Now
 }
 
 // financialInputs maps a risk's stored drivers onto the CRQ input struct. Kept

--- a/backend/internal/application/risk/financial_summary_test.go
+++ b/backend/internal/application/risk/financial_summary_test.go
@@ -93,3 +93,66 @@ func TestFinancialSummary_ListerError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, sum)
 }
+
+// mockCurrencyReader / mockCoverage back the optional ports.
+type mockCurrencyReader struct{ code string }
+
+func (m mockCurrencyReader) OrgCurrency(context.Context, uuid.UUID) (string, error) {
+	return m.code, nil
+}
+
+type mockCoverage struct{ total, quantified int }
+
+func (m mockCoverage) CountFinancialCoverage(context.Context, uuid.UUID) (int, int, error) {
+	return m.total, m.quantified, nil
+}
+
+func TestFinancialSummary_PortfolioBandAndMetadata(t *testing.T) {
+	risks := []domain.Risk{
+		{ID: uuid.New(), Title: "A", Criticality: domain.RiskCriticalityCritical, SLEXAF: fp(20_000_000), ARO: fp(0.5)},
+		{ID: uuid.New(), Title: "B", Criticality: domain.RiskCriticalityHigh, FinesXAF: fp(3_000_000), ARO: fp(1)},
+	}
+	uc := NewFinancialSummaryUseCase(&mockFinancialLister{risks: risks}, crq.NewQuantifier(600, crq.DefaultReference()))
+
+	sum, err := uc.Execute(context.Background(), uuid.New())
+	require.NoError(t, err)
+
+	// A distribution (band), not a single number.
+	pl := sum.PortfolioLoss
+	assert.True(t, pl.P10.XAF <= pl.P50.XAF && pl.P50.XAF <= pl.P90.XAF, "band ordered: %+v", pl)
+	assert.Equal(t, crq.FormulaVersion, pl.FormulaVersion)
+	assert.Equal(t, crq.DefaultIterations, sum.Iterations)
+	assert.False(t, sum.ComputedAt.IsZero(), "computed_at stamped")
+	// Default currency is XAF with the static rate table's date.
+	assert.Equal(t, "XAF", sum.Currency)
+	assert.False(t, sum.FXAsOf.IsZero())
+}
+
+func TestFinancialSummary_TenantCurrencyConversion(t *testing.T) {
+	risks := []domain.Risk{
+		{ID: uuid.New(), Title: "A", Criticality: domain.RiskCriticalityCritical, SLEXAF: fp(655_957_000), ARO: fp(1)},
+	}
+	uc := NewFinancialSummaryUseCase(&mockFinancialLister{risks: risks}, crq.NewQuantifier(600, crq.DefaultReference())).
+		WithPresenters(NewFinancialPresenterFactory(crq.NewQuantifier(600, crq.DefaultReference())).WithCurrency(mockCurrencyReader{code: "EUR"}))
+
+	sum, err := uc.Execute(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, "EUR", sum.Currency)
+	assert.InDelta(t, 655.96, sum.FXRateXAF, 0.01)
+	// The band's median is presented in EUR (XAF preserved alongside).
+	assert.Greater(t, sum.PortfolioLoss.P50.XAF, 0.0)
+	assert.InDelta(t, sum.PortfolioLoss.P50.XAF/655.957, sum.PortfolioLoss.P50.Value, 1.0)
+	assert.Equal(t, crq.CurrencyEUR, sum.PortfolioLoss.P50.Currency)
+}
+
+func TestFinancialSummary_CoverageCounterWins(t *testing.T) {
+	// Lister returns 1 risk but the SQL coverage aggregate is authoritative.
+	risks := []domain.Risk{{ID: uuid.New(), Title: "A", Criticality: domain.RiskCriticalityLow}}
+	uc := NewFinancialSummaryUseCase(&mockFinancialLister{risks: risks}, crq.NewQuantifier(600, crq.DefaultReference())).
+		WithCoverageCounter(mockCoverage{total: 12, quantified: 5})
+
+	sum, err := uc.Execute(context.Background(), uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, 12, sum.TotalRisks)
+	assert.Equal(t, 5, sum.QuantifiedRisks)
+}

--- a/backend/internal/handler/risk_financial_handler.go
+++ b/backend/internal/handler/risk_financial_handler.go
@@ -6,6 +6,9 @@
 package handler
 
 import (
+	"context"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/opendefender/openrisk/internal/application/risk"
@@ -15,15 +18,58 @@ import (
 	"github.com/opendefender/openrisk/pkg/validation"
 )
 
+// OrgCurrencyWriter persists the tenant's display currency (settings change).
+type OrgCurrencyWriter interface {
+	SetOrganizationCurrency(ctx context.Context, tenantID uuid.UUID, currency string) error
+}
+
 // FinancialAnalyticsHandler serves the tenant-wide financial dashboard
 // (GET /analytics/financial) that backs the CISO/CFO screen.
 type FinancialAnalyticsHandler struct {
-	summaryUC *risk.FinancialSummaryUseCase
+	summaryUC  *risk.FinancialSummaryUseCase
+	currencyWr OrgCurrencyWriter // optional
 }
 
 // NewFinancialAnalyticsHandler builds the handler.
 func NewFinancialAnalyticsHandler(summaryUC *risk.FinancialSummaryUseCase) *FinancialAnalyticsHandler {
 	return &FinancialAnalyticsHandler{summaryUC: summaryUC}
+}
+
+// WithCurrencyWriter attaches the tenant-currency setter (for PUT currency).
+func (h *FinancialAnalyticsHandler) WithCurrencyWriter(w OrgCurrencyWriter) *FinancialAnalyticsHandler {
+	h.currencyWr = w
+	return h
+}
+
+// SetCurrencyInput is the body of PUT /analytics/financial/currency.
+type SetCurrencyInput struct {
+	Currency string `json:"currency"`
+}
+
+// SetCurrency PUT /analytics/financial/currency — changes the tenant's display
+// currency (chosen at onboarding, changeable here). Guarded admin at the route.
+func (h *FinancialAnalyticsHandler) SetCurrency(c *fiber.Ctx) error {
+	if h.currencyWr == nil {
+		return c.Status(500).JSON(fiber.Map{"error": "currency writer not configured"})
+	}
+	orgID := uuid.Nil
+	if mwCtx := middleware.GetContext(c); mwCtx != nil {
+		orgID = mwCtx.OrganizationID
+	}
+	if orgID == uuid.Nil {
+		return c.Status(401).JSON(fiber.Map{"error": "unauthenticated"})
+	}
+	in := new(SetCurrencyInput)
+	if err := c.BodyParser(in); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid input"})
+	}
+	if !crq.IsSupportedCurrency(in.Currency) {
+		return c.Status(400).JSON(fiber.Map{"error": "unsupported currency", "supported": crq.SupportedCurrencies})
+	}
+	if err := h.currencyWr.SetOrganizationCurrency(c.UserContext(), orgID, in.Currency); err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to update currency"})
+	}
+	return c.JSON(fiber.Map{"currency": crq.NormalizeCurrency(in.Currency)})
 }
 
 // GetFinancialSummary GET /analytics/financial — aggregated financial posture
@@ -81,8 +127,22 @@ func (h *RiskHandler) GetRiskFinancial(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": "quantifier not configured"})
 	}
 
-	assessment := h.crq.Assess(financialInputsFromRisk(r), string(r.Criticality))
+	assessment := h.assess(c, orgID, financialInputsFromRisk(r), string(r.Criticality))
 	return c.JSON(assessment)
+}
+
+// assess runs the full currency-aware assessment for the caller's tenant and
+// stamps the methodology's computed-at (the pure engine leaves it zero).
+func (h *RiskHandler) assess(c *fiber.Ctx, orgID uuid.UUID, in crq.FinancialInputs, criticality string) crq.FinancialAssessment {
+	pres := crq.NewPresenter(crq.CurrencyXAF, crq.DefaultRateTable(), h.crq.XAFPerUSD)
+	if h.presenters != nil {
+		pres = h.presenters.For(c.UserContext(), orgID)
+	}
+	a := h.crq.AssessP(in, criticality, pres)
+	if a.Methodology != nil {
+		a.Methodology.ComputedAt = time.Now().UTC()
+	}
+	return a
 }
 
 // SimulateFinancialInput carries per-field overrides for a what-if investment
@@ -163,6 +223,6 @@ func (h *RiskHandler) SimulateRiskFinancial(c *fiber.Ctx) error {
 		in.MitigationEffectiveness = input.MitigationEffectiveness
 	}
 
-	assessment := h.crq.Assess(in, string(r.Criticality))
+	assessment := h.assess(c, orgID, in, string(r.Criticality))
 	return c.JSON(assessment)
 }

--- a/backend/internal/handler/risk_handler.go
+++ b/backend/internal/handler/risk_handler.go
@@ -32,7 +32,15 @@ type RiskHandler struct {
 	markReviewedUC    *risk.MarkRiskReviewedUseCase
 	transitionStateUC *risk.TransitionRiskStateUseCase
 	redisClient       *redis.Client
-	crq               *crq.Quantifier // Cyber Risk Quantification (XAF + USD)
+	crq               *crq.Quantifier                 // Cyber Risk Quantification (XAF + USD)
+	presenters        *risk.FinancialPresenterFactory // optional: tenant currency + FX
+}
+
+// WithFinancialPresenters attaches the tenant currency/FX presenter factory used
+// by the per-risk financial + simulate endpoints. Optional (nil → XAF/static).
+func (h *RiskHandler) WithFinancialPresenters(f *risk.FinancialPresenterFactory) *RiskHandler {
+	h.presenters = f
+	return h
 }
 
 func NewRiskHandler(

--- a/backend/internal/handler/risk_handler_test.go
+++ b/backend/internal/handler/risk_handler_test.go
@@ -143,6 +143,8 @@ func setupAppWithDB(t *testing.T) *fiber.App {
 	api.Patch("/risks/:id", handler.UpdateRisk)
 	api.Post("/risks/:id/transition", handler.TransitionPhase)
 	api.Delete("/risks/:id", handler.DeleteRisk)
+	api.Get("/risks/:id/financial", handler.GetRiskFinancial)
+	api.Post("/risks/:id/simulate", handler.SimulateRiskFinancial)
 
 	return app
 }
@@ -205,6 +207,76 @@ func TestRiskCRUDFlow(t *testing.T) {
 	defer delResp.Body.Close()
 	if delResp.StatusCode != 204 {
 		t.Fatalf("expected 204 on delete got %d", delResp.StatusCode)
+	}
+}
+
+// TestRiskFinancialAndSimulator is the end-to-end for the FAIR-lite engine and
+// the ROSI simulator (spec §2, §4, §5) through the real HTTP stack: create a
+// risk, read its financial assessment (band + methodology), then run a what-if
+// investment simulation and assert the ROSI + residual exposure.
+func TestRiskFinancialAndSimulator(t *testing.T) {
+	app := setupAppWithDB(t)
+
+	// 1. Create a risk.
+	b, _ := json.Marshal(map[string]interface{}{
+		"title": "Ransomware", "description": "d", "impact": 8, "probability": 0.6,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/risks", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		t.Fatalf("create: expected 201 got %d", resp.StatusCode)
+	}
+	var created domain.Risk
+	json.NewDecoder(resp.Body).Decode(&created)
+
+	// 2. GET /financial → a distribution band + methodology (explainability).
+	finReq := httptest.NewRequest(http.MethodGet, "/api/v1/risks/"+created.ID.String()+"/financial", nil)
+	finResp, _ := app.Test(finReq)
+	defer finResp.Body.Close()
+	if finResp.StatusCode != 200 {
+		t.Fatalf("financial: expected 200 got %d", finResp.StatusCode)
+	}
+	var assess crq.FinancialAssessment
+	json.NewDecoder(finResp.Body).Decode(&assess)
+	if assess.Distribution == nil || assess.Methodology == nil {
+		t.Fatalf("financial must include distribution + methodology")
+	}
+	d := assess.Distribution
+	if !(d.P10.XAF <= d.P50.XAF && d.P50.XAF <= d.P90.XAF) {
+		t.Fatalf("band not ordered: %+v", d)
+	}
+	if assess.Methodology.ComputedAt.IsZero() {
+		t.Fatalf("handler must stamp methodology.computed_at")
+	}
+
+	// 3. POST /simulate — invest against explicit drivers, assert ROSI + residual.
+	sim, _ := json.Marshal(map[string]interface{}{
+		"sle_xaf": 20_000_000, "aro": 0.5, // ALE = 10M
+		"remediation_cost_xaf": 3_000_000, "mitigation_effectiveness": 0.8,
+	})
+	simReq := httptest.NewRequest(http.MethodPost, "/api/v1/risks/"+created.ID.String()+"/simulate", bytes.NewReader(sim))
+	simReq.Header.Set("Content-Type", "application/json")
+	simResp, _ := app.Test(simReq)
+	defer simResp.Body.Close()
+	if simResp.StatusCode != 200 {
+		t.Fatalf("simulate: expected 200 got %d", simResp.StatusCode)
+	}
+	var out crq.FinancialAssessment
+	json.NewDecoder(simResp.Body).Decode(&out)
+	if out.ALE.XAF != 10_000_000 {
+		t.Fatalf("simulate ALE = %v, want 10000000", out.ALE.XAF)
+	}
+	if out.ALEAfter.XAF != 2_000_000 {
+		t.Fatalf("simulate residual ALE = %v, want 2000000", out.ALEAfter.XAF)
+	}
+	// ROSI = (10M − 2M − 3M) / 3M ≈ 1.67.
+	if !out.ROSIComputable || out.ROSI < 1.6 || out.ROSI > 1.7 {
+		t.Fatalf("simulate ROSI = %v (ok=%v), want ~1.67", out.ROSI, out.ROSIComputable)
+	}
+	if out.Distribution == nil {
+		t.Fatalf("simulate result must include the distribution band")
 	}
 }
 

--- a/backend/internal/infrastructure/repository/gorm_risk_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_risk_repository.go
@@ -332,6 +332,33 @@ func (r *GormRiskRepository) SearchByText(ctx context.Context, tenantID uuid.UUI
 	return risks, err
 }
 
+// CountFinancialCoverage returns, for a tenant, the total active risk count and
+// how many are "quantified" — carrying an explicit SLE or at least one loss
+// component (downtime pair, fines, data-loss or other direct cost). This is a
+// single SQL aggregate so the "N/M risks quantified" counter is a server fact,
+// not a client-side filter that can drift (spec §6). Concrete method (off the
+// RiskRepository port) so mocks stay valid.
+func (r *GormRiskRepository) CountFinancialCoverage(ctx context.Context, tenantID uuid.UUID) (total, quantified int, err error) {
+	type row struct {
+		Total      int64
+		Quantified int64
+	}
+	var res row
+	err = r.db.WithContext(ctx).
+		Model(&domain.Risk{}).
+		Select(`COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE
+				sle_xaf IS NOT NULL
+				OR fines_xaf IS NOT NULL
+				OR data_loss_cost_xaf IS NOT NULL
+				OR other_direct_cost_xaf IS NOT NULL
+				OR (downtime_hours IS NOT NULL AND hourly_downtime_cost_xaf IS NOT NULL)
+			) AS quantified`).
+		Where("tenant_id = ?", tenantID).
+		Scan(&res).Error
+	return int(res.Total), int(res.Quantified), err
+}
+
 func (r *GormRiskRepository) ListRisksForFinancial(ctx context.Context, tenantID uuid.UUID) ([]domain.Risk, error) {
 	var risks []domain.Risk
 	err := r.db.WithContext(ctx).

--- a/backend/internal/infrastructure/repository/onboarding_profile_writes.go
+++ b/backend/internal/infrastructure/repository/onboarding_profile_writes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/crq"
 )
 
 // Narrow, targeted writes for the onboarding wizard's organization and profile
@@ -49,6 +50,51 @@ func (r *GormOrganizationRepository) UpdateOrganizationProfile(ctx context.Conte
 		Model(&domain.Organization{}).
 		Where("id = ?", orgID).
 		Updates(updates).Error
+}
+
+// SetOrganizationCurrency stores the tenant's display currency inside the
+// organization's settings jsonb. The value is validated against the supported
+// set; an unsupported/empty code is ignored (leaves the current setting intact),
+// so a blank onboarding answer can't blank out a real choice. Load-merge-save is
+// safe here (onboarding / settings screen are low-concurrency).
+func (r *GormOrganizationRepository) SetOrganizationCurrency(ctx context.Context, orgID uuid.UUID, currency string) error {
+	if orgID == uuid.Nil {
+		return nil
+	}
+	code := strings.ToUpper(strings.TrimSpace(currency))
+	if !crq.IsSupportedCurrency(code) {
+		return nil
+	}
+	var org domain.Organization
+	if err := r.db.WithContext(ctx).Where("id = ?", orgID).First(&org).Error; err != nil {
+		return err
+	}
+	settings := org.GetSettings()
+	settings["currency"] = code
+	if err := org.SetSettings(settings); err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).
+		Model(&domain.Organization{}).
+		Where("id = ?", orgID).
+		Update("settings", org.Settings).Error
+}
+
+// OrgCurrency reads the tenant's display currency from settings, falling back to
+// XAF (the base) when unset or unknown. Concrete method (off any shared port) so
+// mocks stay valid — same convention as ListRisksForFinancial.
+func (r *GormOrganizationRepository) OrgCurrency(ctx context.Context, orgID uuid.UUID) (string, error) {
+	if orgID == uuid.Nil {
+		return string(crq.CurrencyXAF), nil
+	}
+	var org domain.Organization
+	if err := r.db.WithContext(ctx).Where("id = ?", orgID).First(&org).Error; err != nil {
+		return string(crq.CurrencyXAF), err
+	}
+	if v, ok := org.GetSettings()["currency"].(string); ok && crq.IsSupportedCurrency(v) {
+		return strings.ToUpper(strings.TrimSpace(v)), nil
+	}
+	return string(crq.CurrencyXAF), nil
 }
 
 // UpdateUserProfile applies the wizard's profile step.

--- a/backend/internal/infrastructure/workers/fx_rate_worker.go
+++ b/backend/internal/infrastructure/workers/fx_rate_worker.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package workers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/opendefender/openrisk/pkg/crq"
+)
+
+// FXRateSource fetches a dated rate table from somewhere (a provider API, a
+// config file, …). It is the seam a live FX feed plugs into. The table it returns
+// MUST carry an AsOf date — a converted amount without its reference date is not
+// defensible (spec §3).
+type FXRateSource interface {
+	// Fetch returns the current rates. Name identifies the source for logs.
+	Fetch(ctx context.Context) (*crq.RateTable, error)
+	Name() string
+}
+
+// StaticFXSource returns the built-in reference table. It is the honest default
+// when no live feed is configured: figures still convert, and the fixed AsOf date
+// is shown next to them so nobody mistakes them for live quotes.
+type StaticFXSource struct{}
+
+func (StaticFXSource) Name() string { return "static-reference" }
+func (StaticFXSource) Fetch(context.Context) (*crq.RateTable, error) {
+	return crq.DefaultRateTable(), nil
+}
+
+// FXRateWorker holds the current rate table and refreshes it on a daily cadence
+// (spec §3: "taux de change via job quotidien"). It satisfies
+// risk.RatesProvider via Current(), so handlers and the summary use case read a
+// single, dated source of truth. Reads are concurrency-safe.
+type FXRateWorker struct {
+	source   FXRateSource
+	logger   zerolog.Logger
+	interval time.Duration
+
+	mu      sync.RWMutex
+	current *crq.RateTable
+}
+
+// NewFXRateWorker builds the worker and seeds it immediately (falling back to the
+// static table if the first fetch fails), so Current() is valid before Start.
+func NewFXRateWorker(source FXRateSource, logger zerolog.Logger) *FXRateWorker {
+	if source == nil {
+		source = StaticFXSource{}
+	}
+	w := &FXRateWorker{source: source, logger: logger, interval: 24 * time.Hour}
+	w.current = crq.DefaultRateTable()
+	w.refresh(context.Background())
+	return w
+}
+
+// Current returns the latest rate table (never nil).
+func (w *FXRateWorker) Current() *crq.RateTable {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.current == nil {
+		return crq.DefaultRateTable()
+	}
+	return w.current
+}
+
+// Start refreshes the rates once a day until ctx is cancelled.
+func (w *FXRateWorker) Start(ctx context.Context) {
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	w.logger.Info().Str("source", w.source.Name()).Msg("FX rate worker started (daily refresh)")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			w.refresh(ctx)
+		}
+	}
+}
+
+// refresh pulls the latest table; a failed fetch keeps the last-good table.
+func (w *FXRateWorker) refresh(ctx context.Context) {
+	table, err := w.source.Fetch(ctx)
+	if err != nil || table == nil {
+		w.logger.Warn().Err(err).Msg("FX rate refresh failed — keeping last-known rates")
+		return
+	}
+	w.mu.Lock()
+	w.current = table
+	w.mu.Unlock()
+	w.logger.Debug().Time("as_of", table.AsOf).Str("source", table.Source).Msg("FX rates refreshed")
+}

--- a/backend/pkg/crq/currency.go
+++ b/backend/pkg/crq/currency.go
@@ -63,9 +63,9 @@ func NormalizeCurrency(code string) Currency {
 // direction keeps XAF as the base and matches DefaultXAFPerUSD. AsOf is the date
 // the rates were captured — surfaced next to every converted amount.
 type RateTable struct {
-	Base   Currency             `json:"base"`   // always XAF
-	AsOf   time.Time            `json:"as_of"`  // reference date of the rates
-	Source string               `json:"source"` // provider label ("static", "ecb", …)
+	Base   Currency             `json:"base"`    // always XAF
+	AsOf   time.Time            `json:"as_of"`   // reference date of the rates
+	Source string               `json:"source"`  // provider label ("static", "ecb", …)
 	XAFPer map[Currency]float64 `json:"xaf_per"` // XAF per 1 unit of currency
 }
 
@@ -84,13 +84,13 @@ func DefaultRateTable() *RateTable {
 		Source: "static-reference",
 		XAFPer: map[Currency]float64{
 			CurrencyXAF: 1.0,
-			CurrencyXOF: 1.0,      // XAF and XOF share the fixed CFA parity
-			CurrencyEUR: 655.957,  // fixed BCEAO/BEAC euro peg
+			CurrencyXOF: 1.0,     // XAF and XOF share the fixed CFA parity
+			CurrencyEUR: 655.957, // fixed BCEAO/BEAC euro peg
 			CurrencyUSD: DefaultXAFPerUSD,
-			CurrencyNGN: 0.40,     // ~1 NGN
-			CurrencyMAD: 60.0,     // ~1 MAD
-			CurrencyGHS: 40.0,     // ~1 GHS
-			CurrencyZAR: 33.0,     // ~1 ZAR
+			CurrencyNGN: 0.40, // ~1 NGN
+			CurrencyMAD: 60.0, // ~1 MAD
+			CurrencyGHS: 40.0, // ~1 GHS
+			CurrencyZAR: 33.0, // ~1 ZAR
 		},
 	}
 }

--- a/backend/pkg/crq/currency.go
+++ b/backend/pkg/crq/currency.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+// currency.go gives the CRQ engine a tenant-level display currency. Amounts are
+// always STORED in XAF (FCFA — the target market's base) and converted for
+// display at a dated reference rate. The rate table carries an AsOf date so the
+// UI can show "1 EUR = 655.96 XAF (as of 2026-08-01)" next to every figure — a
+// converted amount without its reference date is not defensible to a CFO.
+package crq
+
+import (
+	"strings"
+	"time"
+)
+
+// Currency is an ISO-4217 code the platform can display. The base/store currency
+// is always XAF; the others are display targets converted at the reference rate.
+type Currency string
+
+const (
+	CurrencyXAF Currency = "XAF" // Central African CFA franc (base)
+	CurrencyXOF Currency = "XOF" // West African CFA franc
+	CurrencyEUR Currency = "EUR"
+	CurrencyUSD Currency = "USD"
+	CurrencyNGN Currency = "NGN" // Nigerian naira
+	CurrencyMAD Currency = "MAD" // Moroccan dirham
+	CurrencyGHS Currency = "GHS" // Ghanaian cedi
+	CurrencyZAR Currency = "ZAR" // South African rand
+)
+
+// SupportedCurrencies is the closed set the tenant may pick (spec §3).
+var SupportedCurrencies = []Currency{
+	CurrencyXAF, CurrencyXOF, CurrencyEUR, CurrencyUSD,
+	CurrencyNGN, CurrencyMAD, CurrencyGHS, CurrencyZAR,
+}
+
+// IsSupportedCurrency reports whether code is one the platform can display.
+// Comparison is case-insensitive and trims spaces.
+func IsSupportedCurrency(code string) bool {
+	c := Currency(strings.ToUpper(strings.TrimSpace(code)))
+	for _, s := range SupportedCurrencies {
+		if s == c {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeCurrency returns a supported currency for an arbitrary string,
+// falling back to XAF (the base) when the code is empty or unknown.
+func NormalizeCurrency(code string) Currency {
+	c := Currency(strings.ToUpper(strings.TrimSpace(code)))
+	if IsSupportedCurrency(string(c)) {
+		return c
+	}
+	return CurrencyXAF
+}
+
+// RateTable maps each display currency to the number of XAF that equal ONE unit
+// of that currency (so "XAFPer[EUR] = 655.957" means 1 EUR = 655.957 XAF). This
+// direction keeps XAF as the base and matches DefaultXAFPerUSD. AsOf is the date
+// the rates were captured — surfaced next to every converted amount.
+type RateTable struct {
+	Base   Currency             `json:"base"`   // always XAF
+	AsOf   time.Time            `json:"as_of"`  // reference date of the rates
+	Source string               `json:"source"` // provider label ("static", "ecb", …)
+	XAFPer map[Currency]float64 `json:"xaf_per"` // XAF per 1 unit of currency
+}
+
+// referenceRatesAsOf is the capture date of the built-in fallback table. XAF and
+// XOF are both pegged to the euro at the fixed parity 1 EUR = 655.957 CFA; the
+// others are rounded market approximations. A live FX job (fx worker) overwrites
+// these with dated provider rates; until then the app is honest about the date.
+var referenceRatesAsOf = time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+
+// DefaultRateTable returns the built-in reference rates (XAF per 1 unit). It is a
+// deterministic fallback used when no live FX rate is available.
+func DefaultRateTable() *RateTable {
+	return &RateTable{
+		Base:   CurrencyXAF,
+		AsOf:   referenceRatesAsOf,
+		Source: "static-reference",
+		XAFPer: map[Currency]float64{
+			CurrencyXAF: 1.0,
+			CurrencyXOF: 1.0,      // XAF and XOF share the fixed CFA parity
+			CurrencyEUR: 655.957,  // fixed BCEAO/BEAC euro peg
+			CurrencyUSD: DefaultXAFPerUSD,
+			CurrencyNGN: 0.40,     // ~1 NGN
+			CurrencyMAD: 60.0,     // ~1 MAD
+			CurrencyGHS: 40.0,     // ~1 GHS
+			CurrencyZAR: 33.0,     // ~1 ZAR
+		},
+	}
+}
+
+// xafPer returns the XAF-per-unit rate for a currency, defaulting to 1.0 (XAF)
+// when the currency is missing from the table.
+func (t *RateTable) xafPer(c Currency) float64 {
+	if t == nil {
+		return 1.0
+	}
+	if v, ok := t.XAFPer[c]; ok && v > 0 {
+		return v
+	}
+	return 1.0
+}
+
+// Convert turns an amount expressed in XAF into the target currency at the
+// table's reference rate. XAF→XAF is the identity.
+func (t *RateTable) Convert(xaf float64, target Currency) float64 {
+	if target == CurrencyXAF || target == "" {
+		return round2(xaf)
+	}
+	return round2(xaf / t.xafPer(target))
+}
+
+// RateFor returns the "1 <currency> = N XAF" figure for display next to amounts.
+func (t *RateTable) RateFor(c Currency) float64 {
+	return round2(t.xafPer(c))
+}

--- a/backend/pkg/crq/currency_test.go
+++ b/backend/pkg/crq/currency_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package crq
+
+import (
+	"math"
+	"testing"
+)
+
+func TestConvert_Currencies(t *testing.T) {
+	rt := DefaultRateTable()
+	const xaf = 655_957_000.0 // exactly 1,000,000 EUR at the fixed peg
+	cases := []struct {
+		cur  Currency
+		want float64
+	}{
+		{CurrencyXAF, xaf},
+		{CurrencyXOF, xaf}, // same CFA parity
+		{CurrencyEUR, 1_000_000.0},
+		{CurrencyUSD, round2(xaf / DefaultXAFPerUSD)},
+		{CurrencyNGN, round2(xaf / 0.40)},
+		{CurrencyZAR, round2(xaf / 33.0)},
+	}
+	for _, c := range cases {
+		got := rt.Convert(xaf, c.cur)
+		if math.Abs(got-c.want) > 0.01 {
+			t.Fatalf("%s: got %.2f want %.2f", c.cur, got, c.want)
+		}
+	}
+}
+
+func TestConvert_XAFIdentity(t *testing.T) {
+	rt := DefaultRateTable()
+	if got := rt.Convert(42_000, CurrencyXAF); got != 42_000 {
+		t.Fatalf("XAF identity broken: %.2f", got)
+	}
+	if got := rt.Convert(42_000, ""); got != 42_000 {
+		t.Fatalf("empty currency should be XAF identity: %.2f", got)
+	}
+}
+
+func TestConvert_UnknownCurrencyDefaultsToXAF(t *testing.T) {
+	rt := DefaultRateTable()
+	// A currency missing from the table falls back to rate 1.0 (XAF).
+	if got := rt.Convert(1000, Currency("JPY")); got != 1000 {
+		t.Fatalf("unknown currency should default to identity: %.2f", got)
+	}
+}
+
+func TestIsSupportedAndNormalize(t *testing.T) {
+	if !IsSupportedCurrency("eur") || !IsSupportedCurrency(" ZAR ") {
+		t.Fatalf("case/space-insensitive support check failed")
+	}
+	if IsSupportedCurrency("JPY") {
+		t.Fatalf("JPY should not be supported")
+	}
+	if NormalizeCurrency("ghs") != CurrencyGHS {
+		t.Fatalf("normalize lower-case failed")
+	}
+	if NormalizeCurrency("") != CurrencyXAF || NormalizeCurrency("nope") != CurrencyXAF {
+		t.Fatalf("normalize fallback to XAF failed")
+	}
+}
+
+func TestRateFor(t *testing.T) {
+	rt := DefaultRateTable()
+	if rt.RateFor(CurrencyEUR) != 655.96 {
+		t.Fatalf("EUR rate display: got %.2f want 655.96", rt.RateFor(CurrencyEUR))
+	}
+	if rt.RateFor(CurrencyXAF) != 1.0 {
+		t.Fatalf("XAF self-rate should be 1")
+	}
+}
+
+func TestAmount_AllThreeCurrencies(t *testing.T) {
+	p := NewPresenter(CurrencyUSD, DefaultRateTable(), DefaultXAFPerUSD)
+	a := p.Amount(1_200_000)
+	if a.XAF != 1_200_000 {
+		t.Fatalf("XAF preserved: %.2f", a.XAF)
+	}
+	if a.USD != 2000 { // 1.2M / 600
+		t.Fatalf("USD: got %.2f want 2000", a.USD)
+	}
+	if a.Value != 2000 || a.Currency != CurrencyUSD {
+		t.Fatalf("display currency: got %.2f %s", a.Value, a.Currency)
+	}
+}

--- a/backend/pkg/crq/financial.go
+++ b/backend/pkg/crq/financial.go
@@ -12,6 +12,8 @@
 // no actuarial black box.
 package crq
 
+import "time"
+
 // Loss-band spread factors used when a risk only carries a most-likely SLE (no
 // explicit min/max). They give a defensible worst/best envelope around the point
 // estimate: best = SLE × 0.5, worst = SLE × 2.0. Documented and deliberately
@@ -47,9 +49,41 @@ type FinancialInputs struct {
 	MitigationEffectiveness *float64 // [0,1] share of ALE the control removes
 }
 
+// MethodologyInput is one intrant surfaced in the explainability panel: what
+// value went into the model, in what unit, and where it came from.
+type MethodologyInput struct {
+	Key    string  `json:"key"`
+	Label  string  `json:"label"`
+	Value  float64 `json:"value"`
+	Unit   string  `json:"unit"`
+	Source string  `json:"source"` // "risk-input" | "reference-model" | "derived"
+}
+
+// Methodology is the audit trail for a quantified figure (spec §4): the model,
+// its exact intrants, assumptions, run parameters and the reference rate used.
+// ComputedAt is stamped by the caller (handler/use case), not the pure engine.
+type Methodology struct {
+	FormulaVersion string             `json:"formula_version"`
+	Model          string             `json:"model"`
+	Iterations     int                `json:"iterations"`
+	Seed           int64              `json:"seed"`
+	ComputedAt     time.Time          `json:"computed_at"`
+	DocURL         string             `json:"doc_url"`
+	Currency       Currency           `json:"currency"`
+	FXAsOf         time.Time          `json:"fx_as_of"`
+	FXRateXAF      float64            `json:"fx_rate_xaf"` // XAF per 1 unit of Currency
+	Inputs         []MethodologyInput `json:"inputs"`
+	Assumptions    []string           `json:"assumptions"`
+}
+
 // FinancialAssessment is the full monetary view of a single risk — the object a
 // CISO/CFO dashboard renders. Every monetary field carries both currencies.
 type FinancialAssessment struct {
+	// --- FAIR-lite loss distribution (spec §2: P10/P50/P90, never one number) ---
+	Distribution *DistributionAmounts `json:"distribution,omitempty"`
+	// --- Explainability (spec §4) ---
+	Methodology *Methodology `json:"methodology,omitempty"`
+
 	// --- Single-event loss magnitude ---
 	SLE          Money `json:"sle"`           // effective single loss expectancy
 	SLEAverage   Money `json:"sle_average"`   // PERT-expected single loss
@@ -104,10 +138,39 @@ func ROSI(aleBefore, aleAfter, remediationCost float64) (float64, bool) {
 	return round2((aleBefore - aleAfter - remediationCost) / remediationCost), true
 }
 
-// Assess runs the full financial model for one risk. It never errors: absent
-// inputs degrade gracefully to the reference model so every risk still carries an
-// order-of-magnitude figure, exactly like Quantify.
+// Assess runs the full financial model for one risk in XAF only (no tenant
+// currency). Kept for callers that don't present a currency; delegates to AssessP
+// with a plain XAF presenter.
 func (q *Quantifier) Assess(in FinancialInputs, criticality string) FinancialAssessment {
+	return q.AssessP(in, criticality, NewPresenter(CurrencyXAF, DefaultRateTable(), q.XAFPerUSD))
+}
+
+// SimulationInputFor derives the FAIR-lite Monte Carlo parameters (LEF + PERT
+// loss-magnitude band) from a risk's stored drivers. LEF is the ARO (falling back
+// to 1 loss/year when unknown so the reference band reads as an annual figure);
+// the PERT band is the composed/explicit SLE as the mode with the loss-band
+// best/worst as the bounds.
+func (q *Quantifier) SimulationInputFor(in FinancialInputs, criticality string) SimulationInput {
+	downtime := DowntimeCostXAF(in.DowntimeHours, in.HourlyDowntimeCostXAF)
+	sleXAF, _ := q.effectiveSLE(in, downtime, criticality)
+	best, worst := q.lossBand(in, sleXAF)
+	lef := 1.0
+	if in.ARO != nil && *in.ARO > 0 {
+		lef = *in.ARO
+	}
+	return SimulationInput{
+		LEF:        lef,
+		LM:         PERT{Min: best, Mode: sleXAF, Max: worst},
+		Iterations: DefaultIterations,
+		Seed:       DefaultSeed,
+	}
+}
+
+// AssessP runs the full financial model for one risk and presents every figure in
+// the tenant's display currency via p. It never errors: absent inputs degrade
+// gracefully to the reference model so every risk still carries an
+// order-of-magnitude figure, exactly like Quantify.
+func (q *Quantifier) AssessP(in FinancialInputs, criticality string, p Presenter) FinancialAssessment {
 	downtime := DowntimeCostXAF(in.DowntimeHours, in.HourlyDowntimeCostXAF)
 
 	// 1. Effective single-loss expectancy (XAF) + how we got it.
@@ -154,7 +217,14 @@ func (q *Quantifier) Assess(in FinancialInputs, criticality string) FinancialAss
 	}
 	rosi, rosiOK := ROSI(aleXAF, aleAfter, remediation)
 
+	// 6. FAIR-lite loss distribution (P10/P50/P90) + explainability metadata.
+	sim := q.SimulationInputFor(in, criticality)
+	dist := p.Present(Simulate(sim))
+	method := q.methodology(in, sim, p, sleBasis)
+
 	return FinancialAssessment{
+		Distribution: &dist,
+		Methodology:  method,
 		SLE:          q.Money(sleXAF),
 		SLEAverage:   q.Money(avg),
 		SLEWorst:     q.Money(worst),
@@ -211,6 +281,76 @@ func (q *Quantifier) lossBand(in FinancialInputs, sleXAF float64) (best, worst f
 		best = sleXAF
 	}
 	return best, worst
+}
+
+// methodology assembles the explainability payload for one risk: the model, the
+// exact intrants that fed it (with their provenance), the assumptions, the run
+// parameters and the reference FX rate. ComputedAt is left zero here (pure
+// engine) and stamped by the caller.
+func (q *Quantifier) methodology(in FinancialInputs, sim SimulationInput, p Presenter, sleBasis Basis) *Methodology {
+	inputs := []MethodologyInput{
+		{Key: "lef", Label: "Loss Event Frequency", Value: round2(sim.LEF), Unit: "events/year", Source: aroSource(in)},
+		{Key: "lm_min", Label: "Loss Magnitude — min", Value: round2(sim.LM.Min), Unit: "XAF", Source: "derived"},
+		{Key: "lm_mode", Label: "Loss Magnitude — most likely", Value: round2(sim.LM.Mode), Unit: "XAF", Source: sleSource(sleBasis)},
+		{Key: "lm_max", Label: "Loss Magnitude — max", Value: round2(sim.LM.Max), Unit: "XAF", Source: "derived"},
+	}
+	// Surface the specific loss drivers that were actually provided.
+	if v := val(in.DowntimeHours); v > 0 {
+		inputs = append(inputs, MethodologyInput{Key: "downtime_hours", Label: "Downtime", Value: v, Unit: "hours", Source: "risk-input"})
+	}
+	if v := val(in.HourlyDowntimeCostXAF); v > 0 {
+		inputs = append(inputs, MethodologyInput{Key: "hourly_downtime_cost", Label: "Downtime cost", Value: v, Unit: "XAF/hour", Source: "risk-input"})
+	}
+	if v := val(in.FinesXAF); v > 0 {
+		inputs = append(inputs, MethodologyInput{Key: "fines", Label: "Regulatory fines", Value: v, Unit: "XAF", Source: "risk-input"})
+	}
+	if v := val(in.DataLossCostXAF); v > 0 {
+		inputs = append(inputs, MethodologyInput{Key: "data_loss", Label: "Data-loss cost", Value: v, Unit: "XAF", Source: "risk-input"})
+	}
+
+	assumptions := []string{
+		"ALE = LEF × LM ; LM follows a 3-point PERT distribution (min / most-likely / max).",
+		"Loss magnitude sampled by Monte Carlo; percentiles are P10 / P50 (median) / P90.",
+	}
+	if sleBasis == BasisReference {
+		assumptions = append(assumptions, "No explicit loss inputs on this risk — the reference band for its criticality was used.")
+	}
+	if in.SLEBestXAF == nil || in.SLEWorstXAF == nil {
+		assumptions = append(assumptions, "Loss band derived from the point estimate (best = ×0.5, worst = ×2.0).")
+	}
+
+	return &Methodology{
+		FormulaVersion: FormulaVersion,
+		Model:          "FAIR-lite: ALE = LEF × LM (PERT), Monte Carlo",
+		Iterations:     sim.Iterations,
+		Seed:           sim.Seed,
+		DocURL:         DocURL,
+		Currency:       p.Currency,
+		FXAsOf:         p.Rates.AsOf,
+		FXRateXAF:      p.Rates.RateFor(p.Currency),
+		Inputs:         inputs,
+		Assumptions:    assumptions,
+	}
+}
+
+// aroSource labels where the LEF came from.
+func aroSource(in FinancialInputs) string {
+	if in.ARO != nil && *in.ARO > 0 {
+		return "risk-input"
+	}
+	return "reference-model"
+}
+
+// sleSource labels where the loss-magnitude mode came from.
+func sleSource(b Basis) string {
+	switch b {
+	case BasisExplicit:
+		return "risk-input"
+	case BasisComposed:
+		return "derived"
+	default:
+		return "reference-model"
+	}
 }
 
 // val safely dereferences an optional positive amount (nil / negative → 0).

--- a/backend/pkg/crq/financial.go
+++ b/backend/pkg/crq/financial.go
@@ -166,11 +166,30 @@ func (q *Quantifier) SimulationInputFor(in FinancialInputs, criticality string) 
 	}
 }
 
+// AssessDeterministic runs the closed-form part of the model (SLE, downtime,
+// ALE, worst/average, ROSI) WITHOUT the Monte Carlo distribution or methodology.
+// It is the cheap path the portfolio summary uses per risk, since the summary
+// runs a single shared portfolio simulation instead of one per risk.
+func (q *Quantifier) AssessDeterministic(in FinancialInputs, criticality string) FinancialAssessment {
+	return q.assessCore(in, criticality)
+}
+
 // AssessP runs the full financial model for one risk and presents every figure in
-// the tenant's display currency via p. It never errors: absent inputs degrade
+// the tenant's display currency via p, including the FAIR-lite loss distribution
+// and the explainability methodology. It never errors: absent inputs degrade
 // gracefully to the reference model so every risk still carries an
 // order-of-magnitude figure, exactly like Quantify.
 func (q *Quantifier) AssessP(in FinancialInputs, criticality string, p Presenter) FinancialAssessment {
+	fa := q.assessCore(in, criticality)
+	sim := q.SimulationInputFor(in, criticality)
+	dist := p.Present(Simulate(sim))
+	fa.Distribution = &dist
+	fa.Methodology = q.methodology(in, sim, p, fa.SLEBasis)
+	return fa
+}
+
+// assessCore computes the deterministic XAF figures shared by both paths.
+func (q *Quantifier) assessCore(in FinancialInputs, criticality string) FinancialAssessment {
 	downtime := DowntimeCostXAF(in.DowntimeHours, in.HourlyDowntimeCostXAF)
 
 	// 1. Effective single-loss expectancy (XAF) + how we got it.
@@ -217,14 +236,7 @@ func (q *Quantifier) AssessP(in FinancialInputs, criticality string, p Presenter
 	}
 	rosi, rosiOK := ROSI(aleXAF, aleAfter, remediation)
 
-	// 6. FAIR-lite loss distribution (P10/P50/P90) + explainability metadata.
-	sim := q.SimulationInputFor(in, criticality)
-	dist := p.Present(Simulate(sim))
-	method := q.methodology(in, sim, p, sleBasis)
-
 	return FinancialAssessment{
-		Distribution: &dist,
-		Methodology:  method,
 		SLE:          q.Money(sleXAF),
 		SLEAverage:   q.Money(avg),
 		SLEWorst:     q.Money(worst),

--- a/backend/pkg/crq/financial_test.go
+++ b/backend/pkg/crq/financial_test.go
@@ -108,6 +108,45 @@ func TestAssess_ExplicitSLEAndROSI(t *testing.T) {
 	}
 }
 
+// AssessP must attach the currency-aware loss distribution AND the explainability
+// methodology (spec §2 + §4); AssessDeterministic must NOT.
+func TestAssessP_DistributionAndMethodology(t *testing.T) {
+	q := NewQuantifier(600, DefaultReference())
+	in := FinancialInputs{SLEXAF: f(20_000_000), ARO: f(0.5)}
+	p := NewPresenter(CurrencyEUR, DefaultRateTable(), 600)
+	a := q.AssessP(in, "critical", p)
+
+	if a.Distribution == nil || a.Methodology == nil {
+		t.Fatalf("AssessP must populate Distribution + Methodology")
+	}
+	d := a.Distribution
+	if !(d.P10.XAF <= d.P50.XAF && d.P50.XAF <= d.P90.XAF) {
+		t.Fatalf("band not ordered: %+v", d)
+	}
+	if d.P50.Currency != CurrencyEUR || d.FormulaVersion != FormulaVersion {
+		t.Fatalf("distribution currency/version wrong: %+v", d)
+	}
+	m := a.Methodology
+	if m.Iterations != DefaultIterations || m.Seed != DefaultSeed || m.Currency != CurrencyEUR {
+		t.Fatalf("methodology run params wrong: %+v", m)
+	}
+	if len(m.Inputs) < 4 || len(m.Assumptions) == 0 {
+		t.Fatalf("methodology intrants/assumptions missing: %+v", m)
+	}
+	// The pure engine leaves ComputedAt zero (stamped by the caller).
+	if !m.ComputedAt.IsZero() {
+		t.Fatalf("ComputedAt should be zero in the pure engine")
+	}
+
+	det := q.AssessDeterministic(in, "critical")
+	if det.Distribution != nil || det.Methodology != nil {
+		t.Fatalf("AssessDeterministic must not attach distribution/methodology")
+	}
+	if det.ALE.XAF != a.ALE.XAF {
+		t.Fatalf("deterministic ALE must match: %v vs %v", det.ALE.XAF, a.ALE.XAF)
+	}
+}
+
 // Worst / average loss modelling (derived band).
 func TestAssess_LossBand(t *testing.T) {
 	q := NewQuantifier(600, DefaultReference())

--- a/backend/pkg/crq/montecarlo.go
+++ b/backend/pkg/crq/montecarlo.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+// montecarlo.go is the FAIR-lite quantification core (spec §9). It turns a risk
+// into a LOSS DISTRIBUTION, not a single number — a single figure is a false
+// certainty. The model, stated plainly so it is defensible to a CISO:
+//
+//	ALE = LEF × LM
+//
+//	  LEF — Loss Event Frequency, expected loss events per year (from ARO).
+//	  LM  — Loss Magnitude, a 3-point PERT distribution (min / most-likely / max).
+//
+// A Monte Carlo run draws N loss magnitudes from the PERT distribution, scales
+// each by LEF, and reports the P10 / P50 / P90 percentiles plus the mean. The
+// run is fully deterministic for a given seed, so the same inputs always yield
+// the same band — a hard requirement for an auditable figure.
+package crq
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// FormulaVersion identifies the quantification model. Bump it on any change to
+// the math so stored figures can be traced to the version that produced them.
+const FormulaVersion = "fair-lite-1.0.0"
+
+// DefaultIterations / DefaultSeed are the reproducible run parameters. 10k
+// iterations converge the percentiles to within a fraction of a percent while
+// staying well under a millisecond per risk.
+const (
+	DefaultIterations = 10_000
+	DefaultSeed       = int64(20260801)
+)
+
+// DocURL points to the methodology reference surfaced in the explainability panel.
+const DocURL = "/docs/financial-quantification.md"
+
+// PERT is a 3-point loss-magnitude distribution: a minimum, a most-likely (mode)
+// and a maximum single-event loss, in XAF.
+type PERT struct {
+	Min  float64 `json:"min"`
+	Mode float64 `json:"mode"`
+	Max  float64 `json:"max"`
+}
+
+// ExpectedValue is the PERT mean: (min + 4·mode + max) / 6. The Monte Carlo mean
+// converges to LEF × this value — the property the convergence test asserts.
+func (p PERT) ExpectedValue() float64 {
+	return (p.Min + 4*p.Mode + p.Max) / 6
+}
+
+// normalized returns a sane, ordered (min ≤ mode ≤ max) copy, clamping negatives
+// to zero so a malformed input can never produce a negative loss.
+func (p PERT) normalized() PERT {
+	n := PERT{Min: math.Max(0, p.Min), Mode: math.Max(0, p.Mode), Max: math.Max(0, p.Max)}
+	if n.Max < n.Min {
+		n.Min, n.Max = n.Max, n.Min
+	}
+	if n.Mode < n.Min {
+		n.Mode = n.Min
+	}
+	if n.Mode > n.Max {
+		n.Mode = n.Max
+	}
+	return n
+}
+
+// SimulationInput is one risk's FAIR-lite parameters.
+type SimulationInput struct {
+	LEF        float64 // loss event frequency (events/year)
+	LM         PERT    // loss magnitude distribution (XAF)
+	Iterations int
+	Seed       int64
+}
+
+// LossDistribution is the Monte Carlo output for one risk (all XAF). The
+// percentiles are the headline; the run metadata makes the figure explainable.
+type LossDistribution struct {
+	P10  float64 `json:"p10"`
+	P50  float64 `json:"p50"` // median — the figure to lead with
+	P90  float64 `json:"p90"`
+	Mean float64 `json:"mean"`
+	Min  float64 `json:"min"`
+	Max  float64 `json:"max"`
+
+	Iterations     int     `json:"iterations"`
+	Seed           int64   `json:"seed"`
+	FormulaVersion string  `json:"formula_version"`
+	LEF            float64 `json:"lef"`
+}
+
+// Simulate runs the FAIR-lite Monte Carlo. It is pure and deterministic: the same
+// SimulationInput (including seed) always yields the same LossDistribution.
+func Simulate(in SimulationInput) LossDistribution {
+	iters := in.Iterations
+	if iters <= 0 {
+		iters = DefaultIterations
+	}
+	lm := in.LM.normalized()
+	lef := in.LEF
+	if lef < 0 {
+		lef = 0
+	}
+
+	dist := LossDistribution{
+		Iterations:     iters,
+		Seed:           in.Seed,
+		FormulaVersion: FormulaVersion,
+		LEF:            round2(lef),
+	}
+
+	// Degenerate magnitude (no spread) → a deterministic point at LEF × mode.
+	if lm.Max <= lm.Min {
+		v := round2(lef * lm.Mode)
+		dist.P10, dist.P50, dist.P90, dist.Mean, dist.Min, dist.Max = v, v, v, v, v, v
+		return dist
+	}
+
+	rng := rand.New(rand.NewSource(in.Seed))
+	alpha, beta := pertBetaParams(lm)
+
+	samples := make([]float64, iters)
+	var sum float64
+	for i := 0; i < iters; i++ {
+		x := sampleBeta(rng, alpha, beta)          // Beta(α,β) ∈ [0,1]
+		loss := lm.Min + x*(lm.Max-lm.Min)         // scale to [min,max]
+		annual := lef * loss                       // ALE contribution = LEF × LM
+		samples[i] = annual
+		sum += annual
+	}
+	sort.Float64s(samples)
+
+	dist.P10 = round2(percentile(samples, 10))
+	dist.P50 = round2(percentile(samples, 50))
+	dist.P90 = round2(percentile(samples, 90))
+	dist.Mean = round2(sum / float64(iters))
+	dist.Min = round2(samples[0])
+	dist.Max = round2(samples[len(samples)-1])
+	return dist
+}
+
+// pertBetaParams derives the standard Beta-PERT shape parameters (λ = 4).
+func pertBetaParams(p PERT) (alpha, beta float64) {
+	span := p.Max - p.Min
+	alpha = 1 + 4*(p.Mode-p.Min)/span
+	beta = 1 + 4*(p.Max-p.Mode)/span
+	return alpha, beta
+}
+
+// sampleBeta draws from Beta(α,β) via two Gamma draws: B = G(α)/(G(α)+G(β)).
+func sampleBeta(rng *rand.Rand, alpha, beta float64) float64 {
+	ga := sampleGamma(rng, alpha)
+	gb := sampleGamma(rng, beta)
+	if ga+gb == 0 {
+		return 0.5
+	}
+	return ga / (ga + gb)
+}
+
+// sampleGamma draws from Gamma(shape, 1) using the Marsaglia–Tsang method. Valid
+// for shape > 0; shapes < 1 are boosted then corrected.
+func sampleGamma(rng *rand.Rand, shape float64) float64 {
+	if shape < 1 {
+		// Boost: Gamma(shape) = Gamma(shape+1) · U^(1/shape).
+		u := rng.Float64()
+		if u == 0 {
+			u = math.SmallestNonzeroFloat64
+		}
+		return sampleGamma(rng, shape+1) * math.Pow(u, 1/shape)
+	}
+	d := shape - 1.0/3.0
+	c := 1.0 / math.Sqrt(9*d)
+	for {
+		var x, v float64
+		for {
+			x = rng.NormFloat64()
+			v = 1 + c*x
+			if v > 0 {
+				break
+			}
+		}
+		v = v * v * v
+		u := rng.Float64()
+		if u < 1-0.0331*x*x*x*x {
+			return d * v
+		}
+		if math.Log(u) < 0.5*x*x+d*(1-v+math.Log(v)) {
+			return d * v
+		}
+	}
+}
+
+// percentile returns the p-th percentile (0–100) of a sorted slice using linear
+// interpolation between order statistics.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	rank := (p / 100) * float64(n-1)
+	lo := int(math.Floor(rank))
+	hi := int(math.Ceil(rank))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[hi]-sorted[lo])
+}
+
+// Amount is a currency-aware monetary value: the canonical XAF store, its USD
+// convenience conversion, and the tenant's chosen display currency + value.
+type Amount struct {
+	XAF      float64  `json:"xaf"`
+	USD      float64  `json:"usd"`
+	Value    float64  `json:"value"`    // amount in Currency
+	Currency Currency `json:"currency"` // tenant display currency
+}
+
+// Presenter converts XAF figures into currency-aware Amounts at a dated rate.
+// Built per request from the tenant's currency + the live rate table.
+type Presenter struct {
+	Rates     *RateTable
+	Currency  Currency
+	XAFPerUSD float64
+}
+
+// NewPresenter builds a Presenter, defaulting the rate table and currency.
+func NewPresenter(currency Currency, rates *RateTable, xafPerUSD float64) Presenter {
+	if rates == nil {
+		rates = DefaultRateTable()
+	}
+	if !IsSupportedCurrency(string(currency)) {
+		currency = CurrencyXAF
+	}
+	if xafPerUSD <= 0 {
+		xafPerUSD = DefaultXAFPerUSD
+	}
+	return Presenter{Rates: rates, Currency: currency, XAFPerUSD: xafPerUSD}
+}
+
+// Amount wraps an XAF figure with its USD and tenant-currency conversions.
+func (p Presenter) Amount(xaf float64) Amount {
+	return Amount{
+		XAF:      round2(xaf),
+		USD:      round2(xaf / p.XAFPerUSD),
+		Value:    p.Rates.Convert(xaf, p.Currency),
+		Currency: p.Currency,
+	}
+}
+
+// DistributionAmounts is the loss band expressed as currency-aware Amounts.
+type DistributionAmounts struct {
+	P10  Amount `json:"p10"`
+	P50  Amount `json:"p50"`
+	P90  Amount `json:"p90"`
+	Mean Amount `json:"mean"`
+
+	Iterations     int     `json:"iterations"`
+	Seed           int64   `json:"seed"`
+	FormulaVersion string  `json:"formula_version"`
+	LEF            float64 `json:"lef"`
+}
+
+// Present converts a raw XAF LossDistribution into currency-aware Amounts.
+func (p Presenter) Present(d LossDistribution) DistributionAmounts {
+	return DistributionAmounts{
+		P10:            p.Amount(d.P10),
+		P50:            p.Amount(d.P50),
+		P90:            p.Amount(d.P90),
+		Mean:           p.Amount(d.Mean),
+		Iterations:     d.Iterations,
+		Seed:           d.Seed,
+		FormulaVersion: d.FormulaVersion,
+		LEF:            d.LEF,
+	}
+}

--- a/backend/pkg/crq/montecarlo.go
+++ b/backend/pkg/crq/montecarlo.go
@@ -126,9 +126,9 @@ func Simulate(in SimulationInput) LossDistribution {
 	samples := make([]float64, iters)
 	var sum float64
 	for i := 0; i < iters; i++ {
-		x := sampleBeta(rng, alpha, beta)          // Beta(α,β) ∈ [0,1]
-		loss := lm.Min + x*(lm.Max-lm.Min)         // scale to [min,max]
-		annual := lef * loss                       // ALE contribution = LEF × LM
+		x := sampleBeta(rng, alpha, beta)  // Beta(α,β) ∈ [0,1]
+		loss := lm.Min + x*(lm.Max-lm.Min) // scale to [min,max]
+		annual := lef * loss               // ALE contribution = LEF × LM
 		samples[i] = annual
 		sum += annual
 	}
@@ -138,6 +138,71 @@ func Simulate(in SimulationInput) LossDistribution {
 	dist.P50 = round2(percentile(samples, 50))
 	dist.P90 = round2(percentile(samples, 90))
 	dist.Mean = round2(sum / float64(iters))
+	dist.Min = round2(samples[0])
+	dist.Max = round2(samples[len(samples)-1])
+	return dist
+}
+
+// SimulatePortfolio runs one shared Monte Carlo across many risks: on each
+// iteration it sums each risk's sampled annual loss, so the resulting P10/P50/P90
+// is the distribution of TOTAL exposure — correctly capturing that not every risk
+// hits its worst case in the same year (diversification). Deterministic given the
+// seed and the order of inputs. iterations/seed are taken from the first input
+// (or defaults); per-risk iteration/seed fields are ignored so the runs stay
+// aligned across risks.
+func SimulatePortfolio(inputs []SimulationInput, iterations int, seed int64) LossDistribution {
+	if iterations <= 0 {
+		iterations = DefaultIterations
+	}
+	dist := LossDistribution{Iterations: iterations, Seed: seed, FormulaVersion: FormulaVersion}
+	if len(inputs) == 0 {
+		return dist
+	}
+
+	// Pre-compute each risk's LEF + Beta shape (or a degenerate point).
+	type risk struct {
+		lef         float64
+		min, span   float64
+		alpha, beta float64
+		point       float64 // set when degenerate (span == 0)
+		degenerate  bool
+	}
+	rs := make([]risk, 0, len(inputs))
+	for _, in := range inputs {
+		lm := in.LM.normalized()
+		lef := in.LEF
+		if lef < 0 {
+			lef = 0
+		}
+		if lm.Max <= lm.Min {
+			rs = append(rs, risk{lef: lef, point: lef * lm.Mode, degenerate: true})
+			continue
+		}
+		a, b := pertBetaParams(lm)
+		rs = append(rs, risk{lef: lef, min: lm.Min, span: lm.Max - lm.Min, alpha: a, beta: b})
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+	samples := make([]float64, iterations)
+	var sum float64
+	for i := 0; i < iterations; i++ {
+		var total float64
+		for _, r := range rs {
+			if r.degenerate {
+				total += r.point
+				continue
+			}
+			x := sampleBeta(rng, r.alpha, r.beta)
+			total += r.lef * (r.min + x*r.span)
+		}
+		samples[i] = total
+		sum += total
+	}
+	sort.Float64s(samples)
+	dist.P10 = round2(percentile(samples, 10))
+	dist.P50 = round2(percentile(samples, 50))
+	dist.P90 = round2(percentile(samples, 90))
+	dist.Mean = round2(sum / float64(iterations))
 	dist.Min = round2(samples[0])
 	dist.Max = round2(samples[len(samples)-1])
 	return dist

--- a/backend/pkg/crq/montecarlo_test.go
+++ b/backend/pkg/crq/montecarlo_test.go
@@ -105,6 +105,37 @@ func TestSimulate_UnorderedInput(t *testing.T) {
 	}
 }
 
+// TestSimulatePortfolio — the portfolio band is deterministic, ordered, and its
+// mean equals the sum of per-risk analytic means (diversification affects the
+// spread, not the mean).
+func TestSimulatePortfolio(t *testing.T) {
+	inputs := []SimulationInput{
+		{LEF: 0.5, LM: PERT{Min: 5e6, Mode: 10e6, Max: 20e6}},
+		{LEF: 1.0, LM: PERT{Min: 2e6, Mode: 4e6, Max: 9e6}},
+		{LEF: 0.2, LM: PERT{Min: 20e6, Mode: 40e6, Max: 80e6}},
+	}
+	a := SimulatePortfolio(inputs, 100_000, DefaultSeed)
+	b := SimulatePortfolio(inputs, 100_000, DefaultSeed)
+	if a != b {
+		t.Fatalf("portfolio not deterministic")
+	}
+	if !(a.P10 <= a.P50 && a.P50 <= a.P90) {
+		t.Fatalf("portfolio percentiles not ordered: %+v", a)
+	}
+	var want float64
+	for _, in := range inputs {
+		want += in.LEF * in.LM.ExpectedValue()
+	}
+	if rel := math.Abs(a.Mean-want) / want; rel > 0.01 {
+		t.Fatalf("portfolio mean off: got %.0f want %.0f (%.2f%%)", a.Mean, want, rel*100)
+	}
+	// Empty portfolio → zero band, still versioned.
+	e := SimulatePortfolio(nil, 1000, 1)
+	if e.P50 != 0 || e.FormulaVersion != FormulaVersion {
+		t.Fatalf("empty portfolio wrong: %+v", e)
+	}
+}
+
 func TestPERT_ExpectedValue(t *testing.T) {
 	p := PERT{Min: 0, Mode: 10, Max: 20}
 	if got := p.ExpectedValue(); got != 10 {

--- a/backend/pkg/crq/montecarlo_test.go
+++ b/backend/pkg/crq/montecarlo_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package crq
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSimulate_Determinism — the same input (including seed) must always yield
+// the identical band. An auditable figure cannot wobble between runs.
+func TestSimulate_Determinism(t *testing.T) {
+	in := SimulationInput{
+		LEF:        0.5,
+		LM:         PERT{Min: 10_000_000, Mode: 20_000_000, Max: 40_000_000},
+		Iterations: 20_000,
+		Seed:       12345,
+	}
+	a := Simulate(in)
+	b := Simulate(in)
+	if a != b {
+		t.Fatalf("non-deterministic: %+v != %+v", a, b)
+	}
+	// A different seed should move the percentiles (but keep them ordered).
+	in.Seed = 999
+	c := Simulate(in)
+	if a.P50 == c.P50 && a.P10 == c.P10 && a.P90 == c.P90 {
+		t.Fatalf("different seed produced identical percentiles — suspicious")
+	}
+}
+
+// TestSimulate_Bounds — ordering and containment properties that must hold for
+// any well-formed input.
+func TestSimulate_Bounds(t *testing.T) {
+	in := SimulationInput{
+		LEF:        1.2,
+		LM:         PERT{Min: 5_000_000, Mode: 12_000_000, Max: 30_000_000},
+		Iterations: 30_000,
+		Seed:       DefaultSeed,
+	}
+	d := Simulate(in)
+	if !(d.P10 <= d.P50 && d.P50 <= d.P90) {
+		t.Fatalf("percentiles not ordered: P10=%.0f P50=%.0f P90=%.0f", d.P10, d.P50, d.P90)
+	}
+	lo := in.LEF * in.LM.Min
+	hi := in.LEF * in.LM.Max
+	if d.Min < lo-1 || d.Max > hi+1 {
+		t.Fatalf("samples out of [LEF·min, LEF·max]=[%.0f,%.0f]: min=%.0f max=%.0f", lo, hi, d.Min, d.Max)
+	}
+	if d.P10 < d.Min-1 || d.P90 > d.Max+1 {
+		t.Fatalf("percentiles outside observed range")
+	}
+	if d.FormulaVersion != FormulaVersion {
+		t.Fatalf("formula version not stamped: %q", d.FormulaVersion)
+	}
+}
+
+// TestSimulate_Convergence — the Monte Carlo mean must converge to the analytic
+// expectation LEF × PERT.ExpectedValue() as iterations grow.
+func TestSimulate_Convergence(t *testing.T) {
+	lm := PERT{Min: 2_000_000, Mode: 8_000_000, Max: 26_000_000}
+	lef := 0.75
+	want := lef * lm.ExpectedValue()
+	d := Simulate(SimulationInput{LEF: lef, LM: lm, Iterations: 200_000, Seed: DefaultSeed})
+	rel := math.Abs(d.Mean-want) / want
+	if rel > 0.01 { // within 1%
+		t.Fatalf("mean did not converge: got %.0f want %.0f (%.3f%% off)", d.Mean, want, rel*100)
+	}
+}
+
+// TestSimulate_Degenerate — a zero-spread magnitude collapses to a deterministic
+// point at LEF × mode.
+func TestSimulate_Degenerate(t *testing.T) {
+	lef := 2.0
+	mode := 9_000_000.0
+	d := Simulate(SimulationInput{LEF: lef, LM: PERT{Min: mode, Mode: mode, Max: mode}, Seed: 1})
+	want := lef * mode
+	for _, v := range []float64{d.P10, d.P50, d.P90, d.Mean} {
+		if v != want {
+			t.Fatalf("degenerate case not a point: got %.0f want %.0f", v, want)
+		}
+	}
+}
+
+// TestSimulate_ZeroLEF — no frequency means no loss.
+func TestSimulate_ZeroLEF(t *testing.T) {
+	d := Simulate(SimulationInput{LEF: 0, LM: PERT{Min: 1e6, Mode: 2e6, Max: 5e6}, Seed: 1})
+	if d.P50 != 0 || d.Mean != 0 || d.P90 != 0 {
+		t.Fatalf("zero LEF should yield zero loss, got %+v", d)
+	}
+}
+
+// TestSimulate_UnorderedInput — a malformed (min>max, mode outside) input is
+// normalized rather than producing garbage or a negative loss.
+func TestSimulate_UnorderedInput(t *testing.T) {
+	d := Simulate(SimulationInput{LEF: 1, LM: PERT{Min: 40_000_000, Mode: -5, Max: 10_000_000}, Iterations: 5000, Seed: 3})
+	if d.Min < 0 || d.P10 < 0 {
+		t.Fatalf("normalization failed, negative loss: %+v", d)
+	}
+	if !(d.P10 <= d.P50 && d.P50 <= d.P90) {
+		t.Fatalf("percentiles not ordered after normalization")
+	}
+}
+
+func TestPERT_ExpectedValue(t *testing.T) {
+	p := PERT{Min: 0, Mode: 10, Max: 20}
+	if got := p.ExpectedValue(); got != 10 {
+		t.Fatalf("PERT mean: got %.4f want 10", got)
+	}
+	p = PERT{Min: 1_000_000, Mode: 2_000_000, Max: 5_000_000}
+	want := (1_000_000.0 + 4*2_000_000 + 5_000_000) / 6
+	if got := p.ExpectedValue(); math.Abs(got-want) > 0.01 {
+		t.Fatalf("PERT mean: got %.2f want %.2f", got, want)
+	}
+}
+
+// TestPresenter_PresentDistribution — the band is converted into the tenant
+// currency at the reference rate, with XAF preserved.
+func TestPresenter_PresentDistribution(t *testing.T) {
+	d := Simulate(SimulationInput{LEF: 1, LM: PERT{Min: 1e6, Mode: 2e6, Max: 4e6}, Seed: DefaultSeed})
+	p := NewPresenter(CurrencyEUR, DefaultRateTable(), DefaultXAFPerUSD)
+	got := p.Present(d)
+	if got.P50.XAF != d.P50 {
+		t.Fatalf("XAF not preserved: %.2f vs %.2f", got.P50.XAF, d.P50)
+	}
+	wantEUR := round2(d.P50 / 655.957)
+	if got.P50.Value != wantEUR || got.P50.Currency != CurrencyEUR {
+		t.Fatalf("EUR conversion wrong: got %.2f %s want %.2f EUR", got.P50.Value, got.P50.Currency, wantEUR)
+	}
+}

--- a/docs/financial-quantification.md
+++ b/docs/financial-quantification.md
@@ -1,0 +1,83 @@
+# Financial Risk Quantification — methodology (FAIR-lite)
+
+`formula_version: fair-lite-1.0.0`
+
+OpenRisk expresses cyber exposure in money using a **FAIR-lite** model. It is
+deliberately simple, fully documented and reproducible — not an actuarial black
+box. Every figure in the product links back to this page.
+
+## 1. The model
+
+```
+ALE = LEF × LM
+```
+
+- **LEF — Loss Event Frequency**: the expected number of loss events per year.
+  Sourced from the risk's ARO (Annualized Rate of Occurrence). When a risk has
+  no explicit ARO, LEF defaults to `1` and the loss magnitude falls back to the
+  reference band for the risk's criticality, so every risk still carries an
+  order-of-magnitude figure.
+- **LM — Loss Magnitude**: a **3-point PERT distribution** (`min` / most-likely
+  / `max`) of the single-event loss, in XAF.
+  - `most-likely` = the effective SLE: an explicit SLE if provided, otherwise the
+    sum of the loss components (downtime `hours × cost/hour`, regulatory fines,
+    data-loss cost, other direct cost), otherwise the reference band.
+  - `min` / `max` = the loss band. Explicit bounds win; otherwise they are
+    derived from the point estimate (`best = ×0.5`, `worst = ×2.0`).
+
+## 2. Output: a distribution, never a single number
+
+A single figure is a false certainty. The engine runs a **Monte Carlo**
+simulation: it draws `N` loss magnitudes from the PERT distribution (via the
+standard Beta-PERT with shape λ = 4), scales each by LEF, and reports:
+
+- **P10 / P50 (median) / P90** percentiles — the band shown in the UI, median
+  emphasised.
+- the mean, which converges to `LEF × (min + 4·mode + max) / 6`.
+
+Default run: **`10 000` iterations**, fixed **seed `20260801`**. The run is fully
+**deterministic** — the same inputs always yield the same band.
+
+### Portfolio band
+
+The dashboard headline is **one shared simulation across all risks**: on each
+iteration it sums every risk's sampled annual loss. This correctly captures that
+not every risk hits its worst case in the same year (diversification), so the
+portfolio P90 is *not* the naive sum of per-risk P90s.
+
+## 3. Currency
+
+Amounts are stored in **XAF (FCFA)** and converted to the tenant's chosen display
+currency (XAF, XOF, EUR, USD, NGN, MAD, GHS, ZAR) at a **dated reference rate**.
+The reference date (`fx_as_of`) is shown next to every converted amount. Rates
+are refreshed by a daily FX job; the built-in fallback table uses the fixed CFA
+euro peg (1 EUR = 655.957 XAF) and rounded market approximations for the rest.
+The currency is chosen at onboarding and changeable later (admin).
+
+## 4. Explainability
+
+Every amount is clickable → a **Methodology** panel listing: the model, the exact
+intrants used and their provenance (`input` / `derived` / `reference`), the
+assumptions, the iteration count, the seed, the calc date, the `formula_version`,
+the FX rate + date, and a link back to this document.
+
+## 5. ROSI — investment simulator
+
+```
+ROSI = (ALE_before − ALE_after − Cost) / Cost
+```
+
+with `ALE_after = ALE_before × (1 − effectiveness)`, effectiveness ∈ [0, 1].
+The simulator turns three inputs (budget, effectiveness, and the concrete measure
+name) into one plain-language decision sentence, including the payback period.
+ROSI is undefined when the cost is 0 (nothing to divide by) — the UI says so
+rather than showing a misleading number.
+
+## 6. Honest limits
+
+- The PERT band factors (×0.5 / ×2.0) are defensible defaults; a real deployment
+  tunes them per sector.
+- Reference bands per criticality are order-of-magnitude, not measured losses.
+- LEF sampling is treated as a deterministic annual multiplier on the magnitude
+  distribution (the uncertainty lives in LM), which keeps the median meaningful
+  for low-frequency risks rather than collapsing it to zero.

--- a/frontend/src/features/financial/FinancialDashboard.tsx
+++ b/frontend/src/features/financial/FinancialDashboard.tsx
@@ -3,56 +3,96 @@
 // This program is free software: you can redistribute it and/or modify it under
 //
 // Financial Risk Quantification dashboard (spec §9) — a CFO/CISO view of the
-// tenant's cyber exposure in money: portfolio ALE, worst-case, remediation
-// budget and ROSI, a cumulative-loss projection (with vs without controls), the
-// annual exposure by criticality, an investment-scenario simulator and the top
-// financial exposures. All figures come from GET /analytics/financial and the
-// per-risk simulator from POST /risks/:id/simulate — no fixtures.
+// tenant's cyber exposure in money. The headline is a FAIR-lite P10/P50/P90
+// LOSS BAND (never a single number), converted into the tenant's currency at a
+// dated reference rate. Every amount is clickable → a "Méthodologie" panel that
+// shows the model, its intrants, assumptions, iterations and calc date. An
+// investment simulator turns three inputs into ONE plain-language ROSI sentence.
+// All figures come from GET /analytics/financial and POST /risks/:id/simulate.
 
 import { useMemo, useState } from 'react';
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from 'recharts';
-import { Coins, RefreshCw, TrendingDown, Wallet, ShieldCheck, Gauge, FlaskConical } from 'lucide-react';
+import {
+  Coins, RefreshCw, TrendingDown, Wallet, ShieldCheck, Gauge, FlaskConical,
+  Info, X, BookOpen,
+} from 'lucide-react';
 import { PageFrame, PageHeader, Card, Btn, Skeleton, EmptyState, ErrorState } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
-import { useFinancialSummary, useSimulateFinancial } from './useFinancial';
-import type { FinancialSummary, TopRiskFinancial, Money } from './financialService';
+import { useAuthStore } from '../../hooks/useAuthStore';
+import { useFinancialSummary, useSimulateFinancial, useSetCurrency } from './useFinancial';
+import type {
+  FinancialSummary, TopRiskFinancial, Amount, Methodology, CurrencyCode,
+} from './financialService';
+import { SUPPORTED_CURRENCIES } from './financialService';
 
-// Series colours match AnalyticsCiso (theme-agnostic hex so Recharts renders
-// consistently in light + dark).
 const C_LOSS = '#ff2d92'; // exposure without controls
 const C_RESID = '#30d158'; // residual with controls
+const C_BAND = 'var(--accent)';
 const CRIT_COLOR: Record<string, string> = {
   critical: 'var(--critical)', high: 'var(--high)', medium: 'var(--medium)', low: 'var(--low)',
 };
 
-function fmtFCFA(n: number): string {
+/* ---------------- currency-aware formatting ---------------- */
+// XAF keeps the familiar "FCFA" label in the target market; others show the code.
+function curLabel(code: string): string {
+  return code === 'XAF' ? 'FCFA' : code;
+}
+function group(n: number): string {
   const sign = n < 0 ? '-' : '';
-  const grouped = Math.abs(Math.trunc(n)).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
-  return `${sign}${grouped} FCFA`;
+  return `${sign}${Math.abs(Math.round(n)).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')}`;
 }
-// Compact form for tiles/axes (e.g. 97,5 M FCFA).
-function fmtCompact(n: number, lang: string): string {
+function compact(n: number, lang: string): string {
   const abs = Math.abs(n);
-  const unit = lang === 'fr' ? { b: ' Md', m: ' M', k: ' k' } : { b: 'B', m: 'M', k: 'K' };
-  const fmt = (v: number) => (lang === 'fr' ? v.toFixed(1).replace('.', ',') : v.toFixed(1));
-  if (abs >= 1e9) return `${fmt(n / 1e9)}${unit.b}`;
-  if (abs >= 1e6) return `${fmt(n / 1e6)}${unit.m}`;
-  if (abs >= 1e3) return `${fmt(n / 1e3)}${unit.k}`;
+  const u = lang === 'fr' ? { b: ' Md', m: ' M', k: ' k' } : { b: 'B', m: 'M', k: 'K' };
+  const f = (v: number) => (lang === 'fr' ? v.toFixed(1).replace('.', ',') : v.toFixed(1));
+  if (abs >= 1e9) return `${f(n / 1e9)}${u.b}`;
+  if (abs >= 1e6) return `${f(n / 1e6)}${u.m}`;
+  if (abs >= 1e3) return `${f(n / 1e3)}${u.k}`;
   return String(Math.round(n));
-}
-function fmtUSD(n: number): string {
-  return `$${Math.round(n).toLocaleString('en-US')}`;
 }
 function fmtPct(ratio: number): string {
   return `${ratio >= 0 ? '+' : ''}${Math.round(ratio * 100)}%`;
+}
+function relTime(iso: string, lang: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return '';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  const mins = Math.round(secs / 60);
+  if (lang === 'fr') {
+    if (secs < 60) return "il y a quelques secondes";
+    if (mins < 60) return `il y a ${mins} min`;
+    return `il y a ${Math.round(mins / 60)} h`;
+  }
+  if (secs < 60) return 'a few seconds ago';
+  if (mins < 60) return `${mins} min ago`;
+  return `${Math.round(mins / 60)} h ago`;
+}
+
+/** A currency-aware formatter bound to the summary's currency + FX rate. */
+function useMoneyFmt(summary: FinancialSummary) {
+  const rate = summary.fx_rate_xaf > 0 ? summary.fx_rate_xaf : 1;
+  const code = summary.currency || 'XAF';
+  const lang = useUIStore((s) => s.lang);
+  const disp = (xaf: number) => xaf / rate;
+  return {
+    code,
+    label: curLabel(code),
+    // From a raw XAF figure (Money-based fields).
+    xafFull: (xaf: number) => `${group(disp(xaf))} ${curLabel(code)}`,
+    xafCompact: (xaf: number) => `${compact(disp(xaf), lang)} ${curLabel(code)}`,
+    // From a currency-aware Amount (already converted server-side).
+    amtFull: (a: Amount) => `${group(a.value)} ${curLabel(a.currency)}`,
+    amtCompact: (a: Amount) => `${compact(a.value, lang)} ${curLabel(a.currency)}`,
+  };
 }
 
 export function FinancialDashboard() {
   const lang = useUIStore((s) => s.lang);
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   const { data, isLoading, isError, refetch, isFetching } = useFinancialSummary();
+  const [methodology, setMethodology] = useState<Methodology | null>(null);
 
   if (isLoading) return <FinancialSkeleton />;
   if (isError || !data) {
@@ -74,9 +114,19 @@ export function FinancialDashboard() {
         title={tr('Quantification financière', 'Financial Quantification')}
         count={tr(`${data.quantified_risks}/${data.total_risks} risques chiffrés`, `${data.quantified_risks}/${data.total_risks} risks quantified`)}
         actions={
-          <Btn label={tr('Actualiser', 'Refresh')} icon={RefreshCw} onClick={() => refetch()} />
+          <div className="flex items-center gap-2">
+            <CurrencyPicker current={data.currency} />
+            <Btn label={tr('Actualiser', 'Refresh')} icon={RefreshCw} onClick={() => refetch()} />
+          </div>
         }
       />
+      <div className="flex items-center gap-2 -mt-1 mb-3 text-[11.5px] text-ink-muted">
+        <span>{tr('Calculé', 'Computed')} {relTime(data.computed_at, lang)}</span>
+        <span>·</span>
+        <span>{tr('Taux', 'Rate')} {data.fx_as_of ? new Date(data.fx_as_of).toLocaleDateString(lang) : '—'}</span>
+        <span>·</span>
+        <span className="mono">{data.formula_version}</span>
+      </div>
       {isFetching && <div className="h-0.5 -mt-2 mb-3 rounded-full or-shimmer" style={{ background: 'var(--accent)' }} />}
 
       {data.total_risks === 0 ? (
@@ -87,46 +137,92 @@ export function FinancialDashboard() {
         />
       ) : (
         <>
-          <KpiRow data={data} lang={lang} tr={tr} />
+          <HeadlineBand data={data} lang={lang} tr={tr} onExplain={() => setMethodology(summaryMethodology(data))} />
+          <div className="mt-4"><KpiRow data={data} lang={lang} tr={tr} /></div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-4">
             <div className="lg:col-span-2"><ProjectionCard data={data} lang={lang} tr={tr} /></div>
             <ByCriticalityCard data={data} lang={lang} tr={tr} />
           </div>
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-4">
-            <div className="lg:col-span-2"><TopExposuresCard rows={data.top_risks} lang={lang} tr={tr} /></div>
-            <SimulatorCard rows={data.top_risks} lang={lang} tr={tr} />
+            <div className="lg:col-span-2"><TopExposuresCard data={data} lang={lang} tr={tr} /></div>
+            <SimulatorCard rows={data.top_risks} summary={data} lang={lang} tr={tr} onExplain={setMethodology} />
           </div>
         </>
       )}
+
+      {methodology && <MethodologyModal m={methodology} lang={lang} tr={tr} onClose={() => setMethodology(null)} />}
     </PageFrame>
+  );
+}
+
+/* ---------------- headline P10/P50/P90 band ---------------- */
+function HeadlineBand({ data, lang, tr, onExplain }: { data: FinancialSummary; lang: string; tr: (f: string, e: string) => string; onExplain: () => void }) {
+  const f = useMoneyFmt(data);
+  const b = data.portfolio_loss;
+  // Position the P50 marker within the [P10, P90] track.
+  const span = Math.max(1, b.p90.value - b.p10.value);
+  const p50Pos = Math.min(100, Math.max(0, ((b.p50.value - b.p10.value) / span) * 100));
+  return (
+    <Card className="or-fadeup" style={{ padding: '20px 22px' }}>
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-[12.5px] text-ink-soft">{tr('Exposition annuelle attendue (médiane)', 'Expected annual exposure (median)')}</span>
+            <button onClick={onExplain} className="inline-flex items-center gap-1 text-[11px] text-accent hover:underline" title={tr('Méthodologie', 'Methodology')}>
+              <Info size={12} /> {tr('Méthodologie', 'Methodology')}
+            </button>
+          </div>
+          <button onClick={onExplain} className="block text-left mt-1 disp mono text-[34px] font-bold text-ink leading-none hover:opacity-80" title={tr('Voir la méthodologie', 'View methodology')}>
+            {f.amtCompact(b.p50)}
+          </button>
+          <div className="text-[11.5px] text-ink-muted mt-1.5">
+            {tr('sur', 'over')} {b.iterations.toLocaleString(lang)} {tr('itérations Monte Carlo', 'Monte Carlo iterations')}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[11px] uppercase tracking-[.05em] text-ink-muted">{tr('Plage P10 – P90', 'P10 – P90 range')}</div>
+          <div className="mono text-[15px] font-semibold text-ink mt-1">{f.amtCompact(b.p10)} — {f.amtCompact(b.p90)}</div>
+        </div>
+      </div>
+      {/* Interval track with the median highlighted. */}
+      <div className="mt-5">
+        <div className="relative h-2.5 rounded-full" style={{ background: `color-mix(in srgb, ${C_BAND} 18%, transparent)` }}>
+          <div className="absolute top-0 bottom-0 rounded-full" style={{ left: 0, right: 0, background: `color-mix(in srgb, ${C_BAND} 32%, transparent)` }} />
+          <div className="absolute -top-1 h-4.5 w-[3px] rounded" style={{ left: `calc(${p50Pos}% - 1.5px)`, background: C_BAND }} />
+        </div>
+        <div className="flex justify-between mt-1.5 text-[10.5px] text-ink-muted">
+          <span>P10 · {f.amtCompact(b.p10)}</span>
+          <span className="font-semibold text-ink">P50 · {f.amtCompact(b.p50)}</span>
+          <span>P90 · {f.amtCompact(b.p90)}</span>
+        </div>
+      </div>
+    </Card>
   );
 }
 
 /* ---------------- KPI tiles ---------------- */
 function KpiRow({ data, lang, tr }: { data: FinancialSummary; lang: string; tr: (f: string, e: string) => string }) {
+  const f = useMoneyFmt(data);
   const rosi = data.portfolio_rosi_computable ? fmtPct(data.portfolio_rosi) : '—';
   const tiles: { label: string; value: string; sub: string; icon: typeof Coins; tone: string }[] = [
     {
-      label: tr('Exposition annuelle (ALE)', 'Annual exposure (ALE)'),
-      value: `${fmtCompact(data.total_ale.xaf, lang)} FCFA`,
-      sub: fmtUSD(data.total_ale.usd), icon: Coins, tone: 'var(--accent)',
+      label: tr('Pire cas P90', 'Worst case P90'),
+      value: f.amtCompact(data.portfolio_loss.p90), sub: tr('1 année sur 10 dépasse ce montant', '1 year in 10 exceeds this'),
+      icon: TrendingDown, tone: 'var(--critical)',
     },
     {
-      label: tr('Scénario du pire', 'Worst-case'),
-      value: `${fmtCompact(data.total_ale_worst.xaf, lang)} FCFA`,
-      sub: fmtUSD(data.total_ale_worst.usd), icon: TrendingDown, tone: 'var(--critical)',
+      label: tr('Exposition ALE (moyenne)', 'ALE exposure (mean)'),
+      value: f.xafCompact(data.total_ale.xaf), sub: `${group(data.total_ale.usd)} USD`, icon: Coins, tone: 'var(--accent)',
     },
     {
       label: tr('Budget de remédiation', 'Remediation budget'),
-      value: `${fmtCompact(data.total_remediation.xaf, lang)} FCFA`,
-      sub: tr(`Réduit l’ALE de ${fmtCompact(data.total_risk_reduction.xaf, lang)} FCFA`, `Cuts ALE by ${fmtCompact(data.total_risk_reduction.xaf, lang)} FCFA`),
+      value: f.xafCompact(data.total_remediation.xaf),
+      sub: tr(`Réduit l’ALE de ${f.xafCompact(data.total_risk_reduction.xaf)}`, `Cuts ALE by ${f.xafCompact(data.total_risk_reduction.xaf)}`),
       icon: Wallet, tone: 'var(--medium)',
     },
     {
       label: tr('ROSI du portefeuille', 'Portfolio ROSI'),
-      value: rosi,
-      sub: tr('Retour sur investissement sécurité', 'Return on security investment'),
-      icon: Gauge, tone: 'var(--low)',
+      value: rosi, sub: tr('Retour sur investissement sécurité', 'Return on security investment'), icon: Gauge, tone: 'var(--low)',
     },
   ];
   return (
@@ -147,20 +243,135 @@ function KpiRow({ data, lang, tr }: { data: FinancialSummary; lang: string; tr: 
   );
 }
 
+/* ---------------- currency picker (admin) ---------------- */
+function CurrencyPicker({ current }: { current: string }) {
+  const lang = useUIStore((s) => s.lang);
+  const can = useAuthStore((s) => s.hasPermission);
+  const setCur = useSetCurrency();
+  // Currency is a tenant setting → the route is guarded admin/root, whose JWT
+  // carries the "*" wildcard. Non-admins see the code, read-only.
+  const allowed = can('*');
+  if (!allowed) {
+    return <span className="text-[12px] text-ink-muted px-2">{curLabel(current)}</span>;
+  }
+  return (
+    <select
+      value={SUPPORTED_CURRENCIES.includes(current as CurrencyCode) ? current : 'XAF'}
+      onChange={(e) => setCur.mutate(e.target.value as CurrencyCode)}
+      disabled={setCur.isPending}
+      title={lang === 'fr' ? 'Devise d’affichage' : 'Display currency'}
+      className="rounded-[9px] px-2.5 py-2 text-[12.5px] text-ink outline-none disabled:opacity-60"
+      style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}
+    >
+      {SUPPORTED_CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
+    </select>
+  );
+}
+
+/* ---------------- methodology panel (explainability §4) ---------------- */
+function MethodologyModal({ m, lang, tr, onClose }: { m: Methodology; lang: string; tr: (f: string, e: string) => string; onClose: () => void }) {
+  const meta: { k: string; v: string }[] = [
+    { k: tr('Modèle', 'Model'), v: m.model },
+    { k: tr('Version de formule', 'Formula version'), v: m.formula_version },
+    { k: tr('Itérations', 'Iterations'), v: m.iterations.toLocaleString(lang) },
+    { k: tr('Graine (déterministe)', 'Seed (deterministic)'), v: String(m.seed) },
+    { k: tr('Calculé le', 'Computed at'), v: m.computed_at ? new Date(m.computed_at).toLocaleString(lang) : '—' },
+    { k: tr('Devise', 'Currency'), v: `${m.currency} · 1 ${m.currency} = ${group(m.fx_rate_xaf)} FCFA (${m.fx_as_of ? new Date(m.fx_as_of).toLocaleDateString(lang) : '—'})` },
+  ];
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ background: 'rgba(0,0,0,.5)' }} onClick={onClose}>
+      <div className="or-scalein w-full max-w-lg max-h-[88vh] flex flex-col rounded-[14px] overflow-hidden" style={{ background: 'var(--bg)', border: '1px solid var(--border)' }} onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: 'var(--border)' }}>
+          <div className="flex items-center gap-2">
+            <BookOpen size={16} style={{ color: 'var(--accent)' }} />
+            <span className="text-[14px] font-semibold text-ink">{tr('Méthodologie', 'Methodology')}</span>
+          </div>
+          <button onClick={onClose} className="text-ink-muted hover:text-ink"><X size={18} /></button>
+        </div>
+        <div className="px-5 py-4 overflow-y-auto text-[12.5px]">
+          <div className="grid grid-cols-1 gap-1.5 mb-4">
+            {meta.map((r) => (
+              <div key={r.k} className="flex items-start justify-between gap-4">
+                <span className="text-ink-muted">{r.k}</span>
+                <span className="text-ink text-right mono">{r.v}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="text-[11px] uppercase tracking-[.05em] text-ink-muted mb-2">{tr('Intrants utilisés', 'Inputs used')}</div>
+          <table className="w-full mb-4">
+            <tbody>
+              {m.inputs.map((inp) => (
+                <tr key={inp.key} className="border-t" style={{ borderColor: 'var(--border)' }}>
+                  <td className="py-1.5 pr-2 text-ink-soft">{inp.label}</td>
+                  <td className="py-1.5 text-right mono text-ink">{group(inp.value)} <span className="text-ink-muted">{inp.unit}</span></td>
+                  <td className="py-1.5 pl-2 text-right"><SourceChip source={inp.source} tr={tr} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="text-[11px] uppercase tracking-[.05em] text-ink-muted mb-2">{tr('Hypothèses', 'Assumptions')}</div>
+          <ul className="list-disc pl-5 flex flex-col gap-1 text-ink-soft mb-3">
+            {m.assumptions.map((a, i) => <li key={i}>{a}</li>)}
+          </ul>
+
+          <a href={m.doc_url} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 text-[12px] text-accent hover:underline">
+            <BookOpen size={13} /> {tr('Documentation du modèle', 'Model documentation')}
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+function SourceChip({ source, tr }: { source: string; tr: (f: string, e: string) => string }) {
+  const map: Record<string, { label: string; tone: string }> = {
+    'risk-input': { label: tr('saisi', 'input'), tone: 'var(--low)' },
+    'derived': { label: tr('dérivé', 'derived'), tone: 'var(--accent)' },
+    'reference-model': { label: tr('référence', 'reference'), tone: 'var(--medium)' },
+  };
+  const s = map[source] ?? { label: source, tone: 'var(--ink-muted)' };
+  return <span className="text-[10.5px] px-1.5 py-0.5 rounded" style={{ background: `color-mix(in srgb, ${s.tone} 14%, transparent)`, color: s.tone }}>{s.label}</span>;
+}
+
+/** Build a Methodology object for the portfolio band from the summary fields. */
+function summaryMethodology(d: FinancialSummary): Methodology {
+  const b = d.portfolio_loss;
+  return {
+    formula_version: d.formula_version || b.formula_version,
+    model: 'FAIR-lite: ALE = LEF × LM (PERT), Monte Carlo (portefeuille)',
+    iterations: d.iterations || b.iterations,
+    seed: b.seed,
+    computed_at: d.computed_at,
+    doc_url: '/docs/financial-quantification.md',
+    currency: d.currency,
+    fx_as_of: d.fx_as_of,
+    fx_rate_xaf: d.fx_rate_xaf,
+    inputs: [
+      { key: 'risks', label: 'Risques agrégés', value: d.total_risks, unit: 'risques', source: 'derived' },
+      { key: 'quantified', label: 'Risques chiffrés', value: d.quantified_risks, unit: 'risques', source: 'risk-input' },
+    ],
+    assumptions: [
+      'Exposition totale = simulation Monte Carlo unique sommant la perte de chaque risque par itération (diversification prise en compte).',
+      'Chaque risque : ALE = LEF × LM ; LM suit une loi PERT à 3 points (min / probable / max).',
+      'La médiane P50 est mise en avant ; P10 et P90 bornent l’intervalle.',
+    ],
+  };
+}
+
 /* ---------------- cumulative loss projection ---------------- */
 function ProjectionCard({ data, lang, tr }: { data: FinancialSummary; lang: string; tr: (f: string, e: string) => string }) {
-  // Expected cumulative loss over 5 years: ALE grows linearly with time. The gap
-  // between "sans contrôle" and "avec contrôles" is the value of the security
-  // program (money not lost thanks to remediation).
+  const rate = data.fx_rate_xaf > 0 ? data.fx_rate_xaf : 1;
+  const code = curLabel(data.currency || 'XAF');
   const series = useMemo(() => {
-    const before = data.total_ale.xaf;
-    const after = data.total_ale_after.xaf;
+    const before = data.total_ale.xaf / rate;
+    const after = data.total_ale_after.xaf / rate;
     return Array.from({ length: 6 }, (_, y) => ({
       year: lang === 'fr' ? `A${y}` : `Y${y}`,
       sans: Math.round(before * y),
       avec: Math.round(after * y),
     }));
-  }, [data, lang]);
+  }, [data, lang, rate]);
 
   return (
     <Card className="or-fadeup" style={{ padding: '18px 20px', animationDelay: '80ms' }}>
@@ -187,11 +398,11 @@ function ProjectionCard({ data, lang, tr }: { data: FinancialSummary; lang: stri
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
             <XAxis dataKey="year" tick={{ fontSize: 11, fill: 'var(--ink-muted)' }} axisLine={{ stroke: 'var(--border)' }} tickLine={false} />
-            <YAxis tick={{ fontSize: 11, fill: 'var(--ink-muted)' }} axisLine={false} tickLine={false} width={54} tickFormatter={(v: number) => fmtCompact(v, lang)} />
+            <YAxis tick={{ fontSize: 11, fill: 'var(--ink-muted)' }} axisLine={false} tickLine={false} width={54} tickFormatter={(v: number) => compact(v, lang)} />
             <Tooltip
               contentStyle={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)', borderRadius: 10, fontSize: 12 }}
               labelStyle={{ color: 'var(--ink)' }}
-              formatter={(v: number, name: string) => [fmtFCFA(v), name === 'sans' ? tr('Sans contrôle', 'Uncontrolled') : tr('Avec contrôles', 'With controls')]}
+              formatter={(v: number, name: string) => [`${group(v)} ${code}`, name === 'sans' ? tr('Sans contrôle', 'Uncontrolled') : tr('Avec contrôles', 'With controls')]}
             />
             <Area type="monotone" dataKey="sans" stroke={C_LOSS} strokeWidth={2} fill="url(#gLoss)" />
             <Area type="monotone" dataKey="avec" stroke={C_RESID} strokeWidth={2} fill="url(#gResid)" />
@@ -204,6 +415,7 @@ function ProjectionCard({ data, lang, tr }: { data: FinancialSummary; lang: stri
 
 /* ---------------- ALE by criticality ---------------- */
 function ByCriticalityCard({ data, lang, tr }: { data: FinancialSummary; lang: string; tr: (f: string, e: string) => string }) {
+  const f = useMoneyFmt(data);
   const label: Record<string, string> = {
     critical: tr('Critique', 'Critical'), high: tr('Élevé', 'High'), medium: tr('Moyen', 'Medium'), low: tr('Faible', 'Low'),
   };
@@ -220,7 +432,7 @@ function ByCriticalityCard({ data, lang, tr }: { data: FinancialSummary; lang: s
                 {label[b.criticality] ?? b.criticality}
                 <span className="text-ink-muted text-[11px]">· {b.count}</span>
               </span>
-              <span className="mono text-[12px] font-semibold text-ink">{fmtCompact(b.ale.xaf, lang)}</span>
+              <span className="mono text-[12px] font-semibold text-ink">{f.xafCompact(b.ale.xaf)}</span>
             </div>
             <div className="h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-hover)' }}>
               <div className="h-full rounded-full" style={{ width: `${(b.ale.xaf / max) * 100}%`, background: CRIT_COLOR[b.criticality] }} />
@@ -233,7 +445,9 @@ function ByCriticalityCard({ data, lang, tr }: { data: FinancialSummary; lang: s
 }
 
 /* ---------------- top exposures table ---------------- */
-function TopExposuresCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: string; tr: (f: string, e: string) => string }) {
+function TopExposuresCard({ data, lang, tr }: { data: FinancialSummary; lang: string; tr: (f: string, e: string) => string }) {
+  const f = useMoneyFmt(data);
+  const rows = data.top_risks;
   return (
     <Card className="or-fadeup" style={{ padding: '18px 20px', animationDelay: '160ms' }}>
       <div className="text-[14px] font-semibold text-ink mb-3">{tr('Principales expositions financières', 'Top financial exposures')}</div>
@@ -248,7 +462,7 @@ function TopExposuresCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: 
             </tr>
           </thead>
           <tbody>
-            {rows.map((r) => (
+            {rows.map((r: TopRiskFinancial) => (
               <tr key={r.id} className="border-t" style={{ borderColor: 'var(--border)' }}>
                 <td className="py-2.5 pr-2">
                   <span className="inline-flex items-center gap-2">
@@ -256,8 +470,8 @@ function TopExposuresCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: 
                     <span className="text-ink truncate" style={{ maxWidth: 260 }}>{r.title}</span>
                   </span>
                 </td>
-                <td className="py-2.5 text-right mono text-ink">{fmtCompact(r.ale.xaf, lang)}</td>
-                <td className="py-2.5 text-right mono text-ink-soft">{fmtCompact(r.ale_worst.xaf, lang)}</td>
+                <td className="py-2.5 text-right mono text-ink">{f.xafCompact(r.ale.xaf)}</td>
+                <td className="py-2.5 text-right mono text-ink-soft">{f.xafCompact(r.ale_worst.xaf)}</td>
                 <td className="py-2.5 text-right">
                   {r.rosi_computable ? (
                     <span className="mono font-semibold" style={{ color: r.rosi >= 0 ? 'var(--low)' : 'var(--critical)' }}>{fmtPct(r.rosi)}</span>
@@ -274,19 +488,23 @@ function TopExposuresCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: 
   );
 }
 
-/* ---------------- investment scenario simulator ---------------- */
-function SimulatorCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: string; tr: (f: string, e: string) => string }) {
+/* ---------------- investment scenario simulator (ROSI, §5) ---------------- */
+function SimulatorCard({ rows, summary, lang, tr, onExplain }: { rows: TopRiskFinancial[]; summary: FinancialSummary; lang: string; tr: (f: string, e: string) => string; onExplain: (m: Methodology) => void }) {
   const [riskId, setRiskId] = useState<string>(rows[0]?.id ?? '');
-  const [cost, setCost] = useState<string>('5000000');
+  const [action, setAction] = useState<string>('');
+  const [cost, setCost] = useState<number>(5_000_000);
   const [eff, setEff] = useState<number>(0.7);
   const sim = useSimulateFinancial(riskId);
+  const f = useMoneyFmt(summary);
+
+  // Slider ceiling scales with the selected risk's ALE (worst case) so the cost
+  // slider stays meaningful.
+  const selected = rows.find((r) => r.id === riskId);
+  const costMax = Math.max(20_000_000, Math.round((selected?.ale_worst.xaf ?? 50_000_000)));
 
   const run = () => {
     if (!riskId) return;
-    sim.mutate({
-      remediation_cost_xaf: cost.trim() === '' ? 0 : Number(cost),
-      mitigation_effectiveness: eff,
-    });
+    sim.mutate({ remediation_cost_xaf: cost, mitigation_effectiveness: eff });
   };
 
   const a = sim.data;
@@ -296,8 +514,9 @@ function SimulatorCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: str
         <FlaskConical size={16} style={{ color: 'var(--accent)' }} />
         <div className="text-[14px] font-semibold text-ink">{tr('Simulateur d’investissement', 'Investment simulator')}</div>
       </div>
-      <div className="text-[11.5px] text-ink-muted mb-4">{tr('Testez un budget de remédiation et son efficacité — sans rien enregistrer.', 'Test a remediation budget and its effectiveness — nothing is saved.')}</div>
+      <div className="text-[11.5px] text-ink-muted mb-4">{tr('Trois réglages → une phrase de décision. Rien n’est enregistré.', 'Three settings → one decision sentence. Nothing is saved.')}</div>
 
+      {/* 1. Which risk */}
       <label className="block mb-3">
         <span className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">{tr('Risque', 'Risk')}</span>
         <select value={riskId} onChange={(e) => setRiskId(e.target.value)} className="mt-1.5 w-full rounded-[10px] px-3 py-2 text-[13px] text-ink outline-none" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }}>
@@ -305,73 +524,104 @@ function SimulatorCard({ rows, lang, tr }: { rows: TopRiskFinancial[]; lang: str
         </select>
       </label>
 
+      {/* 2. Concrete control / action — makes the sentence precise ("comment ?") */}
       <label className="block mb-3">
-        <span className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">{tr('Coût de remédiation (FCFA)', 'Remediation cost (FCFA)')}</span>
-        <input value={cost} onChange={(e) => setCost(e.target.value)} type="number" min={0} className="mt-1.5 w-full rounded-[10px] px-3 py-2 text-[13px] text-ink outline-none" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }} />
+        <span className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">{tr('Mesure envisagée', 'Planned measure')}</span>
+        <input value={action} onChange={(e) => setAction(e.target.value)} placeholder={tr('ex. authentification multifacteur sur les comptes à privilèges', 'e.g. MFA on privileged accounts')} className="mt-1.5 w-full rounded-[10px] px-3 py-2 text-[13px] text-ink outline-none" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)' }} />
       </label>
 
+      {/* 3a. Cost slider */}
+      <label className="block mb-3">
+        <span className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">
+          {tr('Budget', 'Budget')}
+          <span className="mono text-ink">{f.xafCompact(cost)}</span>
+        </span>
+        <input value={cost} onChange={(e) => setCost(Number(e.target.value))} type="range" min={0} max={costMax} step={Math.max(500_000, Math.round(costMax / 40))} className="mt-2 w-full accent-[var(--accent)]" />
+      </label>
+
+      {/* 3b. Effectiveness slider */}
       <label className="block mb-4">
         <span className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">
-          {tr('Efficacité du contrôle', 'Control effectiveness')}
+          {tr('Efficacité de la mesure', 'Measure effectiveness')}
           <span className="mono text-ink">{Math.round(eff * 100)}%</span>
         </span>
         <input value={eff} onChange={(e) => setEff(Number(e.target.value))} type="range" min={0} max={1} step={0.05} className="mt-2 w-full accent-[var(--accent)]" />
       </label>
 
       <button onClick={run} disabled={!riskId || sim.isPending} className="w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-primary disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
-        <Coins size={16} /> {tr('Calculer le ROSI', 'Compute ROSI')}
+        <Coins size={16} /> {tr('Calculer le retour', 'Compute return')}
       </button>
 
       {sim.isError && <div className="mt-3 text-[12px]" style={{ color: 'var(--critical)' }}>{tr('Échec de la simulation', 'Simulation failed')}</div>}
-      {a && <SimResult a={a} lang={lang} tr={tr} />}
+      {a && <SimResult a={a} riskTitle={selected?.title ?? ''} action={action} summary={summary} lang={lang} tr={tr} onExplain={onExplain} />}
     </Card>
   );
 }
 
-function SimResult({ a, lang, tr }: { a: import('./financialService').FinancialAssessment; lang: string; tr: (f: string, e: string) => string }) {
-  const beforeXAF = a.ale.xaf;
-  const max = Math.max(1, beforeXAF);
-  const bar = (label: string, v: MoneyLike, color: string) => (
-    <div>
-      <div className="flex items-center justify-between mb-1">
-        <span className="text-[11.5px] text-ink-soft">{label}</span>
-        <span className="mono text-[12px] font-semibold text-ink">{fmtCompact(v.xaf, lang)}</span>
-      </div>
-      <div className="h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-hover)' }}>
-        <div className="h-full rounded-full" style={{ width: `${(v.xaf / max) * 100}%`, background: color }} />
-      </div>
-    </div>
-  );
+function SimResult({ a, riskTitle, action, summary, lang, tr, onExplain }: { a: import('./financialService').FinancialAssessment; riskTitle: string; action: string; summary: FinancialSummary; lang: string; tr: (f: string, e: string) => string; onExplain: (m: Methodology) => void }) {
+  const f = useMoneyFmt(summary);
+  const before = a.ale;
+  const after = a.ale_after;
+  const cost = a.remediation_cost;
+  const reduction = a.risk_reduction;
+  // Payback in months: cost / (annual loss avoided / 12).
+  const paybackMonths = reduction.xaf > 0 ? Math.round((cost.xaf * 12) / reduction.xaf) : 0;
+  const measure = action.trim() || tr('cette mesure', 'this measure');
+  const rosiTxt = a.rosi_computable ? fmtPct(a.rosi) : '—';
+
+  // One concrete decision sentence (spec §5).
+  const sentence = lang === 'fr'
+    ? `Investir ${f.xafFull(cost.xaf)} dans ${measure}${riskTitle ? ` pour le risque « ${riskTitle} »` : ''} ramènerait son exposition annuelle attendue de ${f.xafFull(before.xaf)} à ${f.xafFull(after.xaf)}${a.rosi_computable ? `, soit un retour de ${rosiTxt}` : ''}${paybackMonths > 0 && cost.xaf > 0 ? ` — l’investissement serait amorti en ~${paybackMonths} mois` : ''}.`
+    : `Investing ${f.xafFull(cost.xaf)} in ${measure}${riskTitle ? ` for the "${riskTitle}" risk` : ''} would cut its expected annual exposure from ${f.xafFull(before.xaf)} to ${f.xafFull(after.xaf)}${a.rosi_computable ? `, a ${rosiTxt} return` : ''}${paybackMonths > 0 && cost.xaf > 0 ? ` — paying for itself in ~${paybackMonths} months` : ''}.`;
+
   return (
     <div className="mt-4 pt-4 border-t" style={{ borderColor: 'var(--border)' }}>
+      {/* The sentence that makes a COMEX understand the product. */}
+      <div className="rounded-[10px] p-3 mb-3 text-[13px] leading-[1.5] text-ink" style={{ background: 'color-mix(in srgb, var(--accent) 8%, transparent)', border: '1px solid color-mix(in srgb, var(--accent) 22%, transparent)' }}>
+        {sentence}
+      </div>
+
       <div className="flex items-center justify-between mb-3">
         <span className="inline-flex items-center gap-1.5 text-[12px] text-ink-soft"><ShieldCheck size={14} style={{ color: 'var(--low)' }} />ROSI</span>
-        <span className="mono text-[22px] font-bold" style={{ color: a.rosi_computable ? (a.rosi >= 0 ? 'var(--low)' : 'var(--critical)') : 'var(--ink-muted)' }}>
-          {a.rosi_computable ? fmtPct(a.rosi) : '—'}
-        </span>
+        <span className="mono text-[22px] font-bold" style={{ color: a.rosi_computable ? (a.rosi >= 0 ? 'var(--low)' : 'var(--critical)') : 'var(--ink-muted)' }}>{rosiTxt}</span>
       </div>
       <div className="flex flex-col gap-3">
-        {bar(tr('ALE actuel', 'Current ALE'), a.ale, C_LOSS)}
-        {bar(tr('ALE résiduel', 'Residual ALE'), a.ale_after, C_RESID)}
+        <Bar label={tr('ALE actuel', 'Current ALE')} v={before.xaf} max={before.xaf} f={f} color={C_LOSS} />
+        <Bar label={tr('ALE résiduel', 'Residual ALE')} v={after.xaf} max={before.xaf} f={f} color={C_RESID} />
       </div>
-      <div className="mt-3 text-[11.5px] text-ink-muted">
-        {tr('Perte évitée / an :', 'Loss avoided / yr:')} <span className="text-ink font-semibold">{fmtFCFA(a.risk_reduction.xaf)}</span>
-        {' · '}{fmtUSD(a.risk_reduction.usd)}
-      </div>
-      <div className="text-[11.5px] text-ink-muted">
-        {tr('Coût de remédiation :', 'Remediation cost:')} <span className="text-ink font-semibold">{fmtFCFA(a.remediation_cost.xaf)}</span>
-        {beforeXAF > 0 && ` · SLE ${fmtCompact(a.sle.xaf, lang)}`}
+      <div className="mt-3 flex items-center justify-between text-[11.5px] text-ink-muted">
+        <span>{tr('Perte évitée / an :', 'Loss avoided / yr:')} <span className="text-ink font-semibold">{f.xafFull(reduction.xaf)}</span></span>
+        {a.methodology && (
+          <button onClick={() => onExplain(a.methodology as Methodology)} className="inline-flex items-center gap-1 text-accent hover:underline">
+            <Info size={12} /> {tr('Méthodologie', 'Methodology')}
+          </button>
+        )}
       </div>
     </div>
   );
 }
-type MoneyLike = Money;
+
+function Bar({ label, v, max, f, color }: { label: string; v: number; max: number; f: ReturnType<typeof useMoneyFmt>; color: string }) {
+  const pct = Math.min(100, (v / Math.max(1, max)) * 100);
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-[11.5px] text-ink-soft">{label}</span>
+        <span className="mono text-[12px] font-semibold text-ink">{f.xafCompact(v)}</span>
+      </div>
+      <div className="h-2 rounded-full overflow-hidden" style={{ background: 'var(--bg-hover)' }}>
+        <div className="h-full rounded-full" style={{ width: `${pct}%`, background: color }} />
+      </div>
+    </div>
+  );
+}
 
 /* ---------------- loading skeleton ---------------- */
 function FinancialSkeleton() {
   return (
     <PageFrame wide>
       <PageHeader title="Financial Quantification" />
+      <Skeleton style={{ height: 120, borderRadius: 14, marginBottom: 16 }} />
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} style={{ height: 96, borderRadius: 14 }} />)}
       </div>

--- a/frontend/src/features/financial/financialService.ts
+++ b/frontend/src/features/financial/financialService.ts
@@ -14,11 +14,61 @@ export interface Money {
   usd: number;
 }
 
+/** Currency-aware amount: canonical XAF, USD, and the tenant display currency. */
+export interface Amount {
+  xaf: number;
+  usd: number;
+  value: number;    // amount in `currency`
+  currency: string; // tenant display currency (ISO code)
+}
+
+/** Supported tenant display currencies (spec §3). */
+export const SUPPORTED_CURRENCIES = ['XAF', 'XOF', 'EUR', 'USD', 'NGN', 'MAD', 'GHS', 'ZAR'] as const;
+export type CurrencyCode = (typeof SUPPORTED_CURRENCIES)[number];
+
+/** FAIR-lite loss distribution: P10 / P50 (median) / P90 band + run metadata. */
+export interface DistributionAmounts {
+  p10: Amount;
+  p50: Amount;
+  p90: Amount;
+  mean: Amount;
+  iterations: number;
+  seed: number;
+  formula_version: string;
+  lef: number;
+}
+
+/** One intrant surfaced in the methodology panel. */
+export interface MethodologyInput {
+  key: string;
+  label: string;
+  value: number;
+  unit: string;
+  source: string;
+}
+
+/** Explainability payload for a quantified figure (spec §4). */
+export interface Methodology {
+  formula_version: string;
+  model: string;
+  iterations: number;
+  seed: number;
+  computed_at: string;
+  doc_url: string;
+  currency: string;
+  fx_as_of: string;
+  fx_rate_xaf: number;
+  inputs: MethodologyInput[];
+  assumptions: string[];
+}
+
 export type SLEBasis = 'explicit' | 'composed' | 'reference';
 export type ALEBasis = 'explicit' | 'reference';
 
 /** Full monetary view of a single risk. */
 export interface FinancialAssessment {
+  distribution?: DistributionAmounts;
+  methodology?: Methodology;
   sle: Money;
   sle_average: Money;
   sle_worst: Money;
@@ -56,9 +106,16 @@ export interface TopRiskFinancial {
 /** Tenant-wide financial posture for the CFO/CISO dashboard. */
 export interface FinancialSummary {
   currency: string;
+  fx_rate_xaf: number;
+  fx_as_of: string;
   xaf_per_usd: number;
+  computed_at: string;
+  formula_version: string;
+  iterations: number;
   total_risks: number;
   quantified_risks: number;
+  /** Headline P10/P50/P90 band of total annual exposure (never one number). */
+  portfolio_loss: DistributionAmounts;
   total_ale: Money;
   total_ale_worst: Money;
   total_ale_after: Money;
@@ -99,6 +156,12 @@ export const financialService = {
   /** What-if assessment with overrides layered on the risk's stored drivers. */
   simulate: async (riskId: string, overrides: SimulateInput): Promise<FinancialAssessment> => {
     const res = await api.post<FinancialAssessment>(`/risks/${riskId}/simulate`, overrides);
+    return res.data;
+  },
+
+  /** Change the tenant display currency (admin). Returns the normalized code. */
+  setCurrency: async (currency: CurrencyCode): Promise<{ currency: string }> => {
+    const res = await api.put<{ currency: string }>('/analytics/financial/currency', { currency });
     return res.data;
   },
 };

--- a/frontend/src/features/financial/useFinancial.ts
+++ b/frontend/src/features/financial/useFinancial.ts
@@ -3,14 +3,29 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
-import { useQuery, useMutation } from '@tanstack/react-query';
-import { financialService, type SimulateInput } from './financialService';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { financialService, type SimulateInput, type CurrencyCode } from './financialService';
+
+/** Shared query key so mutations can invalidate the summary (real recompute). */
+export const FINANCIAL_SUMMARY_KEY = ['financial', 'summary'] as const;
 
 /** Tenant-wide financial summary (CFO/CISO dashboard). */
 export function useFinancialSummary() {
   return useQuery({
-    queryKey: ['financial', 'summary'],
+    queryKey: FINANCIAL_SUMMARY_KEY,
     queryFn: financialService.getSummary,
+  });
+}
+
+/** Change the tenant display currency, then invalidate the summary so every
+ * figure re-converts (spec §3: currency changeable). */
+export function useSetCurrency() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (currency: CurrencyCode) => financialService.setCurrency(currency),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: FINANCIAL_SUMMARY_KEY });
+    },
   });
 }
 

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -185,7 +185,7 @@ const COUNTRIES = [
   { code: 'CA', fr: 'Canada', en: 'Canada' },
 ];
 
-const CURRENCIES = ['XAF', 'XOF', 'EUR', 'USD', 'MAD', 'TND', 'DZD'];
+const CURRENCIES = ['XAF', 'XOF', 'EUR', 'USD', 'NGN', 'MAD', 'GHS', 'ZAR'];
 
 export function OrganizationStep() {
   const lang = useUIStore((s) => s.lang);


### PR DESCRIPTION
## Objectif

Rendre l'exposition financière **crédible et explicable**. Avant, l'écran affichait un montant unique sans qu'on sache d'où il venait — disqualifiant face à un CISO averti. Le calcul repose désormais sur un modèle **FAIR-lite** documenté, calculé sur les données de l'organisation, et chaque montant est traçable.

## Ce qui change

### 1. Modèle FAIR-lite assumé et documenté (`pkg/crq`)
`ALE = LEF × LM` — LEF = fréquence d'événement de perte (occurrences/an, depuis l'ARO) ; LM = magnitude en **loi PERT à 3 points** (min / probable / max). Moteur pur et déterministe (`montecarlo.go`), documenté dans [`docs/financial-quantification.md`](docs/financial-quantification.md) avec un `formula_version` (`fair-lite-1.0.0`).

### 2. Sortie P10 / P50 / P90 — jamais un chiffre unique
Simulation Monte Carlo (10 000 itérations, graine fixe → **déterministe**). L'en-tête du dashboard affiche une **plage** avec la **médiane P50 mise en avant** et l'intervalle P10–P90 dessiné. Le portefeuille utilise **une seule simulation partagée** sommant la perte de chaque risque par itération (diversification correctement prise en compte — le P90 global n'est pas la somme naïve des P90).

### 3. Devise au niveau tenant
XAF, XOF, EUR, USD, NGN, MAD, GHS, ZAR. Stockage canonique en XAF, conversion à un **taux de référence daté** (`fx_as_of` affiché à côté du montant). Job FX quotidien (`fx_rate_worker`, source statique honnête par défaut jusqu'à branchement d'un flux live). Devise choisie à l'onboarding, **changeable** (admin, `PUT /analytics/financial/currency`).

### 4. Explicabilité
Chaque montant est cliquable → panneau **Méthodologie** : modèle, intrants utilisés + provenance (`saisi`/`dérivé`/`référence`), hypothèses, nombre d'itérations, graine, date de calcul, `formula_version`, taux FX + date, lien vers la doc.

### 5. Simulateur d'investissement = ROSI
`ROSI = (ALE_avant − ALE_après − Coût) / Coût`. 3 réglages (mesure + budget + efficacité) → **une phrase de décision concrète** avec le **délai d'amortissement**, ex. : *« Investir 12 000 000 XAF dans l'authentification multifacteur pour le risque « X » ramènerait son exposition annuelle attendue de 41 000 000 à 9 000 000 XAF, soit un retour de 141 % — l'investissement serait amorti en ~4 mois. »*

### 6. Correctifs
- **« N/M risques chiffrés »** : depuis un **agrégat SQL** (`CountFinancialCoverage`, `COUNT(*) FILTER`), plus un filtre côté client.
- **Actualiser** : invalidation de cache + recalcul réel + horodatage **« Calculé il y a X min »** + date du taux.

### 7. Tableau exécutif = mode d'affichage
Déjà en place (`/?view=executive`, `/analytics` redirige) — vérifié, aucune destination de rapport séparée.

## Tests
- **Propriété** (`montecarlo_test.go`) : convergence (moyenne → LEF × espérance PERT), bornes (P10 ≤ P50 ≤ P90, containment), **déterminisme à graine fixe**, portefeuille.
- **Conversion de devise** (`currency_test.go`) : 8 devises, peg CFA, identité XAF, normalisation.
- **E2E du simulateur** (`risk_handler_test.go`) : create → GET /financial (band + méthodologie, `computed_at` estampillé) → POST /simulate (ALE 10M → résiduel 2M, ROSI ~1.67).
- `AssessP` explicabilité, résumé currency-aware + agrégat de couverture.

`go build ./...`, `go vet`, suites backend (crq / application/risk / handler / repository / workers) **vertes** ; `tsc -b` + `vite build` **verts**.

## Restes honnêtes
- Le job FX utilise la source statique de référence (aucun flux live branché dans cet environnement) — la date de référence est affichée honnêtement.
- Frontend prouvé par `tsc`/`vite` + les endpoints (pilotage navigateur interactif hors périmètre).
- L'onglet « Financier » du drawer de risque consomme le même endpoint (désormais enrichi) mais n'affiche pas encore la bande/méthodologie — itération suivante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
