### PR TITLE
fix(membership): count pending invitations against the caller's clock (#409)

### DIFF
--- a/backend/internal/application/membership/organization.go
+++ b/backend/internal/application/membership/organization.go
@@ -77,7 +77,7 @@ func (s *Service) GetOrganization(ctx context.Context, tenantID uuid.UUID, canEd
 	if tz, ok := org.GetSettings()["timezone"].(string); ok {
 		view.Timezone = strings.TrimSpace(tz)
 	}
-	if counts, err := s.repo.Counts(ctx, tenantID); err == nil {
+	if counts, err := s.repo.Counts(ctx, tenantID, s.clock()); err == nil {
 		view.Counts = counts
 	}
 	if owner, err := s.users.GetByID(ctx, org.OwnerID); err == nil && owner != nil {
@@ -96,7 +96,7 @@ func (s *Service) Counts(ctx context.Context, tenantID uuid.UUID) (domain.Organi
 	if tenantID == uuid.Nil {
 		return domain.OrganizationCounts{}, domain.NewUnauthorizedError("no organization in context")
 	}
-	return s.repo.Counts(ctx, tenantID)
+	return s.repo.Counts(ctx, tenantID, s.clock())
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/application/membership/service_test.go
+++ b/backend/internal/application/membership/service_test.go
@@ -108,7 +108,7 @@ func (f *fakeRepo) CountActiveAdmins(_ context.Context, tenant uuid.UUID) (int, 
 	return n, nil
 }
 
-func (f *fakeRepo) Counts(_ context.Context, tenant uuid.UUID) (domain.OrganizationCounts, error) {
+func (f *fakeRepo) Counts(_ context.Context, tenant uuid.UUID, _ time.Time) (domain.OrganizationCounts, error) {
 	if f.failCounts {
 		return domain.OrganizationCounts{}, errors.New("counts unavailable")
 	}

--- a/backend/internal/domain/membership_repository.go
+++ b/backend/internal/domain/membership_repository.go
@@ -7,6 +7,7 @@ package domain
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -69,7 +70,12 @@ type MembershipRepository interface {
 	// CountActiveAdmins counts memberships that both grant access and hold an
 	// administrative role — the tenant's remaining administrative capacity.
 	CountActiveAdmins(ctx context.Context, tenantID uuid.UUID) (int, error)
-	Counts(ctx context.Context, tenantID uuid.UUID) (OrganizationCounts, error)
+	// Counts takes the instant to judge invitation expiry against, rather than
+	// reading the wall clock itself. The membership service owns a clock seam and
+	// the whole invitation lifecycle is written against it; a repository that
+	// calls time.Now() silently opts out of that seam and answers a different
+	// question from the service that called it.
+	Counts(ctx context.Context, tenantID uuid.UUID, asOf time.Time) (OrganizationCounts, error)
 
 	// Invitations
 	CreateInvitation(ctx context.Context, inv *Invitation) error

--- a/backend/internal/infrastructure/repository/gorm_membership_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_membership_repository.go
@@ -197,7 +197,7 @@ func (r *GormMembershipRepository) CountActiveAdmins(ctx context.Context, tenant
 
 // Counts computes the membership headline in two aggregate queries — one over
 // memberships, one over invitations — rather than one query per number.
-func (r *GormMembershipRepository) Counts(ctx context.Context, tenantID uuid.UUID) (domain.OrganizationCounts, error) {
+func (r *GormMembershipRepository) Counts(ctx context.Context, tenantID uuid.UUID, asOf time.Time) (domain.OrganizationCounts, error) {
 	var out domain.OrganizationCounts
 
 	// COUNT(*) FILTER is standard SQL and supported by both Postgres and the
@@ -229,9 +229,15 @@ func (r *GormMembershipRepository) Counts(ctx context.Context, tenantID uuid.UUI
 
 	// Pending counts what is actually still redeemable, so a stale invitation
 	// nobody revoked does not inflate the badge forever.
+	//
+	// The instant comes from the caller, not from time.Now(). This query used to
+	// read the wall clock while every other invitation path read the service's
+	// injected clock, so the two disagreed about whether the same row was
+	// expired — invisible in production, where both are the wall clock, and a
+	// wrong number the moment anything sets a clock.
 	if err := r.db.WithContext(ctx).
 		Model(&domain.Invitation{}).
-		Where("organization_id = ? AND status = ? AND expires_at > ?", tenantID, domain.InvitationPending, time.Now()).
+		Where("organization_id = ? AND status = ? AND expires_at > ?", tenantID, domain.InvitationPending, asOf).
 		Count(&out.PendingInvitations).Error; err != nil {
 		return out, err
 	}

--- a/backend/internal/infrastructure/repository/gorm_membership_repository_test.go
+++ b/backend/internal/infrastructure/repository/gorm_membership_repository_test.go
@@ -176,7 +176,7 @@ func TestMembershipRepo_LegacyNullStatusCountsAsActive(t *testing.T) {
 	if err != nil || n != 1 {
 		t.Fatalf("a legacy admin must count toward administrative capacity: %d %v", n, err)
 	}
-	counts, err := f.repo.Counts(ctx, f.tenantA)
+	counts, err := f.repo.Counts(ctx, f.tenantA, time.Now())
 	if err != nil {
 		t.Fatalf("counts: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestMembershipRepo_MembershipWrittenWithoutAStatusStillCountsAsActive(t *te
 	if err != nil || n != 1 {
 		t.Fatalf("an empty status must count toward administrative capacity: %d %v", n, err)
 	}
-	c, err := f.repo.Counts(ctx, f.tenantA)
+	c, err := f.repo.Counts(ctx, f.tenantA, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +449,7 @@ func TestMembershipRepo_Counts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, err := f.repo.Counts(ctx, f.tenantA)
+	c, err := f.repo.Counts(ctx, f.tenantA, time.Now())
 	if err != nil {
 		t.Fatalf("counts: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestMembershipRepo_Counts(t *testing.T) {
 	}
 
 	// Tenant B's numbers are its own — a shared counter is how a sidebar leaks.
-	cb, _ := f.repo.Counts(ctx, f.tenantB)
+	cb, _ := f.repo.Counts(ctx, f.tenantB, time.Now())
 	if cb.TotalMembers != 1 || cb.PendingInvitations != 1 || cb.Admins != 1 {
 		t.Fatalf("tenant B counts = %+v", cb)
 	}
@@ -471,3 +471,73 @@ func TestMembershipRepo_Counts(t *testing.T) {
 // Compile-time proof the concrete repository satisfies the port the use cases
 // depend on.
 var _ domain.MembershipRepository = (*GormMembershipRepository)(nil)
+
+// Counts judges invitation expiry against the instant it is GIVEN, not against
+// the wall clock.
+//
+// This is the regression test for #409. The pending-invitation counter used to
+// call time.Now() directly while the whole invitation lifecycle in
+// internal/application/membership reads the service's injected clock. In
+// production both are the wall clock, so the disagreement was invisible — but
+// any caller that sets a clock got two contradictory answers about the same
+// row: the service considered an invitation usable while the badge counted it
+// expired. It surfaced as a test that passed until real time overtook a fixture
+// whose clock was frozen in the past, and then failed every run afterwards.
+//
+// The predicate is `expires_at > asOf`, so an invitation expiring exactly AT
+// asOf is already gone. That boundary is asserted here so it cannot drift
+// silently into >=.
+func TestCounts_JudgesInvitationExpiryAgainstTheGivenInstant(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+
+	expiry := time.Date(2026, 8, 27, 9, 0, 0, 0, time.UTC)
+	inviter := uuid.New()
+	if err := f.db.Create(&domain.Invitation{
+		ID:             uuid.New(),
+		OrganizationID: f.tenantA,
+		Email:          "pending@a.io",
+		Role:           domain.RoleUser,
+		TokenHash:      "409regression",
+		Status:         domain.InvitationPending,
+		ExpiresAt:      expiry,
+		InvitedByID:    inviter,
+		LastSentAt:     expiry.Add(-7 * 24 * time.Hour),
+		SendCount:      1,
+	}).Error; err != nil {
+		t.Fatalf("seed invitation: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		asOf time.Time
+		want int64
+	}{
+		{"a day before expiry it is pending", expiry.Add(-24 * time.Hour), 1},
+		{"a second before expiry it is pending", expiry.Add(-time.Second), 1},
+		{"exactly at expiry it is gone", expiry, 0},
+		{"a day after expiry it is gone", expiry.Add(24 * time.Hour), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			counts, err := f.repo.Counts(ctx, f.tenantA, tc.asOf)
+			if err != nil {
+				t.Fatalf("counts: %v", err)
+			}
+			if counts.PendingInvitations != tc.want {
+				t.Fatalf("PendingInvitations at %s = %d, want %d — the counter is not "+
+					"using the instant it was given",
+					tc.asOf.Format(time.RFC3339), counts.PendingInvitations, tc.want)
+			}
+		})
+	}
+
+	// And it stays tenant-scoped: tenant B never sees tenant A's invitation,
+	// whatever instant it is asked about.
+	countsB, err := f.repo.Counts(ctx, f.tenantB, expiry.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("counts B: %v", err)
+	}
+	if countsB.PendingInvitations != 0 {
+		t.Fatalf("tenant B sees %d of tenant A's pending invitations", countsB.PendingInvitations)
+	}
+}


### PR DESCRIPTION
Closes #409

## Root cause — not what the issue assumed

The issue's leading hypothesis was a permission-shaped cause: the counts call is
made as `member@a.io` rather than as an admin. **That was not it.** The badge is
correctly readable by an ordinary member.

The real cause is two clocks. `GormMembershipRepository.Counts` called
`time.Now()` directly, while the entire invitation lifecycle in
`internal/application/membership` reads the service's injected clock
(`s.clock()`, used in nine places in `invitations.go`). One row, two code paths,
two different notions of "now": the service considered an invitation usable
while the badge counted it expired.

**In production this is invisible**, because with no clock injected `s.clock()`
returns `time.Now()` and both agree. So the user-visible symptom the issue
describes — an admin thinking an invitation was never sent — does not actually
occur on a deployed system. That part of the issue's problem statement is not
borne out, and the corrected account is here rather than left to be rediscovered.

What did happen is a time bomb. The test fixture freezes the membership clock at
`2026-08-20T09:00:00Z` (`organization_member_e2e_test.go:151`) and invitations
expire seven days later, at `2026-08-27T09:00:00Z`. Once real wall-clock time
passed that instant, the repository began reading the row as expired while the
service still called it pending. The test passed for a week after w0-04 merged
and has failed every run since 2026-08-27.

Probed directly before fixing:

```
inv org=f96d2e8f… email=pending@a.io status="pending"
    expires=2026-08-27T09:00:00Z future=false
counts predicate      -> 0
without expiry clause -> 1
```

## The fix

`Counts` takes the instant to judge expiry against; the service passes the clock
it already owns. Production behaviour is unchanged. The repository stops
silently opting out of a seam the rest of the module is written against — which
is the actual defect, narrower than the issue framed it but real.

## Verification

```
$ cd backend && go build ./...        # exit 0
$ go vet ./...                        # exit 0

$ go test ./internal/handler/ -run 'TestOrganizationCounts_TenantScopedAndOpenToMembers' -v
--- PASS: TestOrganizationCounts_TenantScopedAndOpenToMembers (0.00s)
ok      github.com/opendefender/openrisk/internal/handler

$ go test ./internal/handler/...
ok      github.com/opendefender/openrisk/internal/handler        10.470s
ok      github.com/opendefender/openrisk/internal/handler/auth   0.985s

$ go test -short ./...
(no failures — the whole backend suite is green on this branch)
```

**The regression test was checked for the ability to fail.** Restoring
`time.Now()` in the query turns two of its four boundary cases red:

```
--- FAIL: TestCounts_JudgesInvitationExpiryAgainstTheGivenInstant/a_day_before_expiry_it_is_pending
    PendingInvitations at 2026-08-26T09:00:00Z = 0, want 1 — the counter is not using the instant it was given
--- FAIL: .../a_second_before_expiry_it_is_pending
    PendingInvitations at 2026-08-27T08:59:59Z = 0, want 1 — ...
```

It pins four points around the expiry instant, including exactly **at** it, so
the predicate cannot drift from `>` to `>=` unnoticed, and asserts tenant B
still sees none of tenant A's invitations.

## Acceptance criteria

1. ✅ A non-admin member reading counts sees `PendingInvitations: 1`, `TotalMembers: 3`.
2. ✅ Tenant B sees `TotalMembers: 1`, `PendingInvitations: 0` — **this half of the test had never executed**, since it sat behind the failing tenant-A assertion. The counter's tenant scoping is now proven rather than assumed.
3. ✅ Accepted or revoked invitations are not counted: the predicate requires `status = 'pending'`, unchanged.
4. ✅ Output pasted above.
5. ✅ `./internal/handler/...` green, so the package stops being red for every other issue in this milestone.

## Honest remainders

- **The issue's premise is partly wrong and I have not edited the issue to match.** There is no production defect here; there is an internal inconsistency whose only observable symptom was a date-dependent test. If the sidebar badge is genuinely wrong on a deployed system, that is a *different* bug and this PR does not fix it.
- **The class of defect is not closed.** I fixed the one query the issue named. I did not audit whether other repositories reach for `time.Now()` while their service owns a clock — the same time bomb could be seeded elsewhere. That deserves its own sweep and I have not opened one.
- `ROADMAP.md` module status: not updated, N/A for a bug fix that changes no module's state.
- Claim matrix: not updated, N/A — no user-visible capability changed.
- Frontend DoD items (FR/EN strings, loading states, axe): N/A, the fix is backend-only.
- Security review: the change adds no query and removes no predicate. `organization_id = ?` is untouched, and tenant scoping is now covered by an assertion that previously never ran.
