### PR TITLE
fix(test): await the lazy login route instead of asserting the Suspense fallback (#413)

### DIFF
--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -38,7 +38,7 @@ describe('App Integration', () => {
     vi.clearAllMocks();
   });
 
-  it('should render Login page when not authenticated', () => {
+  it('should render Login page when not authenticated', async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: any) => {
       const store = {
         isAuthenticated: false,
@@ -50,14 +50,22 @@ describe('App Integration', () => {
     // App renders its own <BrowserRouter>; don't double-wrap.
     render(<App />);
 
-    // Assert on the form itself, not on its heading. The previous version matched
-    // the marketing copy verbatim, so an ordinary wording change broke a test
-    // that is supposed to be about routing — and these ids are locale-independent
-    // by construction.
-    expect(screen.getByTestId('login-email')).toBeInTheDocument();
+    // AuthScreen is lazy (App.tsx:42) behind <Suspense fallback={<RouteFallback />}>,
+    // so the first synchronous paint is the fallback, not the form. The previous
+    // version asserted with getByTestId immediately and therefore tested the
+    // fallback — it passed only while the chunk happened to resolve first, and
+    // failed permanently once it did not.
+    //
+    // findBy* is the right tool here specifically BECAUSE the route does render:
+    // probed on this branch, the form appears once the chunk resolves. If the
+    // route rendered nothing, this would time out rather than paper over it —
+    // which is the difference between waiting for a known-good async boundary
+    // and hiding a broken one.
+    expect(await screen.findByTestId('login-email')).toBeInTheDocument();
     expect(screen.getByTestId('login-password')).toBeInTheDocument();
     expect(screen.getByTestId('login-submit')).toBeInTheDocument();
   });
+
 
   it('should render Dashboard when authenticated', async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: any) => {


### PR DESCRIPTION
Closes #413

## Root cause — the test, not the route

Criterion 1 asked for this to be established rather than assumed, so it was
probed before anything was changed.

`AuthScreen` is lazy-loaded (`App.tsx:42`) and rendered behind
`<Suspense fallback={<RouteFallback />}>` (`App.tsx:212`). The first synchronous
paint of an unauthenticated visit is therefore the fallback, not the login form.
The test called `getByTestId('login-email')` immediately after `render(<App />)`,
so it was asserting against the fallback. It passed only while the lazy chunk
happened to resolve before the assertion ran, and failed permanently once it did
not — which is why it read as "the route renders an empty body".

**The route is fine.** A probe on this branch confirmed
`await screen.findByTestId('login-email')` resolves, i.e. the form does render
once the chunk loads. That is what makes `findBy*` the correct fix here rather
than a wait papering over a broken route — the distinction the issue explicitly
warned about.

The suspect the issue floated — that the sibling `should render Dashboard when
authenticated` test is `async` and passes, hinting at an async cause — turned
out to be a weak signal for an unrelated reason. See the remainders.

## The fix

The test awaits the lazy boundary. One file, 14 insertions.

## Verification

```
$ cd frontend && npx tsc -b            # exit 0
$ npx vitest run src/__tests__/App.integration.test.tsx
  Tests  3 passed (3)
$ npx vitest run --reporter=dot
  Test Files  30 passed (30)
       Tests  305 passed (305)
```

**Checked for the ability to fail.** Replacing the `/login` route element with
`<div />` — a route that genuinely renders nothing — makes the fixed test fail
with the original error:

```
× should render Login page when not authenticated 1028ms
TestingLibraryElementError: Unable to find an element by: [data-testid="login-email"]
```

So the test still catches a dead route; it is not merely waiting until something
passes. The mutation was reverted.

## Acceptance criteria

1. ✅ Root cause stated with the evidence: test defect, lazy route + synchronous assertion.
2. ✅ `npx vitest run src/__tests__/App.integration.test.tsx` passes, output above.
3. ✅ `npx vitest run` reports zero failing tests — 305 passed.
4. N/A — the defect was in the test, not the application. The equivalent guarantee is the mutation check above.
5. ✅ `npx tsc -b` exits 0.

## Honest remainders

- **A vacuous test is left in place, deliberately.** `should render Dashboard when
  authenticated` asserts only
  `expect(screen.queryByText('Welcome back')).not.toBeInTheDocument()` — a
  negative that passes even when nothing renders at all. It cannot fail for the
  reason it exists, so it is not evidence the dashboard route works. Rewriting
  the rest of the file is Scope OUT on #413, so it was not touched. It deserves
  its own issue; I have not opened one.
- **`RouteFallback` renders nothing visible**, which is why the failure presented
  as a bare `<div />` rather than a skeleton. Whether the route-level fallback
  should show a skeleton is a UX question (constitution rule 8), not a bug in
  this test, and is out of scope here.
- No `any` added; the file's existing `(selector: any)` mocks were left as they were.
