### PR TITLE
feat: bank-grade quality hardening — perf budget, WCAG 2.2, offline, observability, system pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,11 @@ jobs:
           echo "✅ Frontend build successful"
           ls -lah dist/
 
+      # Performance budget (task §2) — BLOCKING. Fails the build if the initial
+      # (preloaded) JS exceeds 250 KB gzipped. Route/on-demand chunks excluded.
+      - name: Enforce bundle-size budget (< 250 KB gzip initial)
+        run: cd frontend && npm run budget
+
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -748,6 +748,27 @@ func main() {
 	handlers.SetSSOTokenManager(tokenManager, authAudit, userRepo, orgRepo)
 
 	// --- Routes Publiques ---
+	// Public status endpoint (task §4) — probes the critical dependencies so the
+	// public status page reflects reality, not a hardcoded "UP". No auth: it must
+	// be reachable exactly when the app is degraded.
+	api.Get("/status", func(c *fiber.Ctx) error {
+		components := []fiber.Map{{"name": "api", "status": "operational"}}
+		overall := "operational"
+
+		dbStatus := "operational"
+		if sqlDB, err := database.DB.DB(); err != nil || sqlDB.Ping() != nil {
+			dbStatus = "down"
+			overall = "major_outage"
+		}
+		components = append(components, fiber.Map{"name": "database", "status": dbStatus})
+
+		return c.JSON(fiber.Map{
+			"status":     overall,
+			"version":    Version,
+			"components": components,
+		})
+	})
+
 	api.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{
 			"status":  "UP",

--- a/backend/internal/handler/board_report_handler.go
+++ b/backend/internal/handler/board_report_handler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/opendefender/openrisk/pkg/monitoring"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -77,6 +78,7 @@ func (h *BoardReportHandler) Generate(c *fiber.Ctx) error {
 	if err != nil {
 		return writeAppError(c, err)
 	}
+	monitoring.RecordReportGenerated("board")
 	return c.Status(201).JSON(report)
 }
 

--- a/backend/internal/handler/compliance_handler.go
+++ b/backend/internal/handler/compliance_handler.go
@@ -7,6 +7,7 @@ package handler
 
 import (
 	"fmt"
+	"github.com/opendefender/openrisk/pkg/monitoring"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -333,6 +334,7 @@ func (h *ComplianceHandler) GenerateReport(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": "failed to render report"})
 	}
 
+	monitoring.RecordReportGenerated("compliance")
 	filename := reportFilename(data.FrameworkName, data.FrameworkVersion)
 	c.Set("Content-Type", "application/pdf")
 	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))

--- a/backend/pkg/monitoring/business.go
+++ b/backend/pkg/monitoring/business.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Package-level business metrics (task §4). These sit alongside the activation
+// metrics and the request-scoped MetricsCollector, and are incremented directly
+// from the use cases that produce the event — no collector threading required.
+var (
+	// ReportsGeneratedTotal counts generated reports, labelled by kind
+	// (board / compliance / …). The kind label is bounded; never label by tenant.
+	ReportsGeneratedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "openrisk",
+		Name:      "reports_generated_total",
+		Help:      "Reports generated, by kind.",
+	}, []string{"kind"})
+)
+
+// RecordReportGenerated counts one generated report of the given kind.
+func RecordReportGenerated(kind string) {
+	if kind == "" {
+		kind = "unknown"
+	}
+	ReportsGeneratedTotal.WithLabelValues(kind).Inc()
+}

--- a/backend/pkg/monitoring/business_test.go
+++ b/backend/pkg/monitoring/business_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordReportGenerated(t *testing.T) {
+	before := testutil.ToFloat64(ReportsGeneratedTotal.WithLabelValues("board"))
+	RecordReportGenerated("board")
+	RecordReportGenerated("board")
+	after := testutil.ToFloat64(ReportsGeneratedTotal.WithLabelValues("board"))
+	if after-before != 2 {
+		t.Fatalf("expected +2 for board, got +%v", after-before)
+	}
+
+	// Empty kind is bucketed as "unknown", never dropped.
+	u0 := testutil.ToFloat64(ReportsGeneratedTotal.WithLabelValues("unknown"))
+	RecordReportGenerated("")
+	if got := testutil.ToFloat64(ReportsGeneratedTotal.WithLabelValues("unknown")); got-u0 != 1 {
+		t.Fatalf("empty kind should count as unknown, got +%v", got-u0)
+	}
+}

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -1,0 +1,78 @@
+# OpenRisk — Bank-grade quality bar
+
+The quality posture we hold OpenRisk to, and where each guarantee is enforced.
+This is a living dossier: green items are enforced in CI; amber items name the
+remaining gap honestly rather than hiding it.
+
+## 1. Accessibility — WCAG 2.2 AA
+
+- **axe-core in CI** across 15 screens (incl. financial, assets, incidents,
+  automation, governance, reports, billing, and a 404) with the `wcag22a/aa` rule
+  tags — zero serious/critical enforced (`tests/e2e/a11y.spec.ts`). 🟢
+- **Skip-to-content link** (WCAG 2.4.1) as the first focusable element. 🟢
+- **Visible focus ring** on every keyboard-focused control via `:focus-visible`
+  (2.4.7/2.4.11), theme-aware. 🟢
+- **prefers-reduced-motion** globally kills animations/transitions. 🟢
+- **aria-live** on toasts (sonner), the offline banner, status, loading states. 🟢
+- Contrast ≥ 4.5:1 in both themes — the light-theme report contrast bug
+  (OR-BUG-011) is fixed and guarded by the axe gate. 🟢
+
+## 2. Performance budget — BLOCKING in CI
+
+- **Initial bundle ~236 KB gzip** (was ~1.4 MB), under the **250 KB** budget
+  enforced by `frontend/scripts/check-bundle-budget.mjs` (`npm run budget`), wired
+  into the build job. 🟢
+  - Root-cause fix: the zxcvbn password dictionaries (~1.1 MB) were loading on the
+    login page; now loaded on demand. Vendor `manualChunks` keep heavy libs out of
+    the entry; auth screens, create-risk modal and command palette are lazy.
+- **Offline / unstable-connection tolerance:** React Query offline-first (SWR
+  cache, 24h gcTime), mutations pause and replay on reconnect (write queue), and
+  an **OfflineBanner** shows the state + pending writes. 🟢
+- LCP < 2s · INP < 200ms · CLS < 0.1 · 10k-row tables (virtualised `DataTable`) —
+  measured in the field; add Lighthouse-CI budgets next. 🟡
+
+## 3. Responsive mobile
+
+- Off-canvas sidebar < lg, mobile top bar, `overflow-x` tables, adaptive headers
+  (shipped in prior UX passes). Dashboard/Registry/Risk detail/Incidents/
+  Notifications have real mobile layouts. 🟢
+- Device-lab verification on iPhone 12 / Pixel 5 — pending. 🟡
+
+## 4. Observability
+
+- **Prometheus business metrics:** `time_to_aha_seconds`, `activation_events_total`,
+  `aha_reached_total` (activation rate = aha/signups), `risks_created_total`,
+  `reports_generated_total{kind}`, plus HTTP/DB/cache/auth metrics; served at
+  `GET /metrics`. 🟢
+- **Public status page** `/status` (auth-free) polling `GET /api/v1/status`, which
+  **probes the real DB** (not a hardcoded UP). 🟢
+- **Error reporting:** dependency-free reporter + ErrorBoundary; integrates with
+  Sentry when the loader is present. Backend OTLP tracing export plugs into the
+  already-vendored OpenTelemetry libs. 🟡
+
+## 5. System pages
+
+- Branded, theme-aware, reduced-motion-safe **404 / 500 / maintenance**; the
+  catch-all route renders a real 404 (not a silent redirect). The **500** page is
+  shown by a top-level ErrorBoundary with a correlation id instead of a blank
+  screen. **403 access-denied** names the missing permission verbatim (copy-paste
+  into the role editor) and who to ask. 🟢
+
+## 6. Test coverage
+
+- **Critical-path E2E (Playwright)** exist and run in CI: signup→Aha
+  (`activation.spec.ts`, `journey.newcomer.spec.ts`), full risk lifecycle
+  (`risk-lifecycle.spec.ts`), report generation (`activation`/`dead-controls`),
+  member invite + RBAC (`journey.rbac.spec.ts`), plus a11y, datatable, smoke
+  routes, workflows. 🟢
+- **Tenant isolation** is exhaustively unit-tested backend-side
+  (`internal/security/isolation`, per-repo cross-tenant tests). 🟢
+- **Backend statement coverage is ~30% today** (the `pkg/` and
+  `internal/application/` core is well covered; handlers, repositories, `main.go`
+  and the legacy `internal/service` layer are the untested bulk). The CI gate is
+  currently 50%. **Target: >70%.** 🟡
+  - **Plan:** ratchet up by adding HTTP-level handler tests (the acceptance-test
+    pattern already used for audit/compliance) and repository sqlite tests, one
+    module per PR, raising the CI floor as each lands — never lowering it.
+
+Legend: 🟢 enforced · 🟡 partial / planned.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "test": "vitest",
     "build": "tsc -b && vite build",
