### PR TITLE
feat/w0 01 transformation audit v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,6 @@ REDIS_URL=redis://localhost:6379/0
 # the same storage.Storage interface (see backend/pkg/storage).
 STORAGE_DRIVER=local
 STORAGE_LOCAL_PATH=./uploads
+# Org roles that MUST enrol MFA before holding a session (comma-separated).
+# Default admin,root. Empty string disables mandatory MFA enrolment entirely.
+MFA_REQUIRED_ROLES=admin,root

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ legacy_v1/
 secrets/
 backend/keys/
 /private_key.pem
-/public_key.pem
+/public_key.pembackend/openrisk-server

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test lint clean docker-build docker-up docker-down migrate seed dev install setup version sync-version check-version
+.PHONY: help build test lint clean docker-build docker-up docker-down migrate migrate-rollback migrate-status migrate-force seed dev install setup version sync-version check-version
 
 # ============================================================================
 # VERSION — single source of truth is the root VERSION file (see docs/VERSIONING.md)
@@ -44,6 +44,8 @@ help:
 	@echo "  💾 DATABASE"
 	@echo "     make migrate              - Run database migrations"
 	@echo "     make migrate-rollback     - Rollback last migration"
+	@echo "     make migrate-status       - Show current migration version + dirty flag"
+	@echo "     make migrate-force VERSION=<n> - Recover a DIRTY database (set version, clear dirty)"
 	@echo "     make seed                 - Seed database with sample data"
 	@echo "     make db-shell             - Open database shell (psql)"
 	@echo "     make db-test-shell        - Open test database shell"
@@ -199,14 +201,26 @@ migrate:
 	@echo "📊 Running database migrations..."
 	docker-compose up -d db
 	@sleep 2
-	cd backend && go run ./cmd/server migrate up
+	cd backend && MIGRATIONS_DIR=../migrations go run ./cmd/server migrate up
 	@echo "✅ Migrations complete"
 
 migrate-rollback:
 	@echo "⏮️  Rolling back last migration..."
 	docker-compose up -d db
 	@sleep 2
