### PR TITLE
fix(ci): let the cache tests skip when Redis is absent

### DIFF
--- a/backend/internal/service/cache_service_test.go
+++ b/backend/internal/service/cache_service_test.go
@@ -13,12 +13,34 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+// redisForTest returns a client connected to a local Redis, or skips the test.
+//
+// These tests exercise the cache against a REAL Redis rather than a fake, which
+// is the right call — the behaviour under test is TTL handling, deletion and
+// single-flight callbacks, and a fake would be asserting the fake. But a test
+// that needs a server it did not start has to say so when the server is absent,
+// or it reports someone else's missing dependency as a defect in the code.
+//
+// Skipping is what the first test in this file already intended ("Skip if Redis
+// not available"); the others simply never got the same treatment, so every CI
+// job without a Redis service — including the release workflow, which has no
+// service containers at all — failed here and blocked the release.
+func redisForTest(t *testing.T) *redis.Client {
+	t.Helper()
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		t.Skipf("Redis is not reachable on localhost:6379, skipping: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
 func TestCacheService_SetAndGet(t *testing.T) {
-	// In-memory Redis for testing
-	client := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-	})
-	defer client.Close()
+	client := redisForTest(t)
 
 	cs := NewCacheService(client, 10*time.Second)
 	ctx := context.Background()
@@ -43,10 +65,7 @@ func TestCacheService_SetAndGet(t *testing.T) {
 }
 
 func TestCacheService_Delete(t *testing.T) {
-	client := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-	})
-	defer client.Close()
+	client := redisForTest(t)
 
 	cs := NewCacheService(client, 10*time.Second)
 	ctx := context.Background()
@@ -68,10 +87,7 @@ func TestCacheService_Delete(t *testing.T) {
 }
 
 func TestCacheService_TTL(t *testing.T) {
-	client := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-	})
-	defer client.Close()
+	client := redisForTest(t)
 
 	cs := NewCacheService(client, 10*time.Second)
 	ctx := context.Background()
@@ -91,10 +107,7 @@ func TestCacheService_TTL(t *testing.T) {
 }
 
 func TestCacheService_SetWithCallback(t *testing.T) {
-	client := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-	})
-	defer client.Close()
+	client := redisForTest(t)
 
 	cs := NewCacheService(client, 10*time.Second)
 	ctx := context.Background()


### PR DESCRIPTION
## What this unblocks

The release workflow for `v1.1.0-rc.2` **failed** here, so no GitHub release was
published:

```
--- FAIL: TestCacheService_Delete
--- FAIL: TestCacheService_TTL
--- FAIL: TestCacheService_SetWithCallback
FAIL  github.com/opendefender/openrisk/internal/service
```

## Root cause

Three of the four cache tests build a client against `localhost:6379` and then
assert on the result unconditionally. When nothing answers, a missing server is
reported as a defect in the cache service.

`release.yml` has **no service containers at all**, so this fails there every
time. It is not specific to the release: the same three fail in `ci.yml`'s
"Backend Unit Tests", including on the already-merged #330. Nothing about the
1.1.0-rc.2 release commit caused it — that commit changed only `VERSION`,
`Chart.yaml`, `package.json` and `CHANGELOG.md`. `git log` on the test file
shows it untouched since the Phase 0 / licensing work.

## The fix

The first test in the file already intended the right behaviour — its comment
says *"Skip if Redis not available"*. The other three never got the same
treatment. All four now go through one `redisForTest(t)` helper that pings first
and `t.Skip`s with the reason when nothing answers.

Testing against a **real** Redis stays deliberate: the behaviour under test is
TTL handling, deletion and single-flight callbacks, and a fake would only be
asserting the fake. But a test that needs a server it did not start has to say
so when that server is absent.

## Verification

| Condition | Result |
| --- | --- |
| Redis reachable (`localhost:6379`) | 4/4 **PASS** |
| Redis absent (pointed at a dead port) | 4/4 **SKIP**, package green |
| `go vet ./internal/service/` | clean |

## Note on scope

This is the minimum needed to let a release publish. It does not add a Redis
service to `release.yml` — that is a reasonable follow-up if you would rather
these tests actually *run* during a release than skip.