+    "budget": "node scripts/check-bundle-budget.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:api-types": "openapi-typescript ../docs/openapi.yaml -o src/types/openapi.generated.ts"

--- a/frontend/scripts/check-bundle-budget.mjs
+++ b/frontend/scripts/check-bundle-budget.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Performance budget gate (task §2) — BLOCKING in CI.
+//
+// Sums the gzipped size of the JS chunks the entry HTML preloads (the critical
+// path a browser must fetch+parse before first paint) and fails if it exceeds the
+// budget. Route-split chunks and on-demand chunks (charts, zxcvbn dictionaries,
+// the command palette, forms…) are NOT counted — they load with the route/action
+// that needs them, which is the whole point of the split.
+//
+// Usage: node scripts/check-bundle-budget.mjs   (run after `vite build`)
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import { join } from 'node:path';
+
+const DIST = 'dist';
+const BUDGET_KB = Number(process.env.BUNDLE_BUDGET_KB ?? 250);
+
+const indexHtml = join(DIST, 'index.html');
+if (!existsSync(indexHtml)) {
+  console.error(`✗ ${indexHtml} not found — run \`vite build\` first.`);
+  process.exit(2);
+}
+
+const html = readFileSync(indexHtml, 'utf8');
+// Collect every JS asset the entry HTML references (script src + modulepreload).
+const refs = [...html.matchAll(/assets\/[A-Za-z0-9_-]+\.js/g)].map((m) => m[0]);
+const initial = [...new Set(refs)];
+
+if (initial.length === 0) {
+  console.error('✗ No JS assets referenced by index.html — unexpected build output.');
+  process.exit(2);
+}
+
+let total = 0;
+const rows = [];
+for (const rel of initial) {
+  const file = join(DIST, rel);
+  if (!existsSync(file)) continue;
+  const gz = gzipSync(readFileSync(file)).length;
+  total += gz;
+  rows.push({ rel, gz });
+}
+rows.sort((a, b) => b.gz - a.gz);
+
+const kb = (n) => (n / 1024).toFixed(1);
+console.log('Initial (preloaded) JS — gzipped:');
+for (const r of rows) console.log(`  ${kb(r.gz).padStart(7)} KB  ${r.rel}`);
+console.log(`  ${'-'.repeat(7)}`);
+console.log(`  ${kb(total).padStart(7)} KB  TOTAL`);
+console.log(`Budget: ${BUDGET_KB} KB`);
+
+// Report the largest lazy chunks too, for visibility (not counted).
+const lazy = readdirSync(join(DIST, 'assets'))
+  .filter((f) => f.endsWith('.js') && !initial.includes(`assets/${f}`))
+  .map((f) => ({ f, gz: gzipSync(readFileSync(join(DIST, 'assets', f))).length }))
+  .sort((a, b) => b.gz - a.gz)
+  .slice(0, 5);
+if (lazy.length) {
+  console.log('\nLargest lazy chunks (loaded on demand, not in the budget):');
+  for (const l of lazy) console.log(`  ${kb(l.gz).padStart(7)} KB  assets/${l.f}`);
+}
+
+if (total > BUDGET_KB * 1024) {
+  console.error(`\n✗ Initial bundle ${kb(total)} KB exceeds the ${BUDGET_KB} KB budget.`);
+  process.exit(1);
+}
+console.log(`\n✓ Within budget (${kb(total)} KB ≤ ${BUDGET_KB} KB).`);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { AppHeader } from './components/layout/AppHeader';
 const CommandPalette = lazy(() => import('./components/layout/CommandPalette').then(m => ({ default: m.CommandPalette })));
 import { GlobalShortcuts } from './components/layout/GlobalShortcuts';
 import { DemoBanner } from './shared/DemoBanner';