-	cd backend && go run ./cmd/server migrate down
+	cd backend && MIGRATIONS_DIR=../migrations go run ./cmd/server migrate down
+
+migrate-status:
+	@echo "🔎 Current migration version..."
+	cd backend && MIGRATIONS_DIR=../migrations go run ./cmd/server migrate version
+
+# Recovery for a DIRTY database (a migration that failed mid-apply). Set VERSION
+# to the last known-good migration, then re-run `make migrate`.
+# Example: make migrate-force VERSION=47
+migrate-force:
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make migrate-force VERSION=<known_good_version>"; exit 1; fi
+	@echo "🔧 Forcing migration version to $(VERSION) (clears dirty flag)..."
+	cd backend && MIGRATIONS_DIR=../migrations go run ./cmd/server migrate force $(VERSION)
 	@echo "✅ Rollback complete"
 
 seed:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -713,9 +714,22 @@ func main() {
 	// and REQUIRES it for admin/root: those accounts can change permissions across
 	// the tenant and mint API tokens, so a password alone is not a proportionate
 	// gate. Members keep MFA optional.
+	// Which org roles must hold MFA is a deployment policy. Default admin+root
+	// (privileged accounts); a deployment onboarding non-technical members who may
+	// lack an authenticator can widen or narrow it via MFA_REQUIRED_ROLES
+	// (comma-separated; empty string disables mandatory enrolment entirely).
+	mfaRequiredRoles := []string{"admin", "root"}
+	if v, ok := os.LookupEnv("MFA_REQUIRED_ROLES"); ok {
+		mfaRequiredRoles = mfaRequiredRoles[:0]
+		for _, r := range strings.Split(v, ",") {
+			if r = strings.TrimSpace(r); r != "" {
+				mfaRequiredRoles = append(mfaRequiredRoles, r)
+			}
+		}
+	}
 	loginUseCase := auth.NewLoginUseCase(userRepo, tokenManager, passwordHasher).
 		WithMFA(mfaRepo).
-		RequireMFAForRoles("admin", "root")
+		RequireMFAForRoles(mfaRequiredRoles...)
 	registerUseCase := auth.NewRegisterUseCase(userRepo, orgRepo, notificationService, passwordHasher).
 		// Anchors t0 for the time-to-Aha histogram.
 		WithActivation(activationRecorder)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -103,6 +103,19 @@ var (
 )
 
 func main() {
+	// Migration subcommand: `<server> migrate <up|down|force <version>|version>`.
+	// Handled FIRST, before config.LoadConfig() (which requires RSA keys and would
+	// panic) and before any DB/service init — migrations need only DATABASE_URL.
+	// This makes `make migrate`, `make migrate-rollback` and `make migrate-force`
+	// real migration operations; previously the binary ignored its arguments and
+	// these targets silently booted the whole server instead.
+	if len(os.Args) > 1 && os.Args[1] == "migrate" {
+		if err := migrations.RunCLI(os.Args[2:]); err != nil {
+			log.Fatalf("%v", err)
+		}
+		return
+	}
+
 	// =========================================================================
 	// 1. CONFIGURATION & INFRASTRUCTURE
 	// =========================================================================

--- a/backend/internal/application/auth/mfa_usecase.go
+++ b/backend/internal/application/auth/mfa_usecase.go
@@ -94,8 +94,17 @@ func (uc *SetupMFAUseCase) Execute(ctx context.Context, input SetupMFAInput) (*S
 		return nil, fmt.Errorf("failed to store MFA secret: %w", err)
 	}
 
-	// Generate backup codes
-	backupCodes := otp.GenerateBackupCodes()
+	// Generate backup codes (CSPRNG, unique per user — see otp.GenerateBackupCodes).
+	backupCodes, err := otp.GenerateBackupCodes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate backup codes: %w", err)
+	}
+
+	// Replace any previously-issued codes for this user so re-enrolment
+	// invalidates the old set (defence in depth against a stale/compromised set).
+	if err := uc.mfaRepo.DeleteBackupCodes(ctx, input.UserID, input.TenantID); err != nil {
+		return nil, fmt.Errorf("failed to clear previous backup codes: %w", err)
+	}
 
 	// Hash and store backup codes
 	var hashedCodes []*domain.MFABackupCode

--- a/backend/internal/application/risk/create_risk.go
+++ b/backend/internal/application/risk/create_risk.go
@@ -158,6 +158,11 @@ func (uc *CreateRiskUseCase) Execute(ctx context.Context, orgID uuid.UUID, input
 
 	// 3. Compute score (Claude.md formula: P × I, score engine can override later)
 	risk.Score = risk.Impact * risk.Probability
+	// Band the score synchronously so the create response is self-consistent
+	// (score and criticality agree) instead of returning the default 'low' until
+	// the async ScoreWorker runs ~2s later. The worker refines it once asset
+	// criticality is folded in; both move together (audit-2026 #246).
+	risk.Criticality = domain.CriticalityFromScore(risk.Score)
 
 	// 4. Persist
 	if err := uc.riskRepo.Create(ctx, risk); err != nil {

--- a/backend/internal/application/risk/update_risk.go
+++ b/backend/internal/application/risk/update_risk.go
@@ -195,8 +195,11 @@ func (uc *UpdateRiskUseCase) Execute(ctx context.Context, orgID uuid.UUID, riskI
 		risk.AssignedTo = risk.AssigneeID
 	}
 
-	// 3. Recompute score
+	// 3. Recompute score + band it synchronously so the update response is
+	// self-consistent (score and criticality agree) rather than showing a stale
+	// band until the async ScoreWorker runs (audit-2026 #246).
 	risk.Score = risk.Impact * risk.Probability
+	risk.Criticality = domain.CriticalityFromScore(risk.Score)
 
 	// 4. Persist
 	if err := uc.riskRepo.Update(ctx, risk); err != nil {

--- a/backend/internal/domain/risk.go
+++ b/backend/internal/domain/risk.go
@@ -47,6 +47,25 @@ const (
 	RiskCriticalityCritical CriticalityLevel = "CRITICAL"
 )
 
+// CriticalityFromScore maps a raw Score Engine score (P × I × AC) to its
+// severity band using the canonical thresholds (>=7 critical, >=4 high,
+// >=2 medium, <2 low). It returns the lowercase form the ScoreWorker persists,
+// so a value computed synchronously at create/update time agrees with the band
+// the worker later writes. Kept in the domain so every producer bands
+// identically (mirrors pkg/scoring engine.ToCriticality).
+func CriticalityFromScore(score float64) CriticalityLevel {
+	switch {
+	case score >= 7.0:
+		return CriticalityCriticalNew
+	case score >= 4.0:
+		return CriticalityHighNew
+	case score >= 2.0:
+		return CriticalityMediumNew
+	default:
+		return CriticalityLowNew
+	}
+}
+
 // RiskPhase represents the ISO 31000 risk-management lifecycle stage of a risk.
 // This is ORTHOGONAL to RiskStatus: Status is the resolution state
 // (open/mitigated/accepted/…) while Phase is where the risk sits in the

--- a/backend/internal/domain/risk_criticality_test.go
+++ b/backend/internal/domain/risk_criticality_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package domain
+
+import "testing"
+
+// TestCriticalityFromScore pins the synchronous band computation to the Score
+// Engine thresholds (>=7 critical, >=4 high, >=2 medium, <2 low), lowercase to
+// match what the ScoreWorker persists (audit-2026 #246).
+func TestCriticalityFromScore(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  CriticalityLevel
+	}{
+		{10.0, CriticalityCriticalNew},
+		{7.0, CriticalityCriticalNew},
+		{6.999, CriticalityHighNew},
+		{4.0, CriticalityHighNew},
+		{3.999, CriticalityMediumNew},
+		{2.0, CriticalityMediumNew},
+		{1.999, CriticalityLowNew},
+		{0.0, CriticalityLowNew},
+	}
+	for _, c := range cases {
+		if got := CriticalityFromScore(c.score); got != c.want {
+			t.Errorf("CriticalityFromScore(%v) = %q, want %q", c.score, got, c.want)
+		}
+	}
+}

--- a/backend/internal/handler/compliance_handler.go
+++ b/backend/internal/handler/compliance_handler.go
@@ -449,6 +449,12 @@ func (h *ComplianceHandler) ListControls(c *fiber.Ctx) error {
 	if err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "invalid framework id"})
 	}
+	// Verify the parent framework belongs to this tenant first, so a foreign or
+	// nonexistent framework returns 404 rather than 200 [] — consistent with the
+	// by-id convention everywhere else (audit-2026 #248).
+	if _, err := h.getFrameworkUC.Execute(c.UserContext(), tenantID(c), frameworkID); err != nil {
+		return writeAppError(c, err)
+	}
 	controls, err := h.listControlsUC.Execute(c.UserContext(), tenantID(c), frameworkID)
 	if err != nil {
 		return writeAppError(c, err)

--- a/backend/internal/handler/dashboard_handler.go
+++ b/backend/internal/handler/dashboard_handler.go
@@ -73,7 +73,7 @@ func GetDashboardStats(c *fiber.Ctx) error {
 	err := database.DB.Raw(`
 		SELECT
 			COUNT(*)                                                        AS total,
-			COUNT(*) FILTER (WHERE score >= 15.0)                           AS high,
+			COUNT(*) FILTER (WHERE score >= 4.0)                            AS high,
 			COUNT(*) FILTER (WHERE LOWER(status) = 'mitigated')             AS mitigated,
 			COUNT(*) FILTER (WHERE LOWER(status) IN ('in_progress','active')) AS in_progress,
 			COUNT(*) FILTER (WHERE
@@ -83,10 +83,17 @@ func GetDashboardStats(c *fiber.Ctx) error {
 				OR COALESCE(other_direct_cost_xaf, 0) > 0
 				OR (COALESCE(downtime_hours, 0) > 0 AND COALESCE(hourly_downtime_cost_xaf, 0) > 0)
 			)                                                               AS quantified,
-			COUNT(*) FILTER (WHERE score >= 20.0)                           AS critical,
-			COUNT(*) FILTER (WHERE score >= 15.0 AND score < 20.0)          AS high_band,
-			COUNT(*) FILTER (WHERE score >= 10.0 AND score < 15.0)          AS medium,
-			COUNT(*) FILTER (WHERE score < 10.0)                            AS low,
+			-- Severity bands MUST match the Score Engine (score = P x I x AC),
+			-- the same thresholds the register's criticality column is derived
+			-- from: >=7 critical, >=4 high, >=2 medium, <2 low. The previous
+			-- 20/15/10 thresholds assumed a 1-5 x 1-5 scale and reported 0
+			-- critical / 0 high on a register the register itself showed as
+			-- critical, contradicting /analytics/executive. Score is always set
+			-- and the bands partition fully, so critical+high+medium+low = total.
+			COUNT(*) FILTER (WHERE score >= 7.0)                            AS critical,
+			COUNT(*) FILTER (WHERE score >= 4.0 AND score < 7.0)           AS high_band,
+			COUNT(*) FILTER (WHERE score >= 2.0 AND score < 4.0)           AS medium,
+			COUNT(*) FILTER (WHERE score < 2.0)                            AS low,
 			COALESCE(AVG(score), 0)                                         AS avg_score
 		FROM risks
 		WHERE tenant_id = ? AND deleted_at IS NULL

--- a/backend/internal/handler/dashboard_severity_test.go
+++ b/backend/internal/handler/dashboard_severity_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestDashboardSeverity_MatchesScoreEngineBands pins /stats severity bucketing to
+// the Score Engine bands (score = P x I x AC): >=7 critical, >=4 high, >=2
+// medium, <2 low — the same thresholds the register's `criticality` column is
+// derived from. The previous 20/15/10 thresholds assumed a 1-5 x 1-5 scale and
+// reported 0 critical / 0 high on a register the register itself showed as
+// critical, contradicting /analytics/executive (audit-2026 #243).
+func TestDashboardSeverity_MatchesScoreEngineBands(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(
+		`CREATE TABLE risks (id TEXT PRIMARY KEY, tenant_id TEXT, score REAL, deleted_at DATETIME);`).Error)
+
+	tenant := uuid.New()
+	other := uuid.New()
+
+	// One risk per band plus the exact boundary values, in this tenant.
+	scores := []float64{
+		10.0, // critical
+		7.0,  // critical (>= 7 boundary)
+		6.999, // high  (< 7)
+		4.0,  // high  (>= 4 boundary)
+		3.999, // medium (< 4)
+		2.0,  // medium (>= 2 boundary)
+		1.999, // low   (< 2)
+		0.1,  // low
+	}
+	for _, s := range scores {
+		require.NoError(t, db.Exec(`INSERT INTO risks (id, tenant_id, score) VALUES (?,?,?)`,
+			uuid.NewString(), tenant.String(), s).Error)
+	}
+	// A high-scoring risk in ANOTHER tenant must not be counted.
+	require.NoError(t, db.Exec(`INSERT INTO risks (id, tenant_id, score) VALUES (?,?,?)`,
+		uuid.NewString(), other.String(), 30.0).Error)
+
+	var agg scalarAggregates
+	require.NoError(t, db.Raw(`
+		SELECT
+			COUNT(*)                                              AS total,
+			COUNT(*) FILTER (WHERE score >= 4.0)                  AS high,
+			COUNT(*) FILTER (WHERE score >= 7.0)                  AS critical,
+			COUNT(*) FILTER (WHERE score >= 4.0 AND score < 7.0)  AS high_band,
+			COUNT(*) FILTER (WHERE score >= 2.0 AND score < 4.0)  AS medium,
+			COUNT(*) FILTER (WHERE score < 2.0)                   AS low
+		FROM risks
+		WHERE tenant_id = ? AND deleted_at IS NULL
+	`, tenant.String()).Scan(&agg).Error)
+
+	require.Equal(t, int64(8), agg.Total, "only this tenant's risks")
+	require.Equal(t, int64(2), agg.Critical, "score 10 and 7.0")
+	require.Equal(t, int64(2), agg.HighBand, "score 6.999 and 4.0")
+	require.Equal(t, int64(2), agg.Medium, "score 3.999 and 2.0")
+	require.Equal(t, int64(2), agg.Low, "score 1.999 and 0.1")
+	require.Equal(t, int64(4), agg.High, "high-or-above KPI = high + critical")
+
+	// The bands must partition the register fully: no risk is uncounted or
+	// double-counted, so the dashboard total always reconciles.
+	require.Equal(t, agg.Total, agg.Critical+agg.HighBand+agg.Medium+agg.Low)
+}

--- a/backend/internal/handler/mitigation_handler.go
+++ b/backend/internal/handler/mitigation_handler.go
@@ -197,6 +197,19 @@ func ListMitigationsByRisk(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid risk ID"})
 	}
 
+	// Verify the parent risk belongs to this tenant. Without this the endpoint
+	// returned 200 [] for a foreign/nonexistent risk, which is inconsistent with
+	// the 404 convention every other by-id route follows (audit-2026 #248).
+	var riskCount int64
+	if err := database.DB.Table("risks").
+		Where("id = ? AND tenant_id = ? AND deleted_at IS NULL", riskID, ctx.OrganizationID).
+		Count(&riskCount).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to retrieve mitigations"})
+	}
+	if riskCount == 0 {
+		return c.Status(404).JSON(fiber.Map{"error": "risk not found"})
+	}
+
 	repo := repository.NewGormMitigationRepository(database.DB)
 	plans, err := repo.ListByRiskID(ctx.OrganizationID.String(), uuid.MustParse(riskID))
 	if err != nil {

--- a/backend/internal/handler/risk_handler.go
+++ b/backend/internal/handler/risk_handler.go
@@ -145,7 +145,7 @@ func (h *RiskHandler) TransitionPhase(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid input"})
 	}
 	if err := validation.GetValidator().Struct(input); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "details": err.Error()})
+		return badValidation(c, err)
 	}
 	if input.target() == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "details": "`to` is required"})
@@ -194,6 +194,23 @@ func (h *RiskHandler) ListTransitions(c *fiber.Ctx) error {
 		return writeAppError(c, err)
 	}
 	return c.JSON(view)
+}
+
+// badValidation renders validator errors as human-readable, per-field messages
+// (WHAT/WHY/HOW) instead of leaking the raw go-playground string
+// "Key: 'CreateRiskInput.Title' Error:Field validation..." (audit-2026 #245).
+// `errors` is a field→message map; `message` is a single summary line.
+func badValidation(c *fiber.Ctx, err error) error {
+	fields := validation.HumanizeErrors(err)
+	if len(fields) == 0 {
+		return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "message": "Some fields are invalid."})
+	}
+	first := ""
+	for _, m := range fields {
+		first = m
+		break
+	}
+	return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "message": first, "errors": fields})
 }
 
 // deref reads an optional string field as a plain one ("" when absent).
@@ -287,7 +304,7 @@ func (h *RiskHandler) CreateRisk(c *fiber.Ctx) error {
 	}
 
 	if err := validation.GetValidator().Struct(input); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "details": err.Error()})
+		return badValidation(c, err)
 	}
 
 	stdCtx := c.UserContext()
@@ -543,7 +560,7 @@ func (h *RiskHandler) UpdateRisk(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid input"})
 	}
 	if err := validation.GetValidator().Struct(input); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "validation_failed", "details": err.Error()})
+		return badValidation(c, err)
 	}
 
 	mwCtx := middleware.GetContext(c)

--- a/backend/internal/migrations/migrator.go
+++ b/backend/internal/migrations/migrator.go
@@ -6,59 +6,98 @@
 package migrations
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-// RunMigrations applies the additive SQL migration layer on top of the schema
-// GORM AutoMigrate has already built (see cmd/server/main.go: AutoMigrate is the
-// declared schema authority; this layer carries only what AutoMigrate cannot
-// express — triggers, CHECK constraints, and one-off data backfills). It reads
-// the directory named by MIGRATIONS_DIR (default "migrations", relative to the
-// process working directory) and expects DATABASE_URL in the
-// postgres://user:pass@host:port/dbname?sslmode=... form.
-//
-// It FAILS LOUDLY: a real initialization or apply error is returned so the
-// caller can abort the boot. A boot that silently continued on a half-applied
-// schema — the previous behaviour, which swallowed every error into a log line —
-// is exactly how a production database ends up in an unknowable state. The only
-// non-errors are "no DATABASE_URL" (nothing to do) and migrate.ErrNoChange
-// (already up to date).
-func RunMigrations() error {
+// newMigrate builds a migrate handle from DATABASE_URL and MIGRATIONS_DIR
+// (default "migrations", relative to the process working directory). The caller
+// owns the returned handle and must Close it.
+func newMigrate() (*migrate.Migrate, error) {
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		log.Println("migrations: DATABASE_URL not set — skipping SQL migration layer")
-		return nil
+		return nil, errNoDatabaseURL
 	}
-
 	dir := os.Getenv("MIGRATIONS_DIR")
 	if dir == "" {
 		dir = "migrations"
 	}
 	source := "file://" + dir
-
 	m, err := migrate.New(source, dbURL)
 	if err != nil {
-		return fmt.Errorf("migrations: initialize from %q: %w", source, err)
+		return nil, fmt.Errorf("migrations: initialize from %q: %w", source, err)
 	}
-	defer func() {
-		// Close releases the source and database handles; report but do not mask.
-		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
-			log.Printf("migrations: close: source=%v database=%v", srcErr, dbErr)
-		}
-	}()
+	return m, nil
+}
+
+// errNoDatabaseURL is a sentinel so callers can distinguish "nothing to do"
+// (no DATABASE_URL) from a real failure.
+var errNoDatabaseURL = errors.New("migrations: DATABASE_URL not set")
+
+// dirtyStateError renders an actionable operator message for a database left in
+// golang-migrate's "dirty" state — a previous migration that failed mid-apply.
+// The bare library error ("Dirty database version N. Fix and force version.")
+// tells an operator nothing about how to recover, so the boot appeared to crash
+// for no reason. This spells out the exact recovery path.
+func dirtyStateError(version uint) error {
+	return fmt.Errorf(`migrations: database is DIRTY at version %d — a previous migration failed mid-apply, so the schema state is unknown.
+
+Recovery:
+  1. Inspect the failed migration file (migrations/%04d_*.up.sql) and the DB, and finish or undo whatever it left half-done.
+  2. Mark the last KNOWN-GOOD version as the current one:
+        make migrate-force VERSION=<good_version>
+     (or: cd backend && DATABASE_URL=... go run ./cmd/server migrate force <good_version>)
+  3. Re-run the migrations / re-boot:
+        make migrate
+
+Boot aborts here on purpose rather than serving on a half-applied schema. See docs/runbooks/migrations.md`, version, version)
+}
+
+// RunMigrations applies the additive SQL migration layer on top of the schema
+// GORM AutoMigrate has already built (AutoMigrate is the declared schema
+// authority; this layer carries only what AutoMigrate cannot express — triggers,
+// CHECK constraints, one-off data backfills). It FAILS LOUDLY: a real apply
+// error aborts the boot rather than serving on a half-applied schema. The only
+// non-errors are "no DATABASE_URL" and migrate.ErrNoChange.
+//
+// A DIRTY database is reported with an actionable recovery message
+// (dirtyStateError) instead of the opaque library string.
+func RunMigrations() error {
+	m, err := newMigrate()
+	if errors.Is(err, errNoDatabaseURL) {
+		log.Println("migrations: DATABASE_URL not set — skipping SQL migration layer")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer closeMigrate(m)
+
+	// Detect a dirty state up front so the operator gets the recovery path, not
+	// the raw "Dirty database version N" string buried in an Up() failure.
+	if v, dirty, verr := m.Version(); verr == nil && dirty {
+		return dirtyStateError(v)
+	} else if verr != nil && !errors.Is(verr, migrate.ErrNilVersion) {
+		return fmt.Errorf("migrations: read current version: %w", verr)
+	}
 
 	if err := m.Up(); err != nil {
-		if err == migrate.ErrNoChange {
+		if errors.Is(err, migrate.ErrNoChange) {
 			log.Println("migrations: already up to date")
 			return nil
 		}
-		return fmt.Errorf("migrations: apply from %q: %w", source, err)
+		var dirtyErr migrate.ErrDirty
+		if errors.As(err, &dirtyErr) {
+			return dirtyStateError(uint(dirtyErr.Version))
+		}
+		return fmt.Errorf("migrations: apply: %w", err)
 	}
 
 	if v, dirty, verr := m.Version(); verr == nil {
@@ -67,4 +106,83 @@ func RunMigrations() error {
 		log.Println("migrations: applied successfully")
 	}
 	return nil
+}
+
+// RunCLI implements the `migrate` subcommand of the server binary so that
+// `make migrate`, `make migrate-rollback` and `make migrate-force` are real
+// operations rather than (as before) a full server boot that ignored its args.
+//
+// Usage: <server> migrate <up|down|force|version>
+//
+//	up            apply all pending migrations
+//	down          roll back exactly one migration
+//	force <ver>   set the version and CLEAR the dirty flag (recovery)
+//	version       print current version and dirty flag
+//
+// Returns nil on success so the caller can os.Exit(0).
+func RunCLI(args []string) error {
+	if len(args) == 0 {
+		return errors.New("migrate: expected a subcommand: up | down | force <version> | version")
+	}
+	m, err := newMigrate()
+	if errors.Is(err, errNoDatabaseURL) {
+		return errors.New("migrate: DATABASE_URL not set")
+	}
+	if err != nil {
+		return err
+	}
+	defer closeMigrate(m)
+
+	switch args[0] {
+	case "up":
+		if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			return fmt.Errorf("migrate up: %w", err)
+		}
+		printVersion(m)
+		return nil
+	case "down":
+		// One step only: a full down-migration is destructive and must be explicit.
+		if err := m.Steps(-1); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			return fmt.Errorf("migrate down: %w", err)
+		}
+		printVersion(m)
+		return nil
+	case "force":
+		if len(args) < 2 {
+			return errors.New("migrate force: expected a version number, e.g. `migrate force 47`")
+		}
+		v, convErr := strconv.Atoi(args[1])
+		if convErr != nil {
+			return fmt.Errorf("migrate force: invalid version %q: %w", args[1], convErr)
+		}
+		if err := m.Force(v); err != nil {
+			return fmt.Errorf("migrate force %d: %w", v, err)
+		}
+		log.Printf("migrate: forced version to %d (dirty flag cleared)", v)
+		return nil
+	case "version":
+		printVersion(m)
+		return nil
+	default:
+		return fmt.Errorf("migrate: unknown subcommand %q (want up | down | force <version> | version)", args[0])
+	}
+}
+
+func printVersion(m *migrate.Migrate) {
+	v, dirty, err := m.Version()
+	if errors.Is(err, migrate.ErrNilVersion) {
+		log.Println("migrate: no migrations applied yet (version=nil)")
+		return
+	}
+	if err != nil {
+		log.Printf("migrate: could not read version: %v", err)
+		return
+	}
+	log.Printf("migrate: version=%d dirty=%t", v, dirty)
+}
+
+func closeMigrate(m *migrate.Migrate) {
+	if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+		log.Printf("migrations: close: source=%v database=%v", srcErr, dbErr)
+	}
 }

--- a/backend/pkg/otp/totp.go
+++ b/backend/pkg/otp/totp.go
@@ -7,6 +7,7 @@ package otp
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"image/jpeg"
@@ -101,21 +102,41 @@ func VerifyTOTPWithCustomWindow(secret, code string, window uint) bool {
 	return valid
 }
 
-// GenerateBackupCodes generates 8 backup codes (12-character alphanumeric)
-// Each code should be used only once
-func GenerateBackupCodes() []string {
-	codes := make([]string, 8)
-	chars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-	seed := int64(0x1234567890abcdef)
+// backupCodeCount is how many single-use MFA backup codes are minted per user.
+const backupCodeCount = 8
 
-	for i := 0; i < 8; i++ {
-		code := make([]byte, 12)
-		for j := 0; j < 12; j++ {
-			// Simple pseudo-random using seed (not cryptographically secure)
-			seed = (seed*1103515245 + 12345) & 0x7fffffff
-			code[j] = chars[seed%int64(len(chars))]
+// backupCodeLength is the character length of each backup code.
+const backupCodeLength = 12
+
+// backupCodeAlphabet is a Crockford-style base32 alphabet (no 0/1/8/9 to avoid
+// O/I/B/g confusion). Its length is 32, an exact divisor of 256, so mapping a
+// uniform random byte with `b % 32` introduces no modulo bias.
+const backupCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+// GenerateBackupCodes returns backupCodeCount single-use MFA backup codes, each
+// backupCodeLength characters drawn uniformly from backupCodeAlphabet using
+// crypto/rand.
+//
+// SECURITY: every code MUST be independently unpredictable. A previous
+// implementation seeded a linear congruential generator with a hard-coded
+// constant, which made every user's codes identical and derivable from the
+// public source — a universal MFA bypass (CWE-330/338/798). Do not reintroduce
+// any deterministic seed here.
+func GenerateBackupCodes() ([]string, error) {
+	// One CSPRNG read for all codes; len(alphabet)==32 divides 256 evenly, so
+	// `b % 32` is unbiased.
+	raw := make([]byte, backupCodeCount*backupCodeLength)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, fmt.Errorf("failed to read CSPRNG for backup codes: %w", err)
+	}
+
+	codes := make([]string, backupCodeCount)
+	for i := 0; i < backupCodeCount; i++ {
+		code := make([]byte, backupCodeLength)
+		for j := 0; j < backupCodeLength; j++ {
+			code[j] = backupCodeAlphabet[raw[i*backupCodeLength+j]%byte(len(backupCodeAlphabet))]
 		}
 		codes[i] = string(code)
 	}
-	return codes
+	return codes, nil
 }

--- a/backend/pkg/otp/totp_test.go
+++ b/backend/pkg/otp/totp_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package otp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateBackupCodes_ShapeAndAlphabet asserts the count, length and that
+// every character is drawn from the documented alphabet.
+func TestGenerateBackupCodes_ShapeAndAlphabet(t *testing.T) {
+	codes, err := GenerateBackupCodes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(codes) != backupCodeCount {
+		t.Fatalf("expected %d codes, got %d", backupCodeCount, len(codes))
+	}
+	for i, c := range codes {
+		if len(c) != backupCodeLength {
+			t.Fatalf("code %d: expected length %d, got %d (%q)", i, backupCodeLength, len(c), c)
+		}
+		for _, r := range c {
+			if !strings.ContainsRune(backupCodeAlphabet, r) {
+				t.Fatalf("code %d contains char %q outside alphabet", i, r)
+			}
+		}
+	}
+}
+
+// TestGenerateBackupCodes_UniqueWithinCall guards against the historical bug
+// where all codes were identical/derived from one constant seed.
+func TestGenerateBackupCodes_UniqueWithinCall(t *testing.T) {
+	codes, err := GenerateBackupCodes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	seen := make(map[string]struct{}, len(codes))
+	for _, c := range codes {
+		if _, dup := seen[c]; dup {
+			t.Fatalf("duplicate backup code within a single call: %q", c)
+		}
+		seen[c] = struct{}{}
+	}
+}
+
+// TestGenerateBackupCodes_UniqueAcrossCalls is the regression test for the S0
+// finding: two users (two calls) MUST NOT receive the same codes. With a fixed
+// seed this failed (16/16 identical); with crypto/rand a collision is
+// astronomically unlikely.
+func TestGenerateBackupCodes_UniqueAcrossCalls(t *testing.T) {
+	a, err := GenerateBackupCodes()
+	if err != nil {
+		t.Fatalf("unexpected error (a): %v", err)
+	}
+	b, err := GenerateBackupCodes()
+	if err != nil {
+		t.Fatalf("unexpected error (b): %v", err)
+	}
+
+	all := make(map[string]struct{}, len(a)+len(b))
+	for _, c := range append(append([]string{}, a...), b...) {
+		if _, dup := all[c]; dup {
+			t.Fatalf("backup code %q appeared in two independent generations — codes are not unique per user", c)
+		}
+		all[c] = struct{}{}
+	}
+	if len(all) != len(a)+len(b) {
+		t.Fatalf("expected %d distinct codes across two calls, got %d", len(a)+len(b), len(all))
+	}
+}

--- a/backend/pkg/validation/validator.go
+++ b/backend/pkg/validation/validator.go
@@ -6,6 +6,9 @@
 package validation
 
 import (
+    "fmt"
+    "reflect"
+    "strings"
     "sync"
 
     "github.com/go-playground/validator/v10"
@@ -20,9 +23,71 @@ var (
 func GetValidator() *validator.Validate {
     once.Do(func() {
         v = validator.New()
-        // register uuid4 tag if needed (go-playground supports uuid validation)
+        // Report the JSON field name (not the Go struct field) in errors, so
+        // client-facing messages match the payload the caller actually sent.
+        v.RegisterTagNameFunc(func(fld reflect.StructField) string {
+            name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+            if name == "-" || name == "" {
+                return fld.Name
+            }
+            return name
+        })
     })
     return v
+}
+
+// HumanizeErrors turns validator output into a field→message map answering
+// WHAT/WHY/HOW instead of leaking the raw
+// "Key: 'CreateRiskInput.Title' Error:Field validation..." string
+// (audit-2026 #245). Returns nil if err is not a validator.ValidationErrors.
+func HumanizeErrors(err error) map[string]string {
+    var verrs validator.ValidationErrors
+    if err == nil {
+        return nil
+    }
+    var ok bool
+    if verrs, ok = err.(validator.ValidationErrors); !ok {
+        return nil
+    }
+    out := make(map[string]string, len(verrs))
+    for _, fe := range verrs {
+        field := fe.Field()
+        label := humanizeField(field)
+        param := fe.Param()
+        var msg string
+        switch fe.Tag() {
+        case "required":
+            msg = fmt.Sprintf("%s is required.", label)
+        case "email":
+            msg = fmt.Sprintf("%s must be a valid email address.", label)
+        case "uuid4", "uuid":
+            msg = fmt.Sprintf("%s must be a valid identifier.", label)
+        case "min":
+            msg = fmt.Sprintf("%s is too small (minimum %s).", label, param)
+        case "max":
+            msg = fmt.Sprintf("%s is too large (maximum %s).", label, param)
+        case "oneof":
+            msg = fmt.Sprintf("%s must be one of: %s.", label, strings.ReplaceAll(param, " ", ", "))
+        case "gte":
+            msg = fmt.Sprintf("%s must be at least %s.", label, param)
+        case "lte":
+            msg = fmt.Sprintf("%s must be at most %s.", label, param)
+        default:
+            msg = fmt.Sprintf("%s is invalid.", label)
+        }
+        out[field] = msg
+    }
+    return out
+}
+
+// humanizeField turns a json field name ("sle_xaf") into a readable label
+// ("Sle xaf").
+func humanizeField(name string) string {
+    s := strings.ReplaceAll(name, "_", " ")
+    if s == "" {
+        return s
+    }
+    return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // ValidateStruct validates a struct using go-playground/validator tags.

--- a/backend/pkg/validation/validator_test.go
+++ b/backend/pkg/validation/validator_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+type sample struct {
+	Title  string  `json:"title" validate:"required"`
+	Impact float64 `json:"impact" validate:"required,min=0,max=10"`
+	Email  string  `json:"email" validate:"omitempty,email"`
+}
+
+// TestHumanizeErrors_NoRawValidatorText is the regression for audit-2026 #245:
+// the client must never receive the raw "Key: 'sample.Title' Error:Field
+// validation for 'Title' failed on the 'required' tag" string.
+func TestHumanizeErrors_NoRawValidatorText(t *testing.T) {
+	err := GetValidator().Struct(sample{Impact: 20, Email: "not-an-email"})
+	msgs := HumanizeErrors(err)
+	if msgs == nil {
+		t.Fatal("expected validation errors, got none")
+	}
+	// json field names, not Go struct fields.
+	if _, ok := msgs["title"]; !ok {
+		t.Fatalf("expected a 'title' error keyed by json name, got keys %v", keys(msgs))
+	}
+	if got := msgs["title"]; !strings.Contains(got, "required") {
+		t.Errorf("title message = %q, want a human 'required' message", got)
+	}
+	if got := msgs["impact"]; !strings.Contains(got, "maximum") {
+		t.Errorf("impact message = %q, want a human 'maximum' message", got)
+	}
+	if got := msgs["email"]; !strings.Contains(strings.ToLower(got), "email") {
+		t.Errorf("email message = %q, want a human email message", got)
+	}
+	// No leakage of the raw validator format.
+	for _, m := range msgs {
+		if strings.Contains(m, "Key:") || strings.Contains(m, "Error:Field validation") {
+			t.Errorf("message leaks raw validator text: %q", m)
+		}
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/docs/audit/OPENRISK_TOTAL_AUDIT_2026-08-19.md
+++ b/docs/audit/OPENRISK_TOTAL_AUDIT_2026-08-19.md
@@ -1,0 +1,231 @@
+# OpenRisk — Audit total (QA · UX · Cybersécurité · Utilité métier)
+
+**Date :** 2026-08-19
+**Branche :** `feat/bank-grade-quality-hardening`
+**Mode :** Audit-only (Phases 0→8). **Aucune correction de code, aucune issue GitHub créée.** Les défauts sont observés, reproduits et documentés.
+**Testé LIVE contre la vraie pile** : backend Go (`:8080`), frontend Vite (`:5173`), Postgres (`:5434`), Redis. Deux tenants réels créés via le vrai flux d'inscription (`OpenRisk Demo Bank` / `OpenRisk Demo Insurance`), MFA enrôlé par TOTP calculé, sessions cookie + Bearer.
+
+> ⚠️ **Note d'environnement (setup, pas un correctif)** : la base de dev était bloquée `dirty` à la migration 40 → le binaire **refuse de démarrer** (voir BUG‑002). Pour pouvoir tester le produit, la table `schema_migrations` a été passée à `version=55, dirty=false` (AutoMigrate ayant déjà construit le schéma complet). C'est une manipulation d'état de la **DB de dev**, pas une modification de code.
+
+---
+
+## 1. Executive Verdict
+
+**OpenRisk est-il réellement prêt ? → NON (pas encore).**
+
+Le produit est étonnamment abouti pour son ampleur : le cœur GRC fonctionne *réellement* de bout en bout (inscription → onboarding contextuel → registre des risques → score → mitigation → preuve → rapport PDF), l'**isolation multi‑tenant est solide** (tous les accès inter‑tenant testés renvoient `404`, écritures bloquées, zéro fuite de données observée), les entrées sont parametrées (pas de SQLi), et les en‑têtes de sécurité sont corrects. C'est un socle crédible.
+
+**Mais** l'audit a trouvé **une vulnérabilité bloquante d'authentification prouvée en live** : les **codes de secours MFA sont identiques pour tous les utilisateurs** (générateur à graine constante) et **contournent la MFA en direct**. Comme la MFA est **imposée à chaque compte**, cela transforme le second facteur en une serrure à passe‑partout public. Tant que ce point n'est pas corrigé, **aucune mise en production n'est envisageable**.
+
+S'y ajoutent deux défauts d'intégrité de données qui minent la confiance sur l'écran d'atterrissage principal : le **tableau de bord d'accueil affiche « 0 risque / score 0 »** alors que le tenant a 11 risques (les endpoints renvoient pourtant les bons chiffres), et le calcul de sévérité de `/stats` **n'utilise pas les mêmes seuils que le Score Engine** (0 critique affiché vs 3 réels). Un RSSI qui regarde d'abord le dashboard conclurait « rien à signaler » — faux.
+
+---
+
+## 2. Scores globaux (/10)
+
+| Dimension | Note | Justification (preuves live) |
+|---|---:|---|
+| **Sécurité** | **3** | Isolation multi‑tenant excellente, SQLi safe, headers OK, RBAC/PAT enforce, IA anti‑escape — **mais** MFA bypass S0 prouvé (codes de secours universels). Un seul S0 plombe la note. |
+| **Fonctionnalités** | **8** | Cœur GRC complet et réellement fonctionnel (risque→score→mitigation→preuve→PDF), CRQ financier exact, state machine cycle de vie, onboarding contextuel. |
+| **UX** | **6** | Onboarding guidé de qualité, feedback d'import clair, i18n FR — mais friction MFA imposée pour néophyte, messages de validation bruts, dashboard trompeur. |
+| **Accessibilité** | **N/A (non auditée)** | Non testée cette session (axe-core non exécuté). À faire. |
+| **Performance** | **8** | Endpoints < 100 ms en local (health 74 ms, register < 1 s, /stats/exec instantanés). Pas de p99 sous charge mesuré. |
+| **Fiabilité** | **5** | Boot bloqué par migration dirty ; ScoreWorker async fiable ; pas de crash observé, mais dashboard incohérent. |
+| **Qualité des données** | **4** | Register et Executive cohérents avec le Score Engine ; `/stats` et le dashboard d'accueil incohérents (2 systèmes de seuils). |
+| **Valeur métier** | **8** | Résout de vrais problèmes : registre priorisé, ALE FCFA, conformité citée (ISO/ANTIC/COBAC), rapport présentable en comité. |
+| **Utilité cyber** | **7** | Priorisation, exposition financière, mapping conformité réels. Attack path/CTI non re-vérifiés cette session. |
+
+### 🎯 GLOBAL SCORE : **5.0 / 10** — « bon produit, bloqué par un défaut de sécurité critique et deux incohérences de données ».
+
+---
+
+## 3. Release readiness
+
+| Sévérité | Nombre |
+|---|---:|
+| **S0 — BLOCKER** | **1** |
+| **S1 — Critique** | **2** |
+| **S2 — Majeur** | **1** |
+| **S3 — Modéré** | **4** |
+| **S4 — Mineur** | **1** |
+
+**Verdict release : BLOQUÉ** par BUG‑001 (S0). Les S1 doivent suivre immédiatement.
+
+---
+
+## 4. Métriques mesurées
+
+| Métrique | Valeur observée |
+|---|---|
+| Signup → session (API) | < 1 s (register 201) mais **bloquant MFA obligatoire** avant Aha |
+| Onboarding → /risks | 5 étapes, complété manuellement, contextuel (banking + Cameroun) ✓ |
+| Report → PDF | 1 appel, **PDF valide 5 pages** (`application/pdf`, `%PDF-`) ✓ |
+| Health/API latency | `/api/v1/health` 74 ms ; register < 1 s ; /stats, /analytics/executive instantanés |
+| Écrans réellement pilotés | Login, MFA, Onboarding (5 étapes), Registre des risques, Dashboard d'accueil |
+| Tenant isolation tests | **~30 accès inter‑tenant → tous 404** (0 fuite) |
+| Permission (PAT) tests | read `risks:read`→200 ; delete/create hors‑scope→403 ✓ |
+| Injection | SQLi (3 payloads)→ table intacte ; XSS stocké → échappé par React ✓ |
+| Secrets en réponse | Aucun (creds jamais renvoyées ; JWT typés) |
+| MFA bypass | **PROUVÉ** — code de secours public accepté au challenge → session émise |
+
+---
+
+## 5. TOP 10 des problèmes (impact × sécurité × business ÷ effort)
+
+1. **BUG‑001 (S0) — Codes de secours MFA identiques pour tous → contournement MFA prouvé.** Effort de correction faible, impact maximal. **À corriger avant tout.**
+2. **BUG‑002 (S1) — Démarrage impossible (migration `dirty` à 40).** Bloque tout déploiement/CI ; effort faible.
+3. **BUG‑003 (S1) — Dashboard d'accueil affiche 0 risque / score 0** alors que 11 risques existent et que `/stats` renvoie 11/83. L'écran principal ment sur la posture.
+4. **BUG‑004 (S2) — Sévérité `/stats` calculée sur des seuils (≥20/≥15/≥10) qui ne correspondent PAS au Score Engine (≥7/≥4/≥2)** → 0 critique affiché vs 3 réels.
+5. **BUG‑006 (S3) — Message de validation brut** (`Key: 'CreateRiskInput.Title' Error:Field validation…`) exposé à l'utilisateur.
+6. **BUG‑008 (S3) — MFA imposée dès l'inscription** : un néophyte/juriste sans appli d'authentification est bloqué hors du produit (contre l'objectif « Aha < 8 min »).
+7. **BUG‑005 (S3) — Champ `level` figé à `medium`** quel que soit le score ; `RiskCard.tsx` colore la sévérité dessus.
+8. **BUG‑007 (S3) — Criticité renvoyée `low` pendant ~2 s** après création (recalcul async) : la réponse de création affiche une mauvaise bande.
+9. **BUG‑009 (S4) — Listes sous parent étranger renvoient `200 []` au lieu de `404`** (`/risks/:id/mitigations`, `/frameworks/:id/controls`) — incohérence de convention, sans fuite.
+10. *(Observation à vérifier)* — Le flux OAuth/SAML et les intégrations n'ont pas été exercés live (pas de credentials) ; à traiter comme non prouvés.
+
+---
+
+## 6. Moments d'abandon probables
+
+1. **Écran MFA à l'inscription** : « je voulais juste essayer, on me demande une appli d'authentification » → abandon néophyte.
+2. **Dashboard d'accueil à 0** : « j'ai créé mes risques, le tableau de bord dit 0 — l'outil ne marche pas » → perte de confiance immédiate.
+3. **Message de validation cryptique** en cas d'oubli d'un champ.
+4. **Impossible de démarrer** (opérateur/dev) : migration dirty → binaire quitte en erreur.
+
+---
+
+## 7. Fonctionnalités exceptionnelles (à conserver)
+
+- **Isolation multi‑tenant** : rigoureuse, convention `404` (pas `403`) respectée, écritures inter‑tenant bloquées. C'est le point le plus fort du produit.
+- **Onboarding contextuel** : référentiels suggérés selon secteur + pays (banking + Cameroun → ISO 31000/27005, ANTIC, COBAC), import inline avec feedback « Importé ».
+- **Score Engine + registre** : bandes exactes (10→Critique, 6.9→Élevé, 3.9→Moyen, 1.9→Faible), chip « Critique·3 » cohérent, XSS échappé.
+- **Quantification financière (CRQ)** : ALE = SLE×ARO exact, breakdown complet (pire‑cas, résiduel, ROSI), double devise XAF/USD.
+- **Rapport PDF** conforme et paginé, généré en un appel.
+- **IA anti‑escape** : RAG strictement tenant‑scoped, injection de prompt (« ignore permissions ») sans effet.
+
+---
+
+## 8. Fonctionnalités faibles / trompeuses
+
+- **Dashboard d'accueil** : donne une fausse lecture de la posture (0 partout) → *anti‑valeur* tant que BUG‑003 n'est pas corrigé.
+- **Deux systèmes de sévérité** cohabitent (Score Engine ≥7/≥4/≥2 vs `/stats` ≥20/≥15/≥10) : source d'incohérence structurelle.
+- **Champ `level`** : legacy figé, à supprimer ou recalculer.
+
+---
+
+## 9. Manques produit (constatés cette session)
+
+- Chemin de premier accès **sans MFA obligatoire** (ou MFA différable) pour l'Aha néophyte.
+- **Messages d'erreur** orientés utilisateur (QUOI / POURQUOI / QUE FAIRE).
+- **Accessibilité** (axe-core), **responsive** et **perf sous charge** : non audités → à planifier.
+
+---
+
+## 10. Matrice Néophyte → Expert (modules pilotés)
+
+| Module | Néophyte | Analyste | RSSI | Auditeur | Valeur |
+|---|---|---|---|---|---|
+| Inscription + MFA | ❌ (MFA impose une appli) | ✅ | ✅ | ⚠️ | Indispensable |
+| Onboarding | ✅ (guidé, contextuel) | ✅ | ✅ | ✅ | Utile |
+| Registre des risques | ✅ | ✅ | ✅ | ✅ | **Indispensable** |
+| Score Engine | ⚠️ (jargon) | ✅ | ✅ | ✅ | **Indispensable** |
+| Dashboard d'accueil | ❌ (chiffres faux) | ❌ | ❌ | ⚠️ | Trompeur (à réparer) |
+| Executive dashboard | ✅ | ✅ | ✅ | ✅ | Utile |
+| Conformité + PDF | ✅ | ✅ | ✅ | ✅ | Indispensable |
+| Quantification financière | ⚠️ | ✅ | ✅ | ✅ | Différenciant |
+| IA Advisor (template) | ✅ | ✅ | ✅ | ⚠️ | Utile |
+
+---
+
+## 11. Registre complet des défauts
+
+### BUG-001 — [S0 · security] Codes de secours MFA identiques pour tous les utilisateurs → contournement MFA prouvé en live
+- **Module / fichier** : Auth / `backend/pkg/otp/totp.go:106` `GenerateBackupCodes()`
+- **Type** : security / authentication-bypass
+- **Reproductibilité** : 100 %
+- **Étapes** :
+  1. Inscrire deux utilisateurs distincts (tenants différents) → chacun enrôle la MFA (`POST /auth/mfa/setup`).
+  2. Comparer les `backup_codes` renvoyés → **identiques** :
+     `['4F2LIBGHU5SD','AZ67MVK3YRWX','ENCTQJOP4F2L','IBGHU5SDAZ67','MVK3YRWXENCT','QJOP4F2LIBGH','U5SDAZ67MVK3','YRWXENCTQJOP']`
+  3. Se connecter avec **mot de passe seul** → `mfa_required` + `mfa_token`.
+  4. `POST /auth/mfa/challenge` avec `{"code":"4F2LIBGHU5SD"}` (code public, jamais fourni par l'app à cet attaquant) → **HTTP 200, `token_pair.access_token` émis**.
+- **Résultat attendu** : codes uniques par utilisateur, imprévisibles (`crypto/rand`).
+- **Résultat réel** : graine **constante** `seed := int64(0x1234567890abcdef)` + LCG déterministe (`seed = (seed*1103515245 + 12345) & 0x7fffffff`), commentaire du code : *« not cryptographically secure »*. Les 8 codes sont donc les **mêmes pour tout le monde** et **dérivables depuis les sources AGPL publiques**.
+- **Impact** : la MFA — **imposée à chaque compte** — n'offre aucune protection réelle. Tout attaquant disposant d'un mot de passe (phishing, réutilisation, fuite) obtient une session via un code de secours public. Faux sentiment de sécurité pour un produit qui vend la conformité.
+- **Correctif recommandé** : générer chaque code avec `crypto/rand` (≥ 128 bits d'entropie), un par utilisateur ; invalider les codes de secours déjà émis en base ; ré‑enrôlement forcé. Ajouter un test qui asserte l'unicité entre deux appels.
+- **Critères d'acceptation** : deux appels successifs → 16 codes tous distincts ; un code d'un utilisateur refusé pour un autre ; test de non‑régression.
+
+### BUG-002 — [S1 · reliability] Le backend refuse de démarrer (migration `dirty` version 40)
+- **Module** : boot / `golang-migrate` + `cmd/server/main.go`
+- **Étapes** : lancer le binaire sur la DB de dev en l'état → AutoMigrate réussit, puis `SQL migrations failed: Dirty database version 40. Fix and force version.` → **`exit code 1`**.
+- **Résultat réel** : l'application ne démarre pas du tout. Contourné pour l'audit via `UPDATE schema_migrations SET version=55, dirty=false`.
+- **Impact** : bloque déploiement, CI, tout onboarding d'un nouveau dev. Pré‑existant (documenté de longue date) mais toujours non résolu.
+- **Correctif** : corriger/rejouer la migration 0040 fautive, `migrate force`, et faire échouer proprement (ou avertir) plutôt que quitter en erreur ; réconcilier `migrations/` (0048–0055) avec l'historique `_archive`.
+
+> **⚠️ CORRECTION (post-remédiation, issue #242).** Après investigation approfondie, les « 0 » observés sont **majoritairement un artefact du harnais de test headless**, PAS un bug produit réel : les chiffres sont rendus via une animation `useCountUp` basée sur `requestAnimationFrame`, or **rAF est gelé quand le panneau navigateur n'est pas composité** (prouvé live : aucun callback rAF ne se déclenche). Le composant détient la bonne donnée (`kpis.total=12`, `ScoreGauge` lit `score.value=57.4`) → dans un vrai navigateur, il affiche 12 / 57. **Ce constat était surévalué (pas S1 data-integrity).** Deux faiblesses *réelles* trouvées en le confirmant ont été corrigées (`d85c3d0`) : absence de refresh de token (session morte après 15 min) + `useCountUp` non-robuste (désormais respecte `prefers-reduced-motion`). Le seul chiffre *réellement* faux sur le dashboard (« Critiques : 0 » vs 3) relève de **BUG-004** (seuils `/stats`), pas de celui-ci.
+
+### BUG-003 — [~~S1~~ → corrigé/reclassé · voir note] Le dashboard d'accueil affiche 0 risque / score 0 alors que 11 risques existent
+- **Module / fichier** : `frontend/src/features/dashboard/DashboardPage.tsx` (PostureDashboard) + `useStats.ts`
+- **Étapes** :
+  1. Tenant A a 11 risques (registre le confirme, chip « Critique·3 »).
+  2. Dans la **même session navigateur (cookie)** : `fetch('/api/v1/stats')` → `total_risks:11, global_risk_score:83` ; `fetch('/api/v1/risks?size=1')` → `total:11`.
+  3. Le dashboard `/` rend : **« Risques totaux : 0 », « Critiques : 0 », « Score de sécurité : 0/100 »** — persistant après rechargement complet (donc pas une course de premier rendu), sans erreur console.
+- **Résultat réel** : les cartes KPI et la jauge de score affichent 0 alors que la matrice et l'activité récente (mêmes données) sont peuplées. Défaut **localisé au frontend** (le payload correct n'atteint pas `KpiGrid`/`ScoreGauge`). La cause exacte de ligne nécessite un débogueur (hors périmètre observe‑only).
+- **Impact** : l'écran d'atterrissage principal ment sur la posture ; perte de confiance immédiate d'un RSSI.
+- **Correctif** : tracer `useDashboardStats` → `KpiGrid`/`ScoreGauge` ; ajouter un test qui monte le dashboard avec un `/stats` non‑vide et asserte les valeurs rendues.
+
+### BUG-004 — [S2 · data-integrity] `/stats` calcule la sévérité sur des seuils incompatibles avec le Score Engine
+- **Module / fichier** : `backend/internal/handler/dashboard_handler.go:86-89`
+- **Détail** : `/stats` bande sur le **score brut** : CRITICAL ≥ 20, HIGH 15–20, MEDIUM 10–15, LOW < 10. Or le Score Engine et le registre bandent à **≥7 / ≥4 / ≥2** (P×I×AC, max ~30). Résultat pour 11 risques identiques : `/stats` = `{CRITICAL:0, HIGH:0, LOW:9, MEDIUM:2}` alors que le **registre et l'Executive dashboard** = `{critical:3, high:2, medium:3, low:3}`.
+- **Preuve croisée** : `GET /analytics/executive` (`risk_distribution` + KRI `critical_risks:3`) **concorde avec le registre**, ce qui isole `/stats` comme fautif.
+- **Impact** : compteurs de sévérité faux sur le dashboard (0 critique affiché vs 3 réels), `high_risks:0`.
+- **Correctif** : bander `/stats` avec les seuils du Score Engine (≥7/≥4/≥2), ou mieux, réutiliser la colonne `criticality` déjà calculée par le ScoreWorker (source unique).
+
+### BUG-005 — [S3 · bug] Champ `level` de risque figé à `medium`
+- **Fichier** : DTO risque backend + `frontend/.../components/RiskCard.tsx:33` (`risk.level || 'MEDIUM'`).
+- **Détail** : `level` renvoie toujours `medium` (score 0.1 comme 10). Le registre principal lit `criticality` (correct via `riskMap.ts`), donc rayon de blast limité, mais `RiskCard` colore la sévérité sur `level` → toujours « medium ».
+- **Correctif** : supprimer `level` ou le dériver de `criticality` ; pointer `RiskCard` sur `criticality`.
+
+### BUG-006 — [S3 · ux] Messages de validation bruts exposés à l'utilisateur
+- **Étapes** : `POST /risks` sans titre → `400` avec `Key: 'CreateRiskInput.Title' Error:Field validation for 'Title' failed on the 'required' tag`.
+- **Impact** : jargon développeur, viole QUOI/POURQUOI/QUE FAIRE.
+- **Correctif** : mapper les erreurs de validation en messages humains i18n (« Le titre est obligatoire »).
+
+### BUG-007 — [S3 · ux] Criticité `low` renvoyée pendant ~2 s après création (recalcul async)
+- **Détail** : la réponse de `POST /risks` renvoie `criticality:"low"` jusqu'à ce que le ScoreWorker (Redis) recalcule (~2 s → `critical`). Tout client lisant la réponse de création immédiatement affiche une mauvaise bande.
+- **Correctif** : calculer la bande de façon synchrone dans la réponse de création (le score `P×I×AC` est déjà connu) ; garder le worker pour les recomputes.
+
+### BUG-008 — [S3 · ux/onboarding] MFA obligatoire dès l'inscription bloque l'Aha néophyte
+- **Détail** : après register, `login` renvoie `mfa_enrollment_required` — l'utilisateur DOIT enrôler un TOTP (appli d'authentification) avant de voir le produit. Sécurité‑positif mais contre l'objectif « premier insight < 8 min » pour un profil non technique.
+- **Correctif** : permettre l'exploration avant MFA, ou proposer email‑OTP, ou différer l'enrôlement avec une bannière — sans supprimer BUG‑001 d'abord.
+
+### BUG-009 — [S4 · security-hygiene] Listes sous parent étranger renvoient `200 []` au lieu de `404`
+- **Étapes** : en tant que Tenant B, `GET /risks/{risqueDuTenantA}/mitigations` → `200 []` ; idem `GET /compliance/frameworks/{étranger}/controls` → `200 []`.
+- **Impact** : **aucune fuite** (liste filtrée par tenant, `[]` retourné même pour un id inexistant), mais incohérent avec la convention `404` du reste de l'app.
+- **Correctif** : vérifier l'appartenance du parent et renvoyer `404` pour un parent étranger/inexistant.
+
+---
+
+## 12. Plan de correction (ordre recommandé)
+
+1. **Security blockers** — BUG‑001 (codes de secours MFA : `crypto/rand`, unicité, invalidation, ré‑enrôlement forcé). **Avant toute release.**
+2. **Reliability** — BUG‑002 (débloquer/rejouer la migration 0040 ; démarrage résilient).
+3. **Data integrity / core** — BUG‑003 (dashboard zéro) puis BUG‑004 (seuils `/stats`), idéalement en unifiant la sévérité sur la colonne `criticality`.
+4. **UX** — BUG‑006 (messages d'erreur), BUG‑008 (parcours MFA néophyte), BUG‑005/007 (`level`/async).
+5. **Hygiène** — BUG‑009 (`404` sous parent étranger).
+6. **À auditer ensuite (non couvert cette session)** — accessibilité (axe-core), responsive (375→1920), perf p95/p99 sous charge, OAuth2/SAML live, intégrations réelles, notifications, Attack Path/CTI, cycle mitigation→preuve→risque résiduel complet, les 34 parcours restants.
+
+---
+
+## Annexe — Ce qui a été prouvé PASS (avec preuve live)
+
+- **Isolation multi‑tenant** : `GET/PATCH/DELETE` sur risque/asset/vuln/incident/contrôle/framework d'un autre tenant → **404** ; écriture inter‑tenant bloquée (contrôle inchangé en DB vérifié) ; listes d'un tenant vide → `[]`.
+- **Score Engine** : `P×I×AC` exact ; bandes registre 7/4/2 exactes ; Executive dashboard cohérent avec le registre.
+- **Injection** : 3 payloads SQLi → `total=0`, table `risks` intacte ; `<script>` stocké → rendu inerte (React).
+- **Headers** : `Content-Security-Policy: default-src 'none'…`, `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`.
+- **RBAC / PAT** : PAT `risks:read` → `GET /risks` 200 ; `DELETE`/`POST` → **403** (`Missing required permission`).
+- **IA anti‑escape** : Tenant B (0 donnée) demandant les risques du Tenant A + « ignore permissions » → « no relevant item in your GRC knowledge base », `retrieved:null`.
+- **Auth** : enrôlement TOTP, challenge TOTP, refresh — fonctionnels (paire RS256, cookies + CSRF).
+- **Reporting** : PDF conformité **valide, 5 pages**.
+- **CRQ** : ALE = SLE 40 M × ARO 0.5 = **20 M XAF / 33 333 USD**, breakdown complet.
+- **Non‑auth** : routes protégées → `401` ; `/stats` fail‑closed.

--- a/docs/runbooks/migrations.md
+++ b/docs/runbooks/migrations.md
@@ -1,0 +1,52 @@
+# Runbook — Database migrations & recovery
+
+OpenRisk builds its schema in two layers:
+
+1. **GORM AutoMigrate** (the declared schema authority) runs on every boot and creates/updates all tables and columns from the Go models.
+2. **The additive SQL layer** (`migrations/NNNN_*.up.sql`, run by golang-migrate at boot) carries only what AutoMigrate cannot express: triggers, CHECK constraints, and one-off **data** backfills.
+
+The boot **fails loudly** if the SQL layer cannot be applied — the app must never serve on a half-applied schema.
+
+## Commands
+
+```bash
+make migrate            # apply all pending migrations
+make migrate-status     # print current version + dirty flag
+make migrate-rollback   # roll back exactly one migration
+make migrate-force VERSION=<n>   # recovery: set version, clear the dirty flag
+```
+
+These are backed by a real `migrate` subcommand on the server binary:
+
+```bash
+cd backend && DATABASE_URL=postgres://user:pass@host:port/db?sslmode=disable \
+  go run ./cmd/server migrate <up|down|force <version>|version>
+```
+
+## Recovering a DIRTY database
+
+golang-migrate marks the database **dirty** when a migration fails part-way. On the next boot you will see an actionable error naming the version, e.g.:
+
+```
+migrations: database is DIRTY at version 40 — a previous migration failed mid-apply ...
+```
+
+Recover:
+
+1. **Diagnose.** Open the failing migration (`migrations/00NN_*.up.sql`) and inspect the database. Decide whether it was partly applied.
+2. **Reconcile the schema by hand** if needed (finish or undo what the failed migration left behind). Because AutoMigrate also runs on boot, the tables/columns usually already exist — the dirty flag is the only thing blocking startup.
+3. **Force the last known-good version** (the one *before* the failed one):
+   ```bash
+   make migrate-force VERSION=<good_version>
+   ```
+4. **Re-run** and boot:
+   ```bash
+   make migrate
+   ```
+
+`force` only sets the recorded version and clears the dirty flag — it does **not** run any SQL. Point it at a version whose schema you have verified.
+
+## Notes
+
+- A **fresh** database boots cleanly with no manual steps: AutoMigrate builds the schema and the SQL layer applies from the baseline to head.
+- Historical migrations that predate the current baseline live in `migrations/_archive/` and are not applied by the live runner.

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -113,9 +113,11 @@ function PostureDashboard() {
   }, []);
 
   const critOf = (r: (typeof risks)[number]): Criticality =>
-    // The server's criticality, or nothing. Deriving a band from the number
+    // The server's criticality band (derived from the score by the ScoreWorker).
+    // `level` is a legacy field that is not reliably populated — it rendered
+    // every risk as medium. Prefer criticality; deriving a band from the number
     // here is the mapping that drifted away from the number itself.
-    (r.level?.toLowerCase() as Criticality) || 'low';
+    ((r.criticality ?? r.level)?.toLowerCase() as Criticality) || 'low';
 
   const { stats, loading: statsLoading, error: statsError } = useDashboardStats();
   // The canonical tenant score — the same query key the sidebar and /score use,

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ import { useAuthStore } from '../../hooks/useAuthStore';
 import { useUIStrings } from '../../shared/uiStrings';
 import { critColor, frameworkColor, softFill, type Criticality } from '../../shared/riskColors';
 import { useDashboardStats, type MatrixCell } from './useStats';
+import { useCountUp } from './shared';
 import { useScore } from '../../hooks/useScore';
 import { ScoreGauge } from '../../shared/ScoreGauge';
 import { EmptyState } from '../../shared/EmptyState';
@@ -38,24 +39,6 @@ import { ViewerDashboard } from './ViewerDashboard';
 import { ExecutiveDashboard } from '../analytics/ExecutiveDashboard';
 
 /* ---------------- helpers ---------------- */
-
-/** Numeric count-up over ~1.1s, ease-out cubic. Re-runs when target changes. */
-function useCountUp(target: number, duration = 1100): number {
-  const [value, setValue] = useState(0);
-  const raf = useRef<number>(0);
-  useEffect(() => {
-    const t0 = performance.now();
-    const tick = (now: number) => {
-      let p = Math.min(1, (now - t0) / duration);
-      p = 1 - Math.pow(1 - p, 3);
-      setValue(target * p);
-      if (p < 1) raf.current = requestAnimationFrame(tick);
-    };
-    raf.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf.current);
-  }, [target, duration]);
-  return value;
-}
 
 function polar(cx: number, cy: number, r: number, deg: number): [number, number] {
   const a = ((deg - 90) * Math.PI) / 180;

--- a/frontend/src/features/dashboard/__tests__/useCountUp.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/useCountUp.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// useCountUp is decoration over a real number. These tests pin the guarantee
+// that matters (audit-2026 #242): the figure it lands on is the DATA, and it
+// must be shown even when the count-up animation cannot or should not run —
+// reduced-motion, or an environment where requestAnimationFrame does not fire.
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCountUp } from '../shared';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('useCountUp', () => {
+  it('shows the target immediately under prefers-reduced-motion (no animation from 0)', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    );
+    const { result } = renderHook(() => useCountUp(12));
+    expect(result.current).toBe(12);
+  });
+
+  it('settles on the target when requestAnimationFrame never advances', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    );
+    // rAF that never invokes its callback (models a non-composited / background
+    // page). The displayed value must still be the real number, not a frozen 0.
+    vi.stubGlobal('requestAnimationFrame', undefined as unknown as typeof requestAnimationFrame);
+    const { result } = renderHook(() => useCountUp(57));
+    expect(result.current).toBe(57);
+  });
+});

--- a/frontend/src/features/dashboard/shared.tsx
+++ b/frontend/src/features/dashboard/shared.tsx
@@ -15,6 +15,24 @@ export function useCountUp(target: number, duration = 1100): number {
   const [value, setValue] = useState(0);
   const raf = useRef<number>(0);
   useEffect(() => {
+    // The count-up is decoration. The number it lands on is data. Show the real
+    // number immediately — without animating from 0 — whenever animation is
+    // unavailable or unwanted:
+    //   • prefers-reduced-motion: a WCAG 2.3.3 accessibility requirement.
+    //   • requestAnimationFrame absent (SSR / non-DOM test envs).
+    // requestAnimationFrame is also throttled to zero when the page is not
+    // being composited (a background tab, an off-screen render), which would
+    // otherwise freeze the displayed value at 0 — so falling back to the target
+    // keeps the figure correct rather than merely un-animated.
+    const reduce =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduce || typeof requestAnimationFrame === 'undefined') {
+      setValue(target);
+      return;
+    }
+    setValue(0);
     const t0 = performance.now();
     const tick = (now: number) => {
       let p = Math.min(1, (now - t0) / duration);

--- a/frontend/src/features/risks/components/RiskCard.tsx
+++ b/frontend/src/features/risks/components/RiskCard.tsx
@@ -25,12 +25,16 @@ interface RiskCardProps {
 }
 
 export const RiskCard = ({ risk, onClick }: RiskCardProps) => {
+  // Severity comes from the server-computed `criticality` band (derived from the
+  // score), NOT the legacy `level` field, which is not reliably populated and
+  // rendered every risk as MEDIUM regardless of score.
+  const band = (risk.criticality ?? risk.level ?? 'low').toString().toUpperCase();
   const riskLevelColor = {
     CRITICAL: 'bg-danger-surface border-danger/50',
     HIGH: 'bg-warning-surface border-warning/50',
     MEDIUM: 'bg-warning-surface border-warning/50',
     LOW: 'bg-info-surface border-accent-400/50',
-  }[risk.level || 'MEDIUM'] || 'bg-info-surface border-accent-400/50';
+  }[band] || 'bg-info-surface border-accent-400/50';
 
   return (
     <div

--- a/frontend/src/features/risks/components/__tests__/RiskCard.test.tsx
+++ b/frontend/src/features/risks/components/__tests__/RiskCard.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Regression for audit-2026 #244: RiskCard coloured severity from the legacy
+// `level` field, which is not reliably populated and rendered EVERY risk as
+// medium. Severity must come from the server-computed `criticality` band.
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RiskCard } from '../RiskCard';
+import type { Risk } from '../../../../hooks/useRiskStore';
+
+function make(partial: Partial<Risk>): Risk {
+  return { id: 'r1', title: 'T', score: 0, ...partial } as Risk;
+}
+
+function containerClass(risk: Risk): string {
+  const { container } = render(<RiskCard risk={risk} />);
+  return (container.firstElementChild as HTMLElement).className;
+}
+
+describe('RiskCard severity colour', () => {
+  it('colours from criticality, not the legacy level field', () => {
+    // level says MEDIUM (the stuck value) but criticality is critical.
+    const cls = containerClass(make({ criticality: 'critical', level: 'MEDIUM', score: 10 }));
+    expect(cls).toContain('bg-danger-surface');
+  });
+
+  it('gives critical and low distinct colours (no uniform medium)', () => {
+    const critical = containerClass(make({ criticality: 'critical', score: 10 }));
+    const low = containerClass(make({ criticality: 'low', score: 0.1 }));
+    expect(critical).toContain('bg-danger-surface');
+    expect(low).toContain('bg-info-surface');
+    expect(critical).not.toEqual(low);
+  });
+});

--- a/frontend/src/hooks/useRiskStore.ts
+++ b/frontend/src/hooks/useRiskStore.ts
@@ -60,6 +60,11 @@ export interface Risk {
   mitigations_count?: number;
   created_at?: string;
   updated_at?: string;
+  // Server-computed severity band (ScoreWorker), derived from score via the
+  // Score Engine bands. This is the source of truth for severity. `level` is a
+  // legacy field that is not reliably populated — prefer `criticality`.
+  criticality?: string;
+  /** @deprecated use `criticality` — `level` is not reliably populated. */
   level?: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
   // The single canonical lifecycle. status and lifecycle_phase are derived from
   // it server-side; this is the one that means anything.

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Regression tests for the api client's transparent refresh-and-retry on an
+// expired access token (audit-2026 #242): without it, every fetch-on-mount
+// widget rendered zeros the moment the 15-minute access token lapsed.
+
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { api } from '../api';
+import { getAccessToken, setAccessToken } from '../session';
+
+type MockCall = (config: unknown) => Promise<unknown>;
+
+const origAdapter = api.defaults.adapter;
+
+beforeEach(() => {
+  setAccessToken(null);
+  // Stub window.location so the failure path's redirect does not blow up jsdom.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { href: '' },
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  api.defaults.adapter = origAdapter;
+  vi.restoreAllMocks();
+});
+
+function expired(config: unknown) {
+  const err = new Error('401') as Error & { response?: unknown; config?: unknown };
+  err.response = { status: 401, data: { code: 'TOKEN_EXPIRED' }, headers: {}, config, statusText: '' };
+  err.config = config;
+  return err;
+}
+
+function ok(config: unknown, data: unknown) {
+  return { status: 200, statusText: 'OK', headers: {}, data, config };
+}
+
+describe('api interceptor — refresh & retry on TOKEN_EXPIRED', () => {
+  it('refreshes once and replays the request with the new token', async () => {
+    const post = vi
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ status: 200, data: { token_pair: { access_token: 'fresh-token' } } } as never);
+
+    let calls = 0;
+    const adapter: MockCall = async (config) => {
+      calls += 1;
+      if (calls === 1) throw expired(config);
+      return ok(config, { total_risks: 11 });
+    };
+    api.defaults.adapter = adapter as never;
+
+    const res = await api.get('/stats');
+
+    expect(calls).toBe(2); // original 401 + one retry
+    expect(post).toHaveBeenCalledTimes(1); // exactly one refresh
+    expect((res.data as { total_risks: number }).total_risks).toBe(11);
+    expect(getAccessToken()).toBe('fresh-token'); // in-memory token updated
+  });
+
+  it('shares a single refresh across concurrent expired requests', async () => {
+    const post = vi
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ status: 200, data: { token_pair: { access_token: 't' } } } as never);
+
+    const seen: Record<string, number> = {};
+    const adapter: MockCall = async (config) => {
+      const url = (config as { url: string }).url;
+      seen[url] = (seen[url] ?? 0) + 1;
+      if (seen[url] === 1) throw expired(config);
+      return ok(config, { url });
+    };
+    api.defaults.adapter = adapter as never;
+
+    await Promise.all([api.get('/a'), api.get('/b'), api.get('/c')]);
+
+    // Three requests expired together but only ONE refresh was issued.
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects to /login when the refresh itself fails', async () => {
+    vi.spyOn(axios, 'post').mockRejectedValue(new Error('refresh 401'));
+
+    const adapter: MockCall = async (config) => {
+      throw expired(config);
+    };
+    api.defaults.adapter = adapter as never;
+
+    await expect(api.get('/stats')).rejects.toBeTruthy();
+    expect(window.location.href).toBe('/login');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import axios from 'axios';
-import { CSRF_HEADER, getAccessToken, getCsrfToken } from './session';
+import { CSRF_HEADER, getAccessToken, getCsrfToken, setAccessToken } from './session';
 import { markApiFailure, markApiSuccess } from './connection';
 
 /**
@@ -60,13 +60,46 @@ api.interceptors.request.use((config) => {
 // too, even though their session is perfectly valid. Only force logout on genuine token failures.
 const TOKEN_ERROR_CODES = new Set(['TOKEN_EXPIRED', 'TOKEN_REVOKED', 'TOKEN_INVALID', 'UNAUTHORIZED']);
 
+// A single in-flight refresh shared by every request that 401s at once, so a
+// dashboard full of widgets that all expire together triggers ONE /auth/refresh,
+// not one per widget. Cleared when it settles so a later expiry can refresh
+// again. Returns whether a usable session was re-established.
+let refreshInFlight: Promise<boolean> | null = null;
+
+function refreshSession(): Promise<boolean> {
+  if (!refreshInFlight) {
+    // Bare axios (not `api`) so the refresh call never recurses through this
+    // interceptor. Cookie-based: the HttpOnly refresh cookie authenticates it;
+    // the CSRF header satisfies the double-submit check on this state change.
+    const csrf = getCsrfToken();
+    refreshInFlight = axios
+      .post(
+        `${baseURL}/auth/refresh`,
+        {},
+        { withCredentials: true, headers: csrf ? { [CSRF_HEADER]: csrf } : {} },
+      )
+      .then((res) => {
+        const token = res.data?.token_pair?.access_token as string | undefined;
+        if (token) setAccessToken(token);
+        return res.status === 200;
+      })
+      .catch(() => false);
+    // Null it out once settled — regardless of outcome — so the NEXT expiry
+    // starts a fresh refresh instead of reusing this resolved promise.
+    void refreshInFlight.finally(() => {
+      refreshInFlight = null;
+    });
+  }
+  return refreshInFlight;
+}
+
 api.interceptors.response.use(
   (response) => {
     // Feeds the header's connection indicator with a real observation.
     markApiSuccess();
     return response;
   },
-  (error) => {
+  async (error) => {
     if (error.response) {
       // The backend answered — the connection is fine even if the answer is 4xx.
       markApiSuccess();
@@ -75,9 +108,38 @@ api.interceptors.response.use(
       // connection fault, and the only thing the status dot may go amber for.
       markApiFailure();
     }
-    if (error.response?.status === 401 && TOKEN_ERROR_CODES.has(error.response?.data?.code)) {
+
+    const status = error.response?.status;
+    const code = error.response?.data?.code;
+    const original = error.config as (typeof error.config & { _retried?: boolean }) | undefined;
+
+    // Transparent refresh-and-retry: an access token that merely EXPIRED is
+    // recoverable from the long-lived refresh cookie. Without this, every
+    // fetch-on-mount widget (dashboard KPIs, score gauge, …) silently rendered
+    // zeros — or bounced the user to /login — the moment the 15-minute access
+    // token lapsed, even though a valid session cookie was one refresh away.
+    // Retry at most once per request, and never for the refresh call itself.
+    if (
+      status === 401 &&
+      code === 'TOKEN_EXPIRED' &&
+      original &&
+      !original._retried &&
+      !String(original.url ?? '').includes('/auth/refresh')
+    ) {
+      const ok = await refreshSession();
+      if (ok) {
+        original._retried = true;
+        return api(original); // replays with the refreshed token + cookies
+      }
+      // Refresh genuinely failed: the session is over, send them to login.
+      window.location.href = '/login';
+      return Promise.reject(error);
+    }
+
+    // A revoked/invalid token (or a bare UNAUTHORIZED) is not refreshable.
+    if (status === 401 && TOKEN_ERROR_CODES.has(code)) {
       window.location.href = '/login'; // Redirection forcée
     }
     return Promise.reject(error);
-  }
+  },
 );

--- a/migrations/0056_purge_compromised_mfa_backup_codes.down.sql
+++ b/migrations/0056_purge_compromised_mfa_backup_codes.down.sql
@@ -1,0 +1,2 @@
+-- Irreversible by design: the purged backup codes were compromised (universal,
+-- publicly derivable). There is nothing safe to restore. No-op.

--- a/migrations/0056_purge_compromised_mfa_backup_codes.up.sql
+++ b/migrations/0056_purge_compromised_mfa_backup_codes.up.sql
@@ -1,0 +1,6 @@
+-- Security fix (audit-2026, issue #240): every MFA backup code issued before the
+-- crypto/rand fix was generated from a hard-coded constant seed and was therefore
+-- identical across all users and derivable from public source. Purge them so the
+-- compromised universal codes can no longer satisfy an MFA challenge. Affected
+-- users regenerate fresh, unique codes by re-running MFA setup.
+DELETE FROM mfa_backup_codes;


### PR DESCRIPTION
- **fix(auth): generate MFA backup codes with crypto/rand, purge universal codes**
- **fix(migrations): real migrate subcommand + actionable dirty-state recovery**
- **fix(frontend): refresh session on expiry + show real figures without animation**
- **docs(audit): correct BUG-003 — dashboard zeros were a headless rAF artifact, not a data bug**
- **fix(dashboard): bucket /stats severity on Score Engine bands (7/4/2)**
- **fix(risks): colour severity from criticality, not the stuck level field**
- **fix(api): return 404 (not 200 []) for a foreign/nonexistent parent**
- **fix(risk): band criticality synchronously on create/update**
- **fix(validation): human, per-field messages instead of raw validator output**
- **feat(auth): make mandatory-MFA roles configurable via MFA_REQUIRED_ROLES**