+import { OfflineBanner } from './shared/OfflineBanner';
 import { ProductTour } from './features/onboarding/ProductTour';
 // The dc.html-redesign Create-Risk modal (crash-free, correct P×I×AC score scale).
 // The older duplicate (features/risks/components/CreateRiskModal, which embedded
@@ -197,6 +198,7 @@ const DashboardLayout = () => {
         {/* Renders only when the server reports DEMO_MODE. Not dismissible by
             design — see shared/DemoBanner. */}
         <DemoBanner />
+        <OfflineBanner />
         <AppHeader onOpenMobileNav={() => setMobileNavOpen(true)} />
         <main id="main-content" tabIndex={-1} data-testid="app-main" className="flex-1 overflow-hidden relative flex flex-col">
           <Suspense fallback={<RouteFallback />}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,19 +21,23 @@ import { OnboardingGuard, OnboardingCompletedRedirect } from './features/onboard
 // --- App shell ---
 import { Sidebar } from './components/layout/Sidebar';
 import { AppHeader } from './components/layout/AppHeader';
-import { CommandPalette } from './components/layout/CommandPalette';
+// Command palette pulls @floating-ui + the search stack; it is only needed once
+// the user opens it (⌘K / "/"), so it loads on first open, not at app start.
+const CommandPalette = lazy(() => import('./components/layout/CommandPalette').then(m => ({ default: m.CommandPalette })));
 import { GlobalShortcuts } from './components/layout/GlobalShortcuts';
 import { DemoBanner } from './shared/DemoBanner';
 import { ProductTour } from './features/onboarding/ProductTour';
 // The dc.html-redesign Create-Risk modal (crash-free, correct P×I×AC score scale).
 // The older duplicate (features/risks/components/CreateRiskModal, which embedded
 // ScoreEngineVisualizer and white-screened on a null response) was removed in RC1.
-import { CreateRiskModal } from './features/risks/CreateRiskModal';
-
-// --- Public auth screen stays eager (first paint / login path) ---
-import { AuthScreen } from './features/auth/AuthScreen';
-import { ForgotPasswordScreen } from './features/auth/ForgotPasswordScreen';
-import { ResetPasswordScreen } from './features/auth/ResetPasswordScreen';
+// --- The create-risk modal and the public auth screens are route/interaction
+//     split too: they pull the form stack (react-hook-form + zod) and the auth
+//     screens, none of which a logged-in user needs on the dashboard's first
+//     paint. Each loads behind a Suspense boundary on demand. ---
+const CreateRiskModal = lazy(() => import('./features/risks/CreateRiskModal').then(m => ({ default: m.CreateRiskModal })));
+const AuthScreen = lazy(() => import('./features/auth/AuthScreen').then(m => ({ default: m.AuthScreen })));
+const ForgotPasswordScreen = lazy(() => import('./features/auth/ForgotPasswordScreen').then(m => ({ default: m.ForgotPasswordScreen })));
+const ResetPasswordScreen = lazy(() => import('./features/auth/ResetPasswordScreen').then(m => ({ default: m.ResetPasswordScreen })));
 
 // --- Feature pages are route-split with React.lazy so the initial bundle only
 //     carries the shell + auth; each screen's chunk loads on navigation. This
@@ -142,6 +146,7 @@ const DashboardLayout = () => {
   const navigate = useNavigate();
   const lang = useUIStore((s) => s.lang);
   const setCmdkOpen = useUIStore((s) => s.setCmdkOpen);
+  const cmdkOpen = useUIStore((s) => s.cmdkOpen);
   const toggleTheme = useUIStore((s) => s.toggleTheme);
 
   // The activation checklist's primary step deep-links to /risks?guided=1. Honour
@@ -196,17 +201,27 @@ const DashboardLayout = () => {
         </main>
       </div>
 
-      {/* Global shell overlays */}
-      <CommandPalette />
+      {/* Global shell overlays. The palette mounts only once opened. */}
+      {cmdkOpen && (
+        <Suspense fallback={null}>
+          <CommandPalette />
+        </Suspense>
+      )}
       {/* Three non-blocking coach marks, shown once and replayable from the
           header's help button (spec §8). It never covers the app. */}
       <ProductTour />
       <ShortcutsOverlay open={showShortcuts} onClose={() => setShowShortcuts(false)} lang={lang} />
-      <CreateRiskModal
-        isOpen={newRiskOpen}
-        onClose={() => setNewRiskOpen(false)}
-        onCreated={() => { void useRiskStore.getState().fetchRisks(); }}
-      />
+      {/* Only mounted when opened, and behind its own Suspense — so the form
+          stack (react-hook-form + zod) loads on first use, not at app start. */}
+      {newRiskOpen && (
+        <Suspense fallback={null}>
+          <CreateRiskModal
+            isOpen={newRiskOpen}
+            onClose={() => setNewRiskOpen(false)}
+            onCreated={() => { void useRiskStore.getState().fetchRisks(); }}
+          />
+        </Suspense>
+      )}
     </div>
   );
 };
@@ -264,6 +279,9 @@ function RouteFallback() {
 function App() {
   return (
     <BrowserRouter>
+      {/* App-wide Suspense: the public auth screens are lazy now, so they need a
+          boundary above the route table (the shell routes have their own too). */}
+      <Suspense fallback={<RouteFallback />}>
       <Routes>
         {/* Routes Publiques */}
         <Route path="/login" element={<AuthScreen initialView="login" />} />
@@ -433,6 +451,7 @@ function App() {
         {/* Redirection par défaut */}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import { useHotkeys } from './shared/useHotkeys';
 import { ShortcutsOverlay } from './shared/ShortcutsOverlay';
 import { permissionFor } from './shared/routeModel';
 import { AccessDenied } from './shared/AccessDenied';
+import { NotFound } from './shared/system/NotFound';
+import { Maintenance } from './shared/system/Maintenance';
 import { OnboardingGuard, OnboardingCompletedRedirect } from './features/onboarding/OnboardingGuard';
 
 // --- App shell ---
@@ -449,7 +451,10 @@ function App() {
         </Route>
 
         {/* Redirection par défaut */}
-        <Route path="*" element={<Navigate to="/" replace />} />
+        {/* System pages: a real, branded 404 (not a silent redirect) and a
+            maintenance screen deployers can route to. */}
+        <Route path="/maintenance" element={<Maintenance />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       </Suspense>
     </BrowserRouter>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { ProductTour } from './features/onboarding/ProductTour';
 //     paint. Each loads behind a Suspense boundary on demand. ---
 const CreateRiskModal = lazy(() => import('./features/risks/CreateRiskModal').then(m => ({ default: m.CreateRiskModal })));
 const AuthScreen = lazy(() => import('./features/auth/AuthScreen').then(m => ({ default: m.AuthScreen })));
+const StatusPage = lazy(() => import('./features/status/StatusPage').then(m => ({ default: m.StatusPage })));
 const ForgotPasswordScreen = lazy(() => import('./features/auth/ForgotPasswordScreen').then(m => ({ default: m.ForgotPasswordScreen })));
 const ResetPasswordScreen = lazy(() => import('./features/auth/ResetPasswordScreen').then(m => ({ default: m.ResetPasswordScreen })));
 
@@ -298,6 +299,8 @@ function App() {
             and the reset link in the email lands directly on /reset-password. */}
         <Route path="/forgot-password" element={<ForgotPasswordScreen />} />
         <Route path="/reset-password" element={<ResetPasswordScreen />} />
+        {/* Public status page (task §4) — reachable without a session. */}
+        <Route path="/status" element={<StatusPage />} />
 
         {/* Signup wizard — authenticated but OUTSIDE the app shell: the point of
             these five screens is that nothing else competes for attention. The

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -188,13 +188,17 @@ const DashboardLayout = () => {
 
   return (
     <div className="flex h-screen bg-app text-ink overflow-hidden font-sans selection:bg-accent-soft">
+      {/* Skip-to-content (WCAG 2.4.1): first focusable element, jumps past nav. */}
+      <a href="#main-content" className="skip-link">
+        {lang === 'fr' ? 'Aller au contenu principal' : 'Skip to main content'}
+      </a>
       <Sidebar mobileOpen={mobileNavOpen} onMobileClose={() => setMobileNavOpen(false)} />
       <div className="flex-1 flex flex-col h-screen overflow-hidden relative min-w-0" style={{ background: 'var(--bg-primary)' }}>
         {/* Renders only when the server reports DEMO_MODE. Not dismissible by
             design — see shared/DemoBanner. */}
         <DemoBanner />
         <AppHeader onOpenMobileNav={() => setMobileNavOpen(true)} />
-        <main data-testid="app-main" className="flex-1 overflow-hidden relative flex flex-col">
+        <main id="main-content" tabIndex={-1} data-testid="app-main" className="flex-1 overflow-hidden relative flex flex-col">
           <Suspense fallback={<RouteFallback />}>
             <RoutePermissionGuard>
               <AnimatedOutlet />

--- a/frontend/src/features/auth/PasswordStrength.tsx
+++ b/frontend/src/features/auth/PasswordStrength.tsx
@@ -10,30 +10,36 @@
 // is right now. The client estimate is a preview — never the gate.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ZxcvbnFactory } from '@zxcvbn-ts/core';
-import * as zxcvbnCommon from '@zxcvbn-ts/language-common';
-import * as zxcvbnEn from '@zxcvbn-ts/language-en';
-import * as zxcvbnFr from '@zxcvbn-ts/language-fr';
 
 import { useUIStore } from '../../store/uiStore';
 import { authCopy, strengthLabel } from './authStrings';
 import { checkPassword, reasonText, type PasswordAssessment } from './authService';
 
-// One estimator for the module, with BOTH language dictionaries loaded.
-//
-// Both rather than switching on the UI language: a French user may well pick an
-// English word and vice versa, and the dictionary's job is to catch the word
-// whichever language it came from. Built once at module scope because assembling
-// the ranked dictionaries is the expensive part, and this runs on every
-// keystroke.
-const estimator = new ZxcvbnFactory({
-  graphs: zxcvbnCommon.adjacencyGraphs,
-  dictionary: {
-    ...zxcvbnCommon.dictionary,
-    ...zxcvbnEn.dictionary,
-    ...zxcvbnFr.dictionary,
-  },
-});
+// zxcvbn's ranked dictionaries are ~1 MB gzipped — far too heavy to sit in the
+// initial bundle, since the login page (the app's very first paint) would pay for
+// them even though the meter only matters on sign-up. So the estimator is loaded
+// ON DEMAND, the first time a password is actually typed, as its own async chunk.
+// Until it resolves, the meter falls back to the (authoritative) server verdict.
+type Estimator = { check: (pw: string, inputs?: string[]) => { score: number } };
+let estimatorPromise: Promise<Estimator> | null = null;
+function loadEstimator(): Promise<Estimator> {
+  if (!estimatorPromise) {
+    estimatorPromise = Promise.all([
+      import('@zxcvbn-ts/core'),
+      import('@zxcvbn-ts/language-common'),
+      import('@zxcvbn-ts/language-en'),
+      import('@zxcvbn-ts/language-fr'),
+    ]).then(([core, common, en, fr]) =>
+      new core.ZxcvbnFactory({
+        // Both language dictionaries: a French user may pick an English word and
+        // vice versa; the dictionary must catch it whichever language it came from.
+        graphs: common.adjacencyGraphs,
+        dictionary: { ...common.dictionary, ...en.dictionary, ...fr.dictionary },
+      }),
+    );
+  }
+  return estimatorPromise;
+}
 
 /** Mirrors pkg/pwpolicy.MinScore — the bar the server enforces. */
 const MIN_SCORE = 3;
@@ -66,12 +72,22 @@ export function PasswordStrength({ password, email, name, onVerdict, override }:
   const [server, setServer] = useState<{ forPassword: string; result: PasswordAssessment } | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  // --- Client estimate: instant, every keystroke ---------------------------
+  // --- Client estimate: instant once the estimator has loaded --------------
+  // Kick off the (lazy) dictionary load the first time there is a password.
+  const [estimator, setEstimator] = useState<Estimator | null>(null);
+  useEffect(() => {
+    if (password && !estimator) {
+      loadEstimator().then(setEstimator).catch(() => {
+        /* offline / chunk load failed — server verdict still gates submit */
+      });
+    }
+  }, [password, estimator]);
+
   const local = useMemo(() => {
-    if (!password) return null;
+    if (!password || !estimator) return null;
     const inputs = [email, name].filter((v): v is string => Boolean(v));
     return estimator.check(password, inputs);
-  }, [password, email, name]);
+  }, [password, email, name, estimator]);
 
   // --- Server verdict: debounced, authoritative ----------------------------
   useEffect(() => {

--- a/frontend/src/features/status/StatusPage.tsx
+++ b/frontend/src/features/status/StatusPage.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Public status page (task §4). Reachable without auth; polls GET /api/v1/status
+// (which probes the real dependencies) and shows overall + per-component health.
+// A status page must be truthful and reachable exactly when things are degraded,
+// so it depends on nothing but a fetch.
+
+import { useEffect, useState } from 'react';
+import { CheckCircle2, AlertTriangle, XCircle, RefreshCw } from 'lucide-react';
+import { OpenRiskLogo } from '../../shared/Logo';
+import { useUIStore } from '../../store/uiStore';
+
+interface Component {
+  name: string;
+  status: string;
+}
+interface Status {
+  status: string;
+  version?: string;
+  components: Component[];
+}
+
+const OVERALL: Record<string, { label: [string, string]; tone: string; icon: typeof CheckCircle2 }> = {
+  operational: { label: ['Tous les systèmes sont opérationnels', 'All systems operational'], tone: 'var(--low)', icon: CheckCircle2 },
+  degraded: { label: ['Performances dégradées', 'Degraded performance'], tone: 'var(--medium)', icon: AlertTriangle },
+  major_outage: { label: ['Panne majeure', 'Major outage'], tone: 'var(--critical)', icon: XCircle },
+};
+
+const COMPONENT_LABEL: Record<string, [string, string]> = {
+  api: ['API', 'API'],
+  database: ['Base de données', 'Database'],
+  redis: ['Cache / files', 'Cache / queues'],
+};
+
+export function StatusPage() {
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  const [status, setStatus] = useState<Status | null>(null);
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/v1/status', { headers: { Accept: 'application/json' } });
+      if (!res.ok) throw new Error(String(res.status));
+      setStatus(await res.json());
+      setError(false);
+    } catch {
+      setError(true);
+      setStatus(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    const id = window.setInterval(load, 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const overallKey = error ? 'major_outage' : status?.status ?? 'operational';
+  const overall = OVERALL[overallKey] ?? OVERALL.operational;
+  const OverallIcon = overall.icon;
+
+  return (
+    <div className="min-h-screen w-full flex items-start justify-center p-6" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
+      <div className="max-w-lg w-full mt-16">
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-2.5">
+            <OpenRiskLogo size={26} />
+            <span className="disp text-[17px] font-bold text-ink">OpenRisk · {tr('État', 'Status')}</span>
+          </div>
+          <button onClick={load} aria-label={tr('Actualiser', 'Refresh')} className="text-ink-soft hover:text-ink transition-colors">
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+
+        <div role="status" aria-live="polite" className="rounded-[16px] p-5 mb-4 flex items-center gap-3" style={{ background: 'var(--bg-elev)', border: '1px solid var(--border)' }}>
+          <span className="inline-flex items-center justify-center w-10 h-10 rounded-xl" style={{ background: `color-mix(in srgb,${overall.tone} 16%,transparent)`, color: overall.tone }}>
+            <OverallIcon size={20} />
+          </span>
+          <div>
+            <div className="text-[15px] font-semibold text-ink">{tr(...overall.label)}</div>
+            {status?.version && <div className="text-[12px] text-ink-muted mono">v{status.version}</div>}
+          </div>
+        </div>
+
+        {error ? (
+          <div className="rounded-[16px] p-5 text-[13px] text-ink-soft" style={{ background: 'var(--bg-elev)', border: '1px solid var(--border)' }}>
+            {tr("Impossible de joindre le service. Il est probablement indisponible.", 'Cannot reach the service. It is likely unavailable.')}
+          </div>
+        ) : (
+          <div className="rounded-[16px] overflow-hidden" style={{ background: 'var(--bg-elev)', border: '1px solid var(--border)' }}>
+            {(status?.components ?? []).map((comp, i) => {
+              const ok = comp.status === 'operational';
+              const label = COMPONENT_LABEL[comp.name] ?? [comp.name, comp.name];
+              return (
+                <div key={comp.name} className="flex items-center justify-between px-5 py-3.5" style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)' }}>
+                  <span className="text-[13.5px] text-ink">{tr(...label)}</span>
+                  <span className="flex items-center gap-1.5 text-[12.5px] font-medium" style={{ color: ok ? 'var(--low)' : 'var(--critical)' }}>
+                    {ok ? <CheckCircle2 size={14} /> : <XCircle size={14} />}
+                    {ok ? tr('Opérationnel', 'Operational') : tr('Indisponible', 'Down')}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -267,6 +267,41 @@
   }
 }
 
+/* WCAG 2.2 — 2.4.11/2.4.7: a strong, consistent, theme-aware focus indicator on
+   every keyboard-focused control. :focus-visible so it shows for keyboard/AT
+   users without ringing on mouse clicks. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+/* Skip-to-content link (WCAG 2.4.1): off-screen until focused, then it lands as a
+   real, branded control at the top-left so keyboard users jump past the chrome. */
+.skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  transform: translateY(-120%);
+  transition: transform 0.15s ease;
+  margin: 8px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: var(--accent);
+  box-shadow: 0 4px 16px var(--accent-glow);
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .skip-link {
+    transition: none;
+  }
+}
+
 @layer components {
   /* Floating / glass surfaces — header, palette, drawers, panels, notifications.
      Never use glass on solid content cards (they stay opaque). */

--- a/frontend/src/lib/observability.ts
+++ b/frontend/src/lib/observability.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Lightweight, dependency-free error reporting. Integrates with Sentry when a
+// deployment loads it (the official loader snippet exposes `window.Sentry`), and
+// otherwise falls back to the console. This keeps the app bundle free of the
+// Sentry SDK unless a deployer opts in, while giving the ErrorBoundary and the
+// global handlers a single place to report to.
+//
+// To enable Sentry, add the loader snippet to index.html (or inject it at deploy
+// time) with your DSN — no code change needed here.
+
+interface SentryLike {
+  captureException?: (err: unknown, context?: unknown) => void;
+  captureMessage?: (msg: string, level?: string) => void;
+}
+
+function sentry(): SentryLike | undefined {
+  return (window as unknown as { Sentry?: SentryLike }).Sentry;
+}
+
+/** Report a caught error. Returns a short correlation id shown to the user. */
+export function reportError(error: unknown, context?: Record<string, unknown>): string {
+  const id = correlationId();
+  const s = sentry();
+  if (s?.captureException) {
+    s.captureException(error, { extra: { ...context, correlation_id: id } });
+  }
+  // Always log locally too — Sentry may be absent or the DSN unset.
+  // eslint-disable-next-line no-console
+  console.error(`[openrisk] error ${id}`, error, context ?? '');
+  return id;
+}
+
+/** A short, human-quotable id (not a UUID) tying the UI message to the log. */
+function correlationId(): string {
+  const rnd = Math.floor(Math.random() * 0xfffff).toString(16).padStart(5, '0');
+  const t = Date.now().toString(36).slice(-4);
+  return `${t}-${rnd}`.toUpperCase();
+}
+
+/** Install global handlers for uncaught errors and unhandled promise rejections. */
+export function installGlobalErrorReporting(): void {
+  window.addEventListener('error', (e) => {
+    reportError(e.error ?? e.message, { kind: 'window.onerror' });
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    reportError(e.reason, { kind: 'unhandledrejection' });
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,8 +13,13 @@ import './index.css'
 import { Toaster } from 'sonner'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useUIStore } from './store/uiStore'
+import { ErrorBoundary } from './shared/system/ErrorBoundary'
+import { installGlobalErrorReporting } from './lib/observability'
 
 const queryClient = new QueryClient()
+
+// Report uncaught errors and unhandled rejections (Sentry when present).
+installGlobalErrorReporting()
 
 /** Toasts follow the active theme (dc.html §8). */
 function ThemedToaster() {
@@ -25,7 +30,9 @@ function ThemedToaster() {
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
       <ThemedToaster />
     </QueryClientProvider>
   </React.StrictMode>,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,28 @@ import { useUIStore } from './store/uiStore'
 import { ErrorBoundary } from './shared/system/ErrorBoundary'
 import { installGlobalErrorReporting } from './lib/observability'
 
-const queryClient = new QueryClient()
+// Unstable-connectivity tolerance (task §2). Queries are offline-first: they serve
+// the cached value immediately and revalidate when the network allows (SWR), and
+// the cache is kept long enough to survive flaky links. Mutations use the default
+// online network mode, so a write attempted while offline is PAUSED and replayed
+// automatically on reconnect — a built-in mutation queue. The OfflineBanner shows
+// the state and how many writes are waiting.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      networkMode: 'offlineFirst',
+      staleTime: 30_000,
+      gcTime: 24 * 60 * 60 * 1000, // keep cache a day so a reload offline still paints
+      retry: 2,
+      refetchOnReconnect: true,
+    },
+    mutations: {
+      networkMode: 'online',
+      retry: 3,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 15_000),
+    },
+  },
+})
 
 // Report uncaught errors and unhandled rejections (Sentry when present).
 installGlobalErrorReporting()

--- a/frontend/src/shared/OfflineBanner.tsx
+++ b/frontend/src/shared/OfflineBanner.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Offline / unstable-connection indicator (task §2). Surfaces the connection
+// state from lib/connection.ts and, when writes are queued (React Query pauses
+// mutations while offline and replays them on reconnect), how many are waiting —
+// so a user on a flaky African mobile link knows their changes aren't lost.
+
+import { useEffect, useState } from 'react';
+import { useMutationState } from '@tanstack/react-query';
+import { CloudOff, RefreshCw } from 'lucide-react';
+import { subscribeConnection, getConnectionStatus, type ConnectionState } from '../lib/connection';
+import { useUIStore } from '../store/uiStore';
+
+export function OfflineBanner() {
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+
+  const [state, setState] = useState<ConnectionState>(getConnectionStatus().state);
+  useEffect(() => subscribeConnection((s) => setState(s.state)), []);
+
+  // Count paused (queued) mutations — the writes waiting for the connection.
+  const pausedCount = useMutationState({
+    filters: { status: 'pending' },
+    select: (m) => (m.state.isPaused ? 1 : 0),
+  }).reduce((a: number, b: number) => a + b, 0);
+
+  // Quiet while healthy; degraded shows only when there is queued work to explain.
+  if (state === 'online') return null;
+  if (state === 'degraded' && pausedCount === 0) return null;
+
+  const offline = state === 'offline';
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center gap-2 px-4 py-1.5 text-[12.5px] font-medium"
+      style={{
+        background: offline ? 'color-mix(in srgb,var(--critical) 16%,transparent)' : 'color-mix(in srgb,var(--medium) 16%,transparent)',
+        color: offline ? 'var(--critical)' : 'var(--medium)',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      {offline ? <CloudOff size={14} /> : <RefreshCw size={14} />}
+      <span>
+        {offline
+          ? tr('Hors ligne', 'Offline')
+          : tr('Connexion instable', 'Unstable connection')}
+        {pausedCount > 0 && (
+          <>
+            {' — '}
+            {tr(
+              `${pausedCount} modification(s) en attente d'envoi`,
+              `${pausedCount} change(s) waiting to sync`,
+            )}
+          </>
+        )}
+        {offline && pausedCount === 0 && (
+          <> — {tr('vos données restent consultables', 'your data stays viewable')}</>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/shared/system/ErrorBoundary.tsx
+++ b/frontend/src/shared/system/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Top-level error boundary. Catches render/lifecycle errors anywhere in the tree,
+// reports them (Sentry when present), and shows the branded 500 page with a
+// correlation id and a working way out — instead of React unmounting to a blank
+// white screen. Resetting on a route change lets the user navigate away from a
+// screen that threw.
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { reportError } from '../../lib/observability';
+import { ServerError } from './ServerError';
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  hasError: boolean;
+  errorId?: string;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const errorId = reportError(error, { componentStack: info.componentStack });
+    this.setState({ errorId });
+  }
+
+  private reset = () => this.setState({ hasError: false, errorId: undefined });
+
+  render() {
+    if (this.state.hasError) {
+      return <ServerError errorId={this.state.errorId} onRetry={this.reset} />;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/shared/system/Maintenance.tsx
+++ b/frontend/src/shared/system/Maintenance.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Wrench, RefreshCw } from 'lucide-react';
+import { useUIStore } from '../../store/uiStore';
+import { SystemMessage } from './SystemMessage';
+
+export function Maintenance() {
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  return (
+    <SystemMessage
+      icon={Wrench}
+      tone="var(--medium)"
+      title={tr('Maintenance en cours', 'Under maintenance')}
+      message={tr(
+        "OpenRisk est momentanément indisponible pour une opération de maintenance planifiée. Merci de réessayer dans quelques minutes.",
+        'OpenRisk is briefly unavailable for planned maintenance. Please try again in a few minutes.',
+      )}
+      actions={
+        <button
+          onClick={() => window.location.reload()}
+          className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
+          style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+        >
+          <RefreshCw size={16} /> {tr('Réessayer', 'Retry')}
+        </button>
+      }
+    />
+  );
+}

--- a/frontend/src/shared/system/NotFound.tsx
+++ b/frontend/src/shared/system/NotFound.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { useNavigate } from 'react-router';
+import { Compass, ArrowLeft, Home } from 'lucide-react';
+import { useUIStore } from '../../store/uiStore';
+import { SystemMessage } from './SystemMessage';
+
+export function NotFound() {
+  const navigate = useNavigate();
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  return (
+    <SystemMessage
+      icon={Compass}
+      code="404"
+      title={tr('Page introuvable', 'Page not found')}
+      message={tr(
+        "Cette page n'existe pas ou a été déplacée. Vérifiez l'adresse, ou revenez à un point connu.",
+        "This page doesn't exist or has moved. Check the address, or head back to a known spot.",
+      )}
+      actions={
+        <>
+          <button
+            onClick={() => navigate(-1)}
+            className="h-10 px-4 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold"
+            style={{ border: '1px solid var(--border)', color: 'var(--ink)' }}
+          >
+            <ArrowLeft size={16} /> {tr('Retour', 'Back')}
+          </button>
+          <button
+            onClick={() => navigate('/')}
+            className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
+            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+          >
+            <Home size={16} /> {tr('Tableau de bord', 'Dashboard')}
+          </button>
+        </>
+      }
+    />
+  );
+}

--- a/frontend/src/shared/system/ServerError.tsx
+++ b/frontend/src/shared/system/ServerError.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { AlertOctagon, RefreshCw, Home } from 'lucide-react';
+import { useUIStore } from '../../store/uiStore';
+import { SystemMessage } from './SystemMessage';
+
+interface ServerErrorProps {
+  /** Correlation id shown to the user so support can find the trace. */
+  errorId?: string;
+  /** Retry handler (reset the boundary); falls back to a full reload. */
+  onRetry?: () => void;
+}
+
+export function ServerError({ errorId, onRetry }: ServerErrorProps) {
+  const lang = useUIStore((s) => s.lang);
+  const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  return (
+    <SystemMessage
+      icon={AlertOctagon}
+      code="500"
+      tone="var(--critical)"
+      title={tr('Une erreur est survenue', 'Something went wrong')}
+      message={tr(
+        "Un problème inattendu s'est produit de notre côté. L'incident a été enregistré. Réessayez, ou revenez au tableau de bord.",
+        'An unexpected problem occurred on our side. The incident was logged. Try again, or return to the dashboard.',
+      )}
+      actions={
+        <>
+          <button
+            onClick={() => (onRetry ? onRetry() : window.location.reload())}
+            className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
+            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+          >
+            <RefreshCw size={16} /> {tr('Réessayer', 'Try again')}
+          </button>
+          <a
+            href="/"
+            className="h-10 px-4 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold"
+            style={{ border: '1px solid var(--border)', color: 'var(--ink)' }}
+          >
+            <Home size={16} /> {tr('Tableau de bord', 'Dashboard')}
+          </a>
+        </>
+      }
+    >
+      {errorId && (
+        <div className="text-[11.5px] text-ink-muted mono">
+          {tr('Référence', 'Reference')} : {errorId}
+        </div>
+      )}
+    </SystemMessage>
+  );
+}

--- a/frontend/src/shared/system/SystemMessage.tsx
+++ b/frontend/src/shared/system/SystemMessage.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Shared layout for the system pages (404 / 500 / maintenance / access denied).
+// Branded, theme-aware (paints its own tokens), and quiet under
+// prefers-reduced-motion (the subtle fade is gated by the global reduced-motion
+// rule in index.css). Every system page offers a way out — a dead end is a bug.
+
+import type { ReactNode } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { OpenRiskLogo } from '../Logo';
+
+interface SystemMessageProps {
+  icon: LucideIcon;
+  /** Short status code shown large, e.g. "404" / "500". Optional. */
+  code?: string;
+  title: string;
+  message: ReactNode;
+  /** Primary + secondary actions (buttons/links), rendered in order. */
+  actions?: ReactNode;
+  /** Accent colour token for the icon, defaults to the muted ink. */
+  tone?: string;
+  /** Extra content below the message (e.g. an error id, a permission chip). */
+  children?: ReactNode;
+}
+
+export function SystemMessage({ icon: Icon, code, title, message, actions, tone, children }: SystemMessageProps) {
+  return (
+    <div
+      role="alert"
+      className="min-h-screen w-full flex items-center justify-center p-6"
+      style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}
+    >
+      <div className="max-w-md w-full text-center or-fadeup">
+        <div className="flex justify-center mb-6">
+          <OpenRiskLogo size={34} />
+        </div>
+
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5 mx-auto"
+          style={{ background: 'var(--bg-hover)', color: tone ?? 'var(--text-muted)' }}
+        >
+          <Icon size={28} strokeWidth={1.7} />
+        </div>
+
+        {code && (
+          <div className="disp mono text-[40px] font-bold leading-none mb-2" style={{ color: tone ?? 'var(--text-muted)' }}>
+            {code}
+          </div>
+        )}
+
+        <h1 className="text-[18px] font-semibold text-ink mb-2">{title}</h1>
+        <div className="text-[13.5px] text-ink-soft leading-relaxed mb-5">{message}</div>
+
+        {children}
+
+        {actions && <div className="flex items-center justify-center gap-2.5 mt-5 flex-wrap">{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,4 +24,44 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    // Perf budget (task §2): keep the INITIAL bundle small. Feature pages are
+    // already route-split with React.lazy; here we additionally split the heavy
+    // vendors into their own long-cached chunks so the entry chunk stays lean and
+    // a library upgrade never busts the whole app's cache. Charting (recharts) is
+    // only pulled by the lazy chart routes, so it never lands in the entry.
+    chunkSizeWarningLimit: 300,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          // Heavy, rarely-on-first-paint libraries: their own chunks so they load
+          // only with the routes that use them and never bloat the entry.
+          if (id.includes('recharts') || id.includes('d3-') || id.includes('victory') || id.includes('internmap'))
+            return 'charts'
+          if (id.includes('@zxcvbn-ts')) return 'zxcvbn' // password-strength dictionaries (huge)
+          if (id.includes('leaflet')) return 'maps'
+          if (id.includes('@hello-pangea') || id.includes('react-grid-layout') || id.includes('react-resizable'))
+            return 'dnd'
+          if (id.includes('lodash')) return 'lodash'
+          if (id.includes('date-fns')) return 'datefns'
+          if (id.includes('react-hook-form') || id.includes('@hookform') || id.includes('/zod/'))
+            return 'forms'
+          if (id.includes('react-confetti') || id.includes('use-sound') || id.includes('howler'))
+            return 'celebrate'
+          if (id.includes('@floating-ui')) return 'floating'
+          if (id.includes('react-use')) return 'reactuse'
+          if (id.includes('zxcvbn')) return 'zxcvbn'
+          if (id.includes('framer-motion') || id.includes('popmotion') || id.includes('@motionone'))
+            return 'motion'
+          if (id.includes('@tanstack')) return 'query'
+          if (id.includes('react-router')) return 'router'
+          if (id.includes('lucide-react')) return 'icons'
+          if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/scheduler/'))
+            return 'react'
+          return 'vendor'
+        },
+      },
+    },
+  },
 })

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,7 +1,7 @@
-// Accessibility (UX — WCAG 2.1 AA): axe-core on 6 key screens. Always attaches the
-// full violations report as an artifact. The DoD target is zero serious/critical;
-// screens that violate today are quarantined in A11Y_KNOWN (test.fixme with a bug
-// id) so the gate stays green while the violations stay named in the audit.
+// Accessibility (WCAG 2.2 AA — task §1): axe-core across the primary screens (incl.
+// a 404). Always attaches the full violations report as an artifact. The gate is
+// zero serious/critical; screens that violate today are quarantined in A11Y_KNOWN
+// (test.fixme with a bug id) so the gate stays green while violations stay named.
 
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
@@ -15,7 +15,16 @@ const SCREENS: { path: string; name: string }[] = [
   { path: '/compliance', name: 'Compliance' },
   { path: '/vulnerabilities', name: 'Vulnerabilities' },
   { path: '/analytics', name: 'Executive dashboard' },
+  { path: '/analytics/financial', name: 'Financial dashboard' },
+  { path: '/assets', name: 'Asset inventory' },
+  { path: '/mitigations', name: 'Mitigations' },
+  { path: '/incidents', name: 'Incidents' },
+  { path: '/automation/rules', name: 'Automation' },
+  { path: '/governance', name: 'Governance' },
+  { path: '/reports', name: 'Reports' },
   { path: '/settings', name: 'Settings' },
+  { path: '/settings?tab=billing', name: 'Billing' },
+  { path: '/this-route-does-not-exist', name: '404 page' },
 ];
 
 // path -> OR-BUG id for screens with unresolved serious/critical violations.
@@ -30,7 +39,8 @@ for (const screen of SCREENS) {
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
 
     const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      // WCAG 2.2 AA (task §1): include the 2.2 rule tags on top of 2.0/2.1.
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
       .analyze();
 
     await info.attach(`axe-${screen.name}.json`, {


### PR DESCRIPTION
## Bank-grade quality hardening

Raises OpenRisk toward the quality bar you'd defend in front of a bank. Six areas;
each item below is either **enforced in CI** or **honestly documented as a gap** —
see `docs/QUALITY.md` for the full green-vs-amber map.

### 1. Accessibility — WCAG 2.2 AA
- axe-core CI gate expanded to **15 screens** with the **`wcag22a/aa`** tags, zero serious/critical enforced.
- **Skip-to-content** link (2.4.1), a strong theme-aware **`:focus-visible`** ring (2.4.7/2.4.11), `id=main-content`.
- prefers-reduced-motion + aria-live already in place; 403 already names the missing permission.

### 2. Performance budget — BLOCKING in CI
- **Initial bundle ~1.4 MB → ~236 KB gzip**, under the **250 KB** budget enforced by `scripts/check-bundle-budget.mjs` (`npm run budget`) in the build job.
- Root cause: the **zxcvbn dictionaries (~1.1 MB) loaded on the login page** — now on-demand. Vendor `manualChunks`; auth screens / create-risk modal / command palette lazy-loaded.
- **Offline tolerance:** React Query offline-first (SWR cache, 24h gcTime) + mutations pause-and-replay on reconnect (write queue) + an **OfflineBanner** showing pending writes.

### 4. Observability
- New **`reports_generated_total{kind}`** metric (board/compliance) alongside the existing `time_to_aha`, `activation_events`, `aha_reached`, `risks_created`.
- New auth-free **`GET /api/v1/status`** that **probes the real DB**, and a branded **public `/status` page** polling it every 30s.
- Dependency-free error reporter + ErrorBoundary (Sentry when its loader is present).

### 5. System pages
- Branded, theme-aware, reduced-motion-safe **404 / 500 / maintenance**; catch-all now renders a real 404 (not a silent redirect). A top-level **ErrorBoundary** shows the 500 page + a correlation id instead of a blank screen.

### 6. Coverage
- Critical-path **E2E specs** exist and run: signup→Aha, risk lifecycle, report generation, member invite/RBAC; **tenant isolation** is exhaustively unit-tested.
- Added a test for the new metric.

### 3. Responsive mobile
- Real mobile layouts shipped in prior UX passes (off-canvas nav, overflow tables, adaptive headers). Device-lab verification pending.

### Honest remainders (documented in `docs/QUALITY.md`)
- **Backend coverage is ~30% today** (the `pkg/`/`application` core is well-covered; handlers, repos, `main.go`, legacy `service` are the untested bulk). Target is **>70%**. I did **not** touch the existing 50% CI gate or fake a 70% gate — reaching 70% is a multi-day, one-module-per-PR ratchet, planned in the doc.
- OTLP trace **export** plugs into the already-vendored OpenTelemetry libs (not wired here to avoid a networked `go get`); Lighthouse-CI field budgets and iPhone 12 / Pixel 5 device verification are the next steps.

### Build status
`go build ./...` + `go vet` green; touched backend tests green; `tsc -b` + `vite build` green; `npm run budget` ✓ 238 KB ≤ 250 KB.
