### PR TITLE
refactor(design-system): make the accent fill flat and delete the glow token

### DIFF
--- a/frontend/src/components/dashboard/AnalyticsDashboardToolbar.tsx
+++ b/frontend/src/components/dashboard/AnalyticsDashboardToolbar.tsx
@@ -63,7 +63,7 @@ const AnalyticsDashboardToolbar: React.FC<AnalyticsDashboardToolbarProps> = ({
         {/* Export button */}
         <button
           onClick={onExportClick}
-          className="px-4 py-2 text-sm font-medium text-text-primary bg-accent-500 hover:bg-accent-500 rounded-lg transition flex items-center gap-2"
+          className="px-4 py-2 text-sm font-medium text-text-on-solid bg-accent-solid hover:brightness-110 rounded-lg transition flex items-center gap-2"
           title="Export dashboard"
         >
           <Download size={16} />

--- a/frontend/src/components/dashboard/DashboardFilter.tsx
+++ b/frontend/src/components/dashboard/DashboardFilter.tsx
@@ -53,7 +53,7 @@ const DashboardFilter: React.FC<DashboardFilterProps> = ({
                 onClick={() => onPeriodChange(option.value)}
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition ${
                   selectedPeriod === option.value
-                    ? 'bg-accent-500 text-text-primary'
+                    ? 'bg-accent-soft text-accent-strong'
                     : 'bg-surface-sunken text-text-primary hover:bg-surface-sunken'
                 }`}
               >
@@ -75,7 +75,7 @@ const DashboardFilter: React.FC<DashboardFilterProps> = ({
                     type="date"
                     value={dateRange.start}
                     onChange={(e) => onDateRangeChange(e.target.value, dateRange.end)}
-                    className="w-full px-3 py-2 border border-border-subtle rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-400"
+                    className="w-full px-3 py-2 border border-border-subtle rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-focus"
                   />
                 </div>
               </div>
@@ -87,7 +87,7 @@ const DashboardFilter: React.FC<DashboardFilterProps> = ({
                     type="date"
                     value={dateRange.end}
                     onChange={(e) => onDateRangeChange(dateRange.start, e.target.value)}
-                    className="w-full px-3 py-2 border border-border-subtle rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent-400"
+                    className="w-full px-3 py-2 border border-border-subtle rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-focus"
                   />
                 </div>
               </div>
@@ -117,7 +117,7 @@ const DashboardFilter: React.FC<DashboardFilterProps> = ({
                         onMetricsChange(selectedMetrics.filter((m) => m !== metric.id));
                       }
                     }}
-                    className="w-4 h-4 rounded border-border-subtle text-info-text focus:ring-accent-400"
+                    className="w-4 h-4 rounded border-border-subtle text-info-text focus:ring-focus"
                   />
                   <span className="text-sm text-text-primary">{metric.label}</span>
                 </label>

--- a/frontend/src/components/dashboard/MetricCard.tsx
+++ b/frontend/src/components/dashboard/MetricCard.tsx
@@ -38,7 +38,7 @@ const MetricCard: React.FC<MetricCardProps> = ({
       case 'warning':
         return 'border-l-4 border-warning bg-warning-surface';
       default:
-        return 'border-l-4 border-accent-400 bg-info-surface';
+        return 'border-l-4 border-accent bg-info-surface';
     }
   };
 

--- a/frontend/src/components/dashboard/RBACDashboardWidget.tsx
+++ b/frontend/src/components/dashboard/RBACDashboardWidget.tsx
@@ -23,7 +23,7 @@ interface TeamStats {
 
 const levelColors: Record<number, { bg: string; text: string; icon: string }> = {
   0: { bg: 'bg-surface-3/10', text: 'text-text-secondary', icon: '👁️' },
-  3: { bg: 'bg-accent-500/10', text: 'text-info-text', icon: '🔍' },
+  3: { bg: 'bg-accent-soft', text: 'text-info-text', icon: '🔍' },
   6: { bg: 'bg-purple-500/10', text: 'text-purple-400', icon: '👨‍💼' },
   9: { bg: 'bg-danger/10', text: 'text-danger-text', icon: '👑' },
 };

--- a/frontend/src/components/gamification/AchievementTrackingUI.tsx
+++ b/frontend/src/components/gamification/AchievementTrackingUI.tsx
@@ -65,7 +65,7 @@ const getRarityBorder = (rarity: string) => {
   const borders: Record<string, string> = {
     common: 'border-border-strong',
     uncommon: 'border-success',
-    rare: 'border-accent-400',
+    rare: 'border-accent',
     epic: 'border-purple-500',
     legendary: 'border-warning',
   };
@@ -95,7 +95,7 @@ const AchievementCard = ({ achievement, index }: { achievement: Achievement; ind
         {achievement.unlocked && (
           <div
             className={`absolute inset-0 rounded-lg blur-xl opacity-20 ${
-              achievement.rarity === 'legendary' ? 'bg-warning' : 'bg-accent-500'
+              achievement.rarity === 'legendary' ? 'bg-warning' : 'bg-accent'
             }`}
           />
         )}
@@ -222,7 +222,7 @@ export const AchievementTrackingUI = ({ achievements, isLoading }: AchievementTr
             onClick={() => setFilter(tab)}
             className={`px-4 py-2 rounded-lg font-medium text-sm transition-all ${
               filter === tab
-                ? 'bg-accent-500 text-text-primary shadow-lg shadow-blue-500/50'
+                ? 'bg-accent-soft text-accent-strong'
                 : 'bg-surface-1 text-text-secondary hover:bg-surface-2'
             }`}
           >

--- a/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
+++ b/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
@@ -94,14 +94,14 @@ export const EnhancedNotificationCenter = () => {
       milestone: {
         icon: Zap,
         color: 'text-info-text',
-        bg: 'bg-accent-500/10',
+        bg: 'bg-accent-soft',
         textColor: 'text-info-text',
         gradient: 'from-blue-600 to-blue-700',
       },
       info: {
         icon: Info,
         color: 'text-info-text',
-        bg: 'bg-accent-500/10',
+        bg: 'bg-accent-soft',
         textColor: 'text-info-text',
         gradient: 'from-blue-600 to-blue-700',
       },
@@ -287,7 +287,7 @@ export const EnhancedNotificationCenter = () => {
                     <motion.button
                       whileHover={{ scale: 1.02 }}
                       onClick={requestNotificationPermission}
-                      className="w-full mt-4 px-3 py-2 bg-accent-500 hover:bg-accent-500 text-text-primary text-sm rounded-lg transition-colors"
+                      className="w-full mt-4 px-3 py-2 bg-accent-solid hover:brightness-110 text-text-on-solid text-sm rounded-lg transition-colors"
                     >
                       Enable Desktop Notifications
                     </motion.button>
@@ -350,7 +350,7 @@ export const EnhancedNotificationCenter = () => {
                                   <motion.div
                                     initial={{ scale: 0 }}
                                     animate={{ scale: 1 }}
-                                    className="w-2 h-2 bg-accent-500 rounded-full flex-shrink-0 mt-1"
+                                    className="w-2 h-2 bg-accent rounded-full flex-shrink-0 mt-1"
                                   />
                                 )}
                               </div>
@@ -365,7 +365,7 @@ export const EnhancedNotificationCenter = () => {
                                       notification.action?.onClick();
                                       markAsRead(notification.id);
                                     }}
-                                    className="text-xs px-3 py-1 bg-accent-500 hover:bg-accent-500 text-text-primary rounded transition-colors"
+                                    className="text-xs px-3 py-1 bg-accent-solid hover:brightness-110 text-text-on-solid rounded transition-colors"
                                   >
                                     {notification.action.label}
                                   </motion.button>
@@ -399,7 +399,7 @@ export const EnhancedNotificationCenter = () => {
                 >
                   <button
                     onClick={markAllAsRead}
-                    className="flex-1 text-xs px-3 py-2 bg-accent-500/20 hover:bg-accent-500/30 text-info-text rounded-lg transition-colors"
+                    className="flex-1 text-xs px-3 py-2 bg-accent-soft hover:bg-accent-line text-info-text rounded-lg transition-colors"
                   >
                     Mark All as Read
                   </button>

--- a/frontend/src/components/gamification/GamificationDashboard.tsx
+++ b/frontend/src/components/gamification/GamificationDashboard.tsx
@@ -151,7 +151,7 @@ export const GamificationDashboard = ({
             onClick={() => setActiveTab(tab)}
             className={`px-6 py-3 font-medium text-sm transition-all border-b-2 ${
               activeTab === tab
-                ? 'text-info-text border-accent-400'
+                ? 'text-info-text border-accent'
                 : 'text-text-secondary border-transparent hover:text-text-secondary'
             }`}
           >
@@ -173,7 +173,7 @@ export const GamificationDashboard = ({
         >
           {/* Quick Stats */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <Card className="bg-surface-1/50 border-border-subtle hover:border-accent-400/50 transition-colors">
+            <Card className="bg-surface-1/50 border-border-subtle hover:border-accent-line transition-colors">
               <div className="p-6">
                 <div className="flex items-center justify-between mb-3">
                   <p className="text-text-secondary text-sm">Your Rank</p>
@@ -289,7 +289,7 @@ export const GamificationDashboard = ({
                         transition={{ delay: index * 0.05 }}
                         className={`flex items-center gap-4 p-4 rounded-lg transition-colors ${
                           isCurrent
-                            ? 'bg-gradient-to-r from-blue-900/30 to-purple-900/30 border border-accent-400/50'
+                            ? 'bg-gradient-to-r from-blue-900/30 to-purple-900/30 border border-accent-line'
                             : 'bg-surface-2/30 hover:bg-surface-2/50'
                         }`}
                       >

--- a/frontend/src/components/layout/NotificationCenter.tsx
+++ b/frontend/src/components/layout/NotificationCenter.tsx
@@ -23,7 +23,7 @@ export const NotificationCenter = () => {
         return { icon: AlertTriangle, color: 'text-warning-text', bg: 'bg-warning/10' };
       case 'info':
       default:
-        return { icon: Info, color: 'text-info-text', bg: 'bg-accent-500/10' };
+        return { icon: Info, color: 'text-info-text', bg: 'bg-accent-soft' };
     }
   };
 
@@ -124,7 +124,7 @@ export const NotificationCenter = () => {
                                   </p>
                                 </div>
                                 {!notification.read && (
-                                  <div className="w-2 h-2 bg-accent-500 rounded-full flex-shrink-0 mt-1" />
+                                  <div className="w-2 h-2 bg-accent rounded-full flex-shrink-0 mt-1" />
                                 )}
                               </div>
                               <div className="flex gap-2 mt-3">

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -213,7 +213,7 @@ export const PageHeader = ({ onNewRisk }: PageHeaderProps) => {
             </div>
           </div>
           
-          <Button variant="primary" onClick={onNewRisk} className="shadow-lg shadow-blue-500/20">
+          <Button variant="primary" onClick={onNewRisk}>
             <Plus size={16} className="mr-2" /> New Risk
           </Button>
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -207,10 +207,9 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
           <div className="px-[14px] pt-4 pb-2.5">
             <div className={cn('flex items-center gap-2.5 px-1.5 pb-3.5', collapsed && 'justify-center px-0')}>
               <div
-                className="w-[30px] h-[30px] rounded-[9px] flex items-center justify-center shrink-0 text-text-primary"
+                className="w-[30px] h-[30px] rounded-[9px] flex items-center justify-center shrink-0 text-text-on-solid"
                 style={{
-                  background: 'linear-gradient(135deg,var(--accent),var(--accent-2))',
-                  boxShadow: '0 2px 10px var(--accent-glow)',
+                  background: 'var(--accent-solid)',
                 }}
               >
                 <OpenRiskLogo size={18} />
@@ -226,8 +225,8 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
                 className="w-full flex items-center gap-2.5 px-2 py-1.5 rounded-[9px] hover:bg-hover transition-colors"
               >
                 <div
-                  className="w-[26px] h-[26px] rounded-[7px] flex items-center justify-center text-[11px] font-bold shrink-0 text-text-primary"
-                  style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))' }}
+                  className="w-[26px] h-[26px] rounded-[7px] flex items-center justify-center text-[11px] font-bold shrink-0 text-accent-strong"
+                  style={{ background: 'var(--accent-soft)' }}
                 >
                   {orgInitials}
                 </div>
@@ -252,8 +251,7 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
               }}
               className="w-full h-[38px] rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-primary transition-[filter] hover:brightness-110"
               style={{
-                background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-                boxShadow: '0 3px 12px var(--accent-glow)',
+                background: 'var(--accent-solid)', color: 'var(--text-on-solid)',
               }}
               title={L.newRisk}
             >
@@ -311,7 +309,7 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
                   className="h-full rounded-[5px]"
                   style={{
                     width: `${score}%`,
-                    background: `linear-gradient(90deg,var(--accent),${scoreColor})`,
+                    background: scoreColor,
                     transition: 'width .8s cubic-bezier(.2,.8,.2,1)',
                   }}
                 />
@@ -357,8 +355,8 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
                 className={cn('flex items-center gap-2.5 min-w-0 rounded-[9px] py-1 pr-1.5 hover:bg-hover transition-colors', collapsed ? 'px-1' : 'flex-1 pl-1')}
               >
                 <div
-                  className="w-[30px] h-[30px] rounded-full flex items-center justify-center text-[11px] font-bold text-text-primary shrink-0"
-                  style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))' }}
+                  className="w-[30px] h-[30px] rounded-full flex items-center justify-center text-[11px] font-bold text-accent-strong shrink-0"
+                  style={{ background: 'var(--accent-soft)' }}
                 >
                   {initials(user?.full_name)}
                 </div>

--- a/frontend/src/components/search/AdvancedSearch.tsx
+++ b/frontend/src/components/search/AdvancedSearch.tsx
@@ -63,7 +63,7 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
     <div ref={containerRef} className="relative w-full">
       <div className="relative">
         {/* Search Input */}
-        <div className="relative flex items-center bg-surface-1 border border-border-default rounded-lg focus-within:border-accent-400 focus-within:ring-1 focus-within:ring-accent-400/20 transition-all">
+        <div className="relative flex items-center bg-surface-1 border border-border-default rounded-lg focus-within:border-accent focus-within:ring-1 focus-within:ring-focus transition-all">
           <Search
             className="absolute left-3 text-text-secondary pointer-events-none"
             size={18}
@@ -119,7 +119,7 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
                     onClick={() => handleSelect(result)}
                     className={`w-full text-left px-4 py-3 border-b border-border-subtle last:border-b-0 transition-colors ${
                       index === state.selectedIndex
-                        ? 'bg-accent-500/20 border-l-2 border-l-blue-500'
+                        ? 'bg-accent-soft border-l-2 border-l-blue-500'
                         : 'hover:bg-surface-2'
                     }`}
                   >
@@ -193,7 +193,7 @@ export const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
                       onClick={() => handleSelect(result)}
                       className={`w-full text-left px-4 py-2 border-b border-border-subtle last:border-b-0 transition-colors ${
                         index === state.selectedIndex
-                          ? 'bg-accent-500/20 border-l-2 border-l-blue-500'
+                          ? 'bg-accent-soft border-l-2 border-l-blue-500'
                           : 'hover:bg-surface-2'
                       }`}
                     >
@@ -357,7 +357,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ commands }) => {
                     onClick={() => handleExecute(cmd)}
                     className={`w-full text-left px-4 py-3 border-b border-border-subtle last:border-b-0 transition-colors ${
                       index === selectedIndex
-                        ? 'bg-accent-500/20'
+                        ? 'bg-accent-soft'
                         : 'hover:bg-surface-2'
                     }`}
                   >

--- a/frontend/src/components/shared/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar.tsx
@@ -41,7 +41,7 @@ export const ProgressBar = ({
   };
 
   const variantClasses = {
-    default: 'bg-accent-500',
+    default: 'bg-accent',
     success: 'bg-success',
     warning: 'bg-warning',
     danger: 'bg-danger',

--- a/frontend/src/components/shared/StatusDot.tsx
+++ b/frontend/src/components/shared/StatusDot.tsx
@@ -30,7 +30,7 @@ const STATUS_CONFIG: Record<string, { bg: string; label: string; textColor: stri
   open: { bg: 'bg-danger', label: 'Ouvert', textColor: 'text-danger-text' },
   draft: { bg: 'bg-surface-3', label: 'Brouillon', textColor: 'text-text-secondary' },
   active: { bg: 'bg-danger', label: 'Actif', textColor: 'text-danger-text' },
-  in_progress: { bg: 'bg-accent-500', label: 'En cours', textColor: 'text-info-text' },
+  in_progress: { bg: 'bg-accent', label: 'En cours', textColor: 'text-info-text' },
   planned: { bg: 'bg-blue-400', label: 'Planifié', textColor: 'text-info-text' },
   review: { bg: 'bg-violet-500', label: 'En revue', textColor: 'text-violet-400' },
   mitigated: { bg: 'bg-warning', label: 'Atténué', textColor: 'text-warning-text' },

--- a/frontend/src/features/ai/AiAdvisor.tsx
+++ b/frontend/src/features/ai/AiAdvisor.tsx
@@ -114,8 +114,8 @@ export function AiAdvisor() {
             x.role === 'ai' ? (
               <div key={i} className="flex gap-3.5">
                 <div
-                  className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center text-text-primary shrink-0"
-                  style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))', boxShadow: '0 2px 10px var(--accent-glow)' }}
+                  className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center text-accent-strong shrink-0"
+                  style={{ background: 'var(--accent-soft)' }}
                 >
                   <Sparkles size={18} />
                 </div>
@@ -152,8 +152,8 @@ export function AiAdvisor() {
           {ask.isPending && (
             <div className="flex gap-3.5 items-center">
               <div
-                className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center text-text-primary shrink-0"
-                style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))' }}
+                className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center text-accent-strong shrink-0"
+                style={{ background: 'var(--accent-soft)' }}
               >
                 <Sparkles size={18} />
               </div>
@@ -196,7 +196,7 @@ export function AiAdvisor() {
               onClick={() => send()}
               disabled={ask.isPending}
               className="w-12 h-12 rounded-[14px] flex items-center justify-center text-text-primary shrink-0 disabled:opacity-60"
-              style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+              style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
             >
               {ask.isPending ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
             </button>

--- a/frontend/src/features/ai/AiAuditReportButton.tsx
+++ b/frontend/src/features/ai/AiAuditReportButton.tsx
@@ -63,7 +63,7 @@ export function AiAuditReportButton({ auditId, title }: { auditId: string; title
             style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border)', boxShadow: 'var(--shadow-lg)', animation: 'or-scalein .2s ease' }}
           >
             <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: '1px solid var(--border)' }}>
-              <div className="w-8 h-8 rounded-[9px] flex items-center justify-center text-text-primary shrink-0" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))' }}><Sparkles size={16} /></div>
+              <div className="w-8 h-8 rounded-[9px] flex items-center justify-center text-accent-strong shrink-0" style={{ background: 'var(--accent-soft)' }}><Sparkles size={16} /></div>
               <div className="flex-1 min-w-0">
                 <div className="text-[14px] font-semibold text-ink truncate">{tr('Rapport d’audit — IA', 'Audit report — AI')}</div>
                 <div className="text-[11.5px] text-ink-muted truncate">{title}</div>

--- a/frontend/src/features/ai/EmergingRisksPage.tsx
+++ b/frontend/src/features/ai/EmergingRisksPage.tsx
@@ -44,7 +44,7 @@ export function EmergingRisksPage() {
   return (
     <div className="max-w-[900px] mx-auto px-6 py-7">
       <div className="flex items-center gap-3 mb-1.5">
-        <div className="w-9 h-9 rounded-[11px] flex items-center justify-center text-text-primary" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))' }}>
+        <div className="w-9 h-9 rounded-[11px] flex items-center justify-center text-accent-strong" style={{ background: 'var(--accent-soft)' }}>
           <Sparkles size={19} />
         </div>
         <h1 className="disp text-[22px] font-bold text-ink">{tr('Détection de risques émergents', 'Emerging risk detection')}</h1>
@@ -90,7 +90,7 @@ export function EmergingRisksPage() {
             onClick={analyze}
             disabled={detect.isPending || !text.trim()}
             className="h-10 px-5 rounded-[11px] flex items-center gap-2 text-text-primary text-[13px] font-semibold disabled:opacity-60"
-            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+            style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {detect.isPending ? <Loader2 size={16} className="animate-spin" /> : <Sparkles size={16} />}
             {detect.isPending ? tr('Analyse…', 'Analysing…') : tr('Analyser avec l’IA', 'Analyse with AI')}

--- a/frontend/src/features/assets/CriticalityBadge.tsx
+++ b/frontend/src/features/assets/CriticalityBadge.tsx
@@ -7,7 +7,7 @@ const COLORS: Record<string, string> = {
   CRITICAL: 'bg-danger/10 text-danger-text border-danger/20',
   HIGH: 'bg-warning/10 text-warning-text border-warning/20',
   MEDIUM: 'bg-warning/10 text-warning-text border-warning/20',
-  LOW: 'bg-accent-500/10 text-info-text border-accent-400/20',
+  LOW: 'bg-accent-soft text-info-text border-accent-line',
 };
 
 export const CriticalityBadge = ({ level }: { level: string }) => (

--- a/frontend/src/features/auth/AuthLayout.tsx
+++ b/frontend/src/features/auth/AuthLayout.tsx
@@ -246,34 +246,14 @@ export function AuthLayout({ children }: AuthLayoutProps) {
         // white type on it depends on. Everything layered on top is exempted for
         // the same reason.
         // eslint-disable-next-line openrisk/no-raw-colors -- brand surface, see above
-        style={{ flex: '0 0 45%', background: 'linear-gradient(150deg,#0a0b12,#111225)' }}
+        style={{ flex: '0 0 45%', background: 'linear-gradient(150deg,#0f0f0f,#1c1c1b)' }}
       >
-        <div
-          className="absolute rounded-full"
-          style={{
-            top: '-15%', right: '-10%', width: 420, height: 420,
-            background: 'radial-gradient(circle,var(--accent-glow),transparent 70%)',
-            filter: 'blur(30px)', opacity: 0.5,
-          }}
-        />
-        <div
-          className="absolute rounded-full"
-          style={{
-            bottom: '0%', left: '-15%', width: 380, height: 380,
-            // Iris glow on the fixed dark brand panel; see the wrapper above.
-            // eslint-disable-next-line openrisk/no-raw-colors -- brand surface, see above
-            background: 'radial-gradient(circle,rgba(124,108,255,.4),transparent 70%)',
-            filter: 'blur(30px)', opacity: 0.5,
-          }}
-        />
-
         <div className="flex items-center gap-2.5 relative" style={cascade(0, reduced)}>
           <div
             className="w-[34px] h-[34px] rounded-[10px] flex items-center justify-center"
             style={{
               color: ON_BRAND_PANEL,
-              background: 'linear-gradient(135deg,var(--accent),var(--accent-2))',
-              boxShadow: '0 3px 14px var(--accent-glow)',
+              background: 'var(--accent-solid)',
             }}
           >
             <OpenRiskLogo size={20} />

--- a/frontend/src/features/auth/AuthScreen.tsx
+++ b/frontend/src/features/auth/AuthScreen.tsx
@@ -297,7 +297,7 @@ function MFAChallenge({ token, onCancel }: { token: string; onCancel: () => void
       <div style={cascade(0, reduced)}>
         <div
           className="w-11 h-11 rounded-[13px] flex items-center justify-center mb-4"
-          style={{ background: 'var(--accent-glow)', color: 'var(--accent-500)' }}
+          style={{ background: 'var(--accent-soft)', color: 'var(--accent-500)' }}
         >
           <ShieldCheck size={22} />
         </div>

--- a/frontend/src/features/auth/MFAEnrollmentBanner.tsx
+++ b/frontend/src/features/auth/MFAEnrollmentBanner.tsx
@@ -212,7 +212,7 @@ export function MFAEnrollmentBanner() {
             type="button"
             onClick={() => setDialogOpen(true)}
             className="h-8 px-3.5 rounded-[9px] text-[12.5px] font-semibold text-text-primary transition-all"
-            style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+            style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {copy.cta}
           </button>

--- a/frontend/src/features/auth/MFAEnrollmentDialog.tsx
+++ b/frontend/src/features/auth/MFAEnrollmentDialog.tsx
@@ -243,7 +243,7 @@ export function MFAEnrollmentDialog({ onClose, onEnrolled }: { onClose: () => vo
             type="submit"
             disabled={busy || phase !== 'scan' || code.trim().length < 6}
             className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 transition-all disabled:opacity-60"
-            style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 3px 12px var(--accent-glow)' }}
+            style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {busy && <Loader2 size={15} className="animate-spin" />}
             {tr('Activer', 'Enable')}

--- a/frontend/src/features/auth/MFAPostAhaPrompt.tsx
+++ b/frontend/src/features/auth/MFAPostAhaPrompt.tsx
@@ -133,7 +133,7 @@ export function MFAPostAhaPrompt() {
             type="button"
             onClick={() => setEnrolling(true)}
             className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary transition-all"
-            style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 3px 12px var(--accent-glow)' }}
+            style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {tr('Activer le MFA', 'Enable MFA')}
           </button>

--- a/frontend/src/features/auth/SessionsPanel.tsx
+++ b/frontend/src/features/auth/SessionsPanel.tsx
@@ -182,7 +182,7 @@ export function SessionsPanel() {
                     {s.current && (
                       <span
                         className="text-[10.5px] font-semibold px-1.5 py-0.5 rounded"
-                        style={{ background: 'var(--accent-glow)', color: 'var(--accent-500)' }}
+                        style={{ background: 'var(--accent-soft)', color: 'var(--accent-500)' }}
                       >
                         {t.thisDevice}
                       </span>

--- a/frontend/src/features/auth/formStyles.ts
+++ b/frontend/src/features/auth/formStyles.ts
@@ -25,6 +25,5 @@ export const primaryBtn =
   'w-full h-[46px] rounded-xl text-[14px] font-semibold text-text-primary transition-opacity';
 
 export const primaryStyle: React.CSSProperties = {
-  background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-  boxShadow: '0 4px 16px var(--accent-glow)',
+  background: 'var(--accent-solid)', color: 'var(--text-on-solid)',
 };

--- a/frontend/src/features/billing/BillingPanel.tsx
+++ b/frontend/src/features/billing/BillingPanel.tsx
@@ -190,7 +190,6 @@ export function BillingPanel() {
               style={{
                 background: 'var(--bg-elev)',
                 border: `1px solid ${plan === 'pro' ? 'var(--accent)' : 'var(--border)'}`,
-                boxShadow: plan === 'pro' ? '0 4px 20px var(--accent-glow)' : 'none',
               }}
             >
               <div className="flex items-center gap-1.5">
@@ -213,7 +212,7 @@ export function BillingPanel() {
                 style={
                   isCurrent
                     ? { border: '1px solid var(--border)', color: 'var(--ink-soft)' }
-                    : { background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-primary)' }
+                    : { background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }
                 }
               >
                 {isCurrent

--- a/frontend/src/features/billing/DangerZonePanel.tsx
+++ b/frontend/src/features/billing/DangerZonePanel.tsx
@@ -72,7 +72,7 @@ export function DangerZonePanel() {
           onClick={cancel}
           disabled={cancelDeletion.isPending}
           className="h-[38px] px-4 rounded-[10px] text-[13px] font-semibold text-text-primary disabled:opacity-50"
-          style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+          style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
         >
           Annuler la suppression
         </button>

--- a/frontend/src/features/compliance/ComplianceModals.tsx
+++ b/frontend/src/features/compliance/ComplianceModals.tsx
@@ -157,7 +157,7 @@ export function FooterButtons({ onCancel, submitLabel, pending }: { onCancel: ()
       <button type="button" onClick={onCancel} className="h-9 px-3.5 rounded-[10px] text-[13px] font-semibold text-ink-soft hover:text-ink transition-colors" style={{ border: '1px solid var(--border-strong)', background: 'var(--bg-elevated)' }}>
         {tr('Annuler', 'Cancel')}
       </button>
-      <button type="submit" disabled={pending} className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 transition-all disabled:opacity-60" style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 3px 12px var(--accent-glow)' }}>
+      <button type="submit" disabled={pending} className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-on-solid inline-flex items-center gap-1.5 transition-all disabled:opacity-60" style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
         {pending && <Loader2 size={15} className="animate-spin" />}
         {submitLabel}
       </button>

--- a/frontend/src/features/financial/FinancialDashboard.tsx
+++ b/frontend/src/features/financial/FinancialDashboard.tsx
@@ -570,7 +570,7 @@ function SimulatorCard({ rows, summary, lang, tr, onExplain }: { rows: TopRiskFi
         <input value={eff} onChange={(e) => setEff(Number(e.target.value))} type="range" min={0} max={1} step={0.05} className="mt-2 w-full accent-[var(--accent)]" />
       </label>
 
-      <button onClick={run} disabled={!riskId || sim.isPending} className="w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-primary disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+      <button onClick={run} disabled={!riskId || sim.isPending} className="w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-on-solid disabled:opacity-60" style={{ background: 'var(--accent-solid)' }}>
         <Coins size={16} /> {tr('Calculer le retour', 'Compute return')}
       </button>
 

--- a/frontend/src/features/incidents/IncidentDrawer.tsx
+++ b/frontend/src/features/incidents/IncidentDrawer.tsx
@@ -236,7 +236,7 @@ export function IncidentDrawer({ incident, canWrite, onClose }: { incident: Inci
               onClick={save}
               disabled={!dirty || updateIncident.isPending}
               className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 transition-all disabled:opacity-50"
-              style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 3px 12px var(--accent-glow)' }}
+              style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
             >
               {updateIncident.isPending ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
               {tr('Enregistrer', 'Save')}

--- a/frontend/src/features/mitigations/MitigationCard.tsx
+++ b/frontend/src/features/mitigations/MitigationCard.tsx
@@ -94,7 +94,7 @@ export const MitigationCard = ({
       className={cn(
         'p-4 rounded-lg border transition-all duration-200 cursor-grab active:cursor-grabbing',
         isDragging ? 'opacity-50 scale-95' : 'opacity-100 scale-100',
-        isSelected ? 'border-accent-400 bg-accent-500/5' : 'border-border-default bg-surface-1/40 hover:border-border-default',
+        isSelected ? 'border-accent bg-accent-soft' : 'border-border-default bg-surface-1/40 hover:border-border-default',
       )}
       onClick={onClick}
     >

--- a/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
+++ b/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
@@ -27,7 +27,7 @@ const getStatusColor = (status: string) => {
     case 'TODO':
       return 'bg-surface-3';
     case 'IN_PROGRESS':
-      return 'bg-accent-500';
+      return 'bg-accent';
     case 'REVIEW':
       return 'bg-warning';
     case 'DONE':
@@ -127,7 +127,7 @@ export const MitigationDetailDrawer = ({
                 className={cn(
                   'px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors',
                   activeTab === tab
-                    ? 'border-accent-400 text-text-primary'
+                    ? 'border-accent text-text-primary'
                     : 'border-transparent text-text-secondary hover:text-text-secondary'
                 )}
               >
@@ -210,7 +210,7 @@ export const MitigationDetailDrawer = ({
                           value={descriptionValue}
                           onChange={(e) => setDescriptionValue(e.currentTarget.value)}
                           placeholder="Description..."
-                          className="w-full min-h-[100px] px-3 py-2 bg-surface-2 border border-border-default rounded text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-400"
+                          className="w-full min-h-[100px] px-3 py-2 bg-surface-2 border border-border-default rounded text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent"
                         />
                         <div className="flex gap-2">
                           <Button variant="primary"
@@ -242,7 +242,7 @@ export const MitigationDetailDrawer = ({
                     <div className="flex gap-2">
                       {mitigation.assigned_to_user ? (
                         <div
-                          className="w-8 h-8 rounded-full bg-accent-500 flex items-center justify-center text-xs text-text-primary font-medium"
+                          className="w-8 h-8 rounded-full bg-accent-soft flex items-center justify-center text-xs text-accent-strong font-medium"
                           title={mitigation.assigned_to_user.name}
                         >
                           {mitigation.assigned_to_user.name.slice(0, 1).toUpperCase()}
@@ -281,7 +281,7 @@ export const MitigationDetailDrawer = ({
 
               {activeTab === 'ai' && (
                 <div className="space-y-4">
-                  <div className="p-4 rounded-lg bg-accent-500/10 border border-accent-400/30">
+                  <div className="p-4 rounded-lg bg-accent-soft border border-accent-line">
                     <div className="flex items-start gap-3">
                       <MessageCircle size={16} className="text-info-text flex-shrink-0 mt-1" />
                       <div>

--- a/frontend/src/features/mitigations/MitigationGanttView.tsx
+++ b/frontend/src/features/mitigations/MitigationGanttView.tsx
@@ -125,7 +125,7 @@ export const MitigationGanttView = memo(function MitigationGanttView({
                   <motion.div
                     className={cn(
                       'absolute top-0 bottom-0 rounded transition-colors',
-                      isOverdue ? 'bg-danger/40 hover:bg-danger/50' : 'bg-accent-500/40 hover:bg-accent-500/50'
+                      isOverdue ? 'bg-danger/40 hover:bg-danger/50' : 'bg-accent-line hover:bg-accent-line'
                     )}
                     style={{
                       left: `${startPos}%`,
@@ -150,7 +150,7 @@ export const MitigationGanttView = memo(function MitigationGanttView({
             <span>En retard</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-3 h-3 bg-accent-500" />
+            <div className="w-3 h-3 bg-accent" />
             <span>En cours</span>
           </div>
           <div className="flex items-center gap-2">

--- a/frontend/src/features/mitigations/MitigationKanbanPage.tsx
+++ b/frontend/src/features/mitigations/MitigationKanbanPage.tsx
@@ -32,7 +32,7 @@ type KanbanColumn = MitigationStatus;
 
 const KANBAN_COLUMNS: Array<{ id: KanbanColumn; label: string; color: string }> = [
   { id: 'TODO', label: 'À faire', color: 'bg-surface-3/20' },
-  { id: 'IN_PROGRESS', label: 'En cours', color: 'bg-accent-500/20' },
+  { id: 'IN_PROGRESS', label: 'En cours', color: 'bg-accent-soft' },
   { id: 'REVIEW', label: 'Vérification', color: 'bg-warning/20' },
   { id: 'DONE', label: 'Complété', color: 'bg-success/20' },
 ];

--- a/frontend/src/features/mitigations/PrioritizedMitigationsList.tsx
+++ b/frontend/src/features/mitigations/PrioritizedMitigationsList.tsx
@@ -77,7 +77,7 @@ export const PrioritizedMitigationsList = () => {
         return (
           <div 
             key={m.id} 
-            className={`p-4 border border-border-default rounded-lg shadow-xl transition-all duration-200 hover:border-accent-400 ${priorityColor}`}
+            className={`p-4 border border-border-default rounded-lg shadow-xl transition-all duration-200 hover:border-accent ${priorityColor}`}
           >
             <div className="flex justify-between items-start">
               <h3 className="text-lg font-semibold text-text-primary">{m.title}</h3>

--- a/frontend/src/features/mitigations/SubActionTable.tsx
+++ b/frontend/src/features/mitigations/SubActionTable.tsx
@@ -175,7 +175,7 @@ export const SubActionTable = ({ mitigationId, subActions, onUpdate }: SubAction
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
-            className={cn('space-y-2', snapshot.isDraggingOver && 'bg-accent-500/10 rounded-lg p-2')}
+            className={cn('space-y-2', snapshot.isDraggingOver && 'bg-accent-soft rounded-lg p-2')}
           >
             {displaySubActions.length === 0 ? (
               <div className="text-center py-8 text-text-muted text-sm">
@@ -200,7 +200,7 @@ export const SubActionTable = ({ mitigationId, subActions, onUpdate }: SubAction
                         {...provided.dragHandleProps}
                         className={cn(
                           'flex items-center gap-3 p-3 rounded-lg border border-border-default bg-surface-2/40 transition-all',
-                          snapshot.isDragging && 'bg-accent-500/20 shadow-lg',
+                          snapshot.isDragging && 'bg-accent-soft shadow-lg',
                           (subAction.depends_on?.length || 0) > 0 && 'border-l-2 border-l-yellow-500',
                           isReverting && 'opacity-50'
                         )}
@@ -237,7 +237,7 @@ export const SubActionTable = ({ mitigationId, subActions, onUpdate }: SubAction
                               scanId={subAction.scanner_details?.scan_id || 'unknown'}
                             />
                           ) : (
-                            <span className="text-xs px-2 py-1 rounded-full bg-accent-500/20 text-info-text">
+                            <span className="text-xs px-2 py-1 rounded-full bg-accent-soft text-info-text">
                               Manuel
                             </span>
                           )}

--- a/frontend/src/features/mitigations/ViewSwitcher.tsx
+++ b/frontend/src/features/mitigations/ViewSwitcher.tsx
@@ -29,7 +29,7 @@ export const ViewSwitcher = memo(function ViewSwitcher() {
           className={cn(
             'px-3 py-2 rounded flex items-center gap-2 transition-colors text-sm font-medium',
             viewMode === view.id
-              ? 'bg-accent-500 text-text-primary'
+              ? 'bg-accent-soft text-accent-strong'
               : 'text-text-secondary hover:text-text-primary'
           )}
           whileHover={{ scale: 1.02 }}

--- a/frontend/src/features/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/features/onboarding/OnboardingChecklist.tsx
@@ -112,7 +112,7 @@ export function OnboardingChecklist() {
           className="h-full rounded-full"
           style={{
             width: `${state.percent}%`,
-            background: 'linear-gradient(90deg,var(--accent),var(--accent-2))',
+            background: 'var(--accent)',
             transition: 'width .5s var(--ease-out, ease)',
           }}
         />
@@ -223,9 +223,8 @@ function StepRow({
           style={
             isCurrent
               ? {
-                  background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-                  color: '#fff',
-                  boxShadow: '0 3px 12px var(--accent-glow)',
+                  background: 'var(--accent-solid)',
+                  color: 'var(--text-on-solid)',
                 }
               : {
                   background: 'var(--bg-hover)',

--- a/frontend/src/features/onboarding/ProductTour.tsx
+++ b/frontend/src/features/onboarding/ProductTour.tsx
@@ -176,7 +176,6 @@ export function ProductTour() {
           width: rect.width + 8,
           height: rect.height + 8,
           border: '2px solid var(--accent)',
-          boxShadow: '0 0 0 4px var(--accent-glow)',
           transition: 'all .2s ease',
         }}
       />
@@ -225,8 +224,8 @@ export function ProductTour() {
               onClick={() => (isLast ? close() : setStep((s) => (s ?? 0) + 1))}
               className="h-8 px-3 rounded-[8px] text-[12px] font-semibold inline-flex items-center gap-1.5"
               style={{
-                background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-                color: '#fff',
+                background: 'var(--accent-solid)',
+                color: 'var(--text-on-solid)',
               }}
             >
               {isLast ? tr('Terminer', 'Done') : tr('Suivant', 'Next')}

--- a/frontend/src/features/onboarding/wizard/OnboardingWizard.tsx
+++ b/frontend/src/features/onboarding/wizard/OnboardingWizard.tsx
@@ -77,7 +77,7 @@ export function OnboardingWizard() {
             className="h-full rounded-full"
             style={{
               width: `${percent}%`,
-              background: 'linear-gradient(90deg,var(--accent),var(--accent-2))',
+              background: 'var(--accent)',
               transition: 'width .45s var(--ease-out, ease)',
             }}
           />

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -111,9 +111,8 @@ function StepShell({
           data-testid="wizard-next"
           className="h-11 px-5 rounded-[10px] text-[13.5px] font-semibold inline-flex items-center gap-2 disabled:opacity-50"
           style={{
-            background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-            color: '#fff',
-            boxShadow: '0 3px 12px var(--accent-glow)',
+            background: 'var(--accent-solid)',
+            color: 'var(--text-on-solid)',
           }}
         >
           {busy ? <Loader2 size={15} className="animate-spin" /> : null}
@@ -631,8 +630,8 @@ export function FrameworkStep() {
                         color: 'var(--low)',
                       }
                     : {
-                        background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-                        color: '#fff',
+                        background: 'var(--accent-solid)',
+                        color: 'var(--text-on-solid)',
                       }
                 }
               >

--- a/frontend/src/features/organization/AcceptInvitationPage.tsx
+++ b/frontend/src/features/organization/AcceptInvitationPage.tsx
@@ -177,7 +177,7 @@ export function AcceptInvitationPage() {
               </p>
               <button onClick={() => navigate('/')}
                 className="w-full h-[42px] rounded-[10px] text-[14px] font-semibold inline-flex items-center justify-center gap-2"
-                style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-on-solid)' }}>
+                style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
                 {tr("Ouvrir OpenRisk", 'Open OpenRisk')} <ArrowRight size={16} />
               </button>
             </div>
@@ -255,7 +255,7 @@ export function AcceptInvitationPage() {
 
                 <button type="submit" disabled={submitting}
                   className="w-full h-[44px] rounded-[10px] text-[14px] font-semibold inline-flex items-center justify-center gap-2 disabled:opacity-60"
-                  style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-on-solid)' }}>
+                  style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
                   {submitting && <Loader2 size={15} className="animate-spin" />}
                   {submitting
                     ? tr('Un instant…', 'One moment…')

--- a/frontend/src/features/organization/MembersView.tsx
+++ b/frontend/src/features/organization/MembersView.tsx
@@ -162,7 +162,7 @@ export function MembersView() {
             onClick={() => setManualInvite(true)}
             data-testid="invite-member"
             className="h-9 px-3.5 rounded-[9px] text-[12.5px] font-semibold inline-flex items-center gap-1.5"
-            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-on-solid)', boxShadow: '0 3px 12px var(--accent-glow)' }}
+            style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             <UserPlus size={15} /> {tr('Inviter un membre', 'Invite a member')}
           </button>
@@ -754,7 +754,7 @@ function InviteDialog({ tr, onClose }: { tr: Tr; onClose: () => void }) {
         <button
           type="submit" disabled={invite.isPending || !email}
           className="w-full h-[42px] rounded-[10px] text-[14px] font-semibold disabled:opacity-60"
-          style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-on-solid)' }}
+          style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
         >
           {invite.isPending ? tr('Envoi…', 'Sending…') : tr("Envoyer l'invitation", 'Send invitation')}
         </button>
@@ -833,7 +833,7 @@ function ManualLinkDialog({ tr, result, onClose, created }: {
       )}
 
       <button onClick={onClose} className="w-full h-[42px] rounded-[10px] text-[14px] font-semibold"
-        style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', color: 'var(--text-on-solid)' }}>
+        style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
         {tr('Terminé', 'Done')}
       </button>
     </Overlay>

--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -889,7 +889,7 @@ function DrawerAI({ r }: { r: UiRisk }) {
         onClick={() => plan.mutate({ riskId: r.id, locale })}
         disabled={plan.isPending}
         className="w-full h-11 rounded-[12px] flex items-center justify-center gap-2 text-text-primary text-[13.5px] font-semibold disabled:opacity-60"
-        style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 2px 12px var(--accent-glow)' }}
+        style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
       >
         {plan.isPending ? <Loader2 size={17} className="animate-spin" /> : <Sparkles size={17} />}
         {plan.isPending ? tr('Génération…', 'Generating…') : res ? tr('Régénérer', 'Regenerate') : tr('Générer avec l’IA', 'Generate with AI')}
@@ -1169,7 +1169,7 @@ function DrawerDetails({ r, onCreateMiti }: { r: UiRisk; onCreateMiti: () => voi
           <ShieldCheck size={16} /> {tr(`Voir les mitigations (${mitiCount})`, `View mitigations (${mitiCount})`)}
         </button>
       ) : (
-        <button onClick={onCreateMiti} className="mt-2 w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-primary transition-all hover:brightness-110" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+        <button onClick={onCreateMiti} className="mt-2 w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-on-solid transition-all hover:brightness-110" style={{ background: 'var(--accent-solid)' }}>
           <ShieldCheck size={16} /> {L.createMiti}
         </button>
       )}
@@ -1423,7 +1423,7 @@ function DrawerFinancial({ r }: { r: UiRisk }) {
               <input value={eff} onChange={(e) => setEff(Number(e.target.value))} type="range" min={0} max={1} step={0.05} className="mt-3 w-full accent-[var(--accent)]" />
             </label>
           </div>
-          <button disabled={busy} onClick={save} className="w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-primary disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+          <button disabled={busy} onClick={save} className="w-full h-10 rounded-[10px] flex items-center justify-center gap-2 text-[13px] font-semibold text-text-on-solid disabled:opacity-60" style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
             <Coins size={16} /> {tr('Recalculer l’exposition', 'Recalculate exposure')}
           </button>
           <div className="text-[11px] text-ink-muted mt-2">{tr('SLE explicite prioritaire ; sinon composé depuis interruptions + amendes + perte de données ; sinon référence par criticité.', 'Explicit SLE wins; else composed from downtime + fines + data loss; else reference by criticality.')}</div>

--- a/frontend/src/features/risks/components/EditRiskModal.tsx
+++ b/frontend/src/features/risks/components/EditRiskModal.tsx
@@ -209,7 +209,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                 </label>
                 <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto p-2 border border-border rounded-lg bg-surface-1/30">
                   {assets.length === 0 ? <div className="text-text-muted text-xs w-full text-center py-2">Aucun asset.</div> : assets.map(a => (
-                    <button key={a.id} type="button" onClick={() => toggleAsset(a.id)} disabled={isLoading} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedAssetIds.includes(a.id) ? 'bg-accent-500/20 border-accent-400 text-info-text' : 'bg-surface-2 border-border-default text-text-secondary'} ${isLoading ? 'opacity-70' : ''}`}>
+                    <button key={a.id} type="button" onClick={() => toggleAsset(a.id)} disabled={isLoading} className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedAssetIds.includes(a.id) ? 'bg-accent-soft border-accent text-info-text' : 'bg-surface-2 border-border-default text-text-secondary'} ${isLoading ? 'opacity-70' : ''}`}>
                       {a.name}
                     </button>
                   ))}

--- a/frontend/src/features/risks/components/RiskCard.tsx
+++ b/frontend/src/features/risks/components/RiskCard.tsx
@@ -33,8 +33,8 @@ export const RiskCard = ({ risk, onClick }: RiskCardProps) => {
     CRITICAL: 'bg-danger-surface border-danger/50',
     HIGH: 'bg-warning-surface border-warning/50',
     MEDIUM: 'bg-warning-surface border-warning/50',
-    LOW: 'bg-info-surface border-accent-400/50',
-  }[band] || 'bg-info-surface border-accent-400/50';
+    LOW: 'bg-info-surface border-accent-line',
+  }[band] || 'bg-info-surface border-accent-line';
 
   return (
     <div

--- a/frontend/src/features/score/ScorePage.tsx
+++ b/frontend/src/features/score/ScorePage.tsx
@@ -131,8 +131,8 @@ export function ScorePage() {
               onClick={() => navigate('/risks')}
               className="mt-5 h-10 px-4 rounded-[10px] text-[13px] font-semibold inline-flex items-center gap-2"
               style={{
-                background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))',
-                color: '#fff',
+                background: 'var(--accent-solid)',
+                color: 'var(--text-on-solid)',
               }}
             >
               {tr('Ouvrir le registre des risques', 'Open the risk register')}

--- a/frontend/src/features/scoreEngine/components/ScoreEngineVisualizer.tsx
+++ b/frontend/src/features/scoreEngine/components/ScoreEngineVisualizer.tsx
@@ -188,7 +188,7 @@ export const ScoreEngineVisualizer = ({
       {loading && (
         <div className="text-center py-4">
           <div className="inline-flex items-center gap-2 text-text-muted">
-            <div className="w-4 h-4 bg-accent-500 rounded-full animate-bounce" />
+            <div className="w-4 h-4 bg-accent rounded-full animate-bounce" />
             <span>Calcul du score...</span>
           </div>
         </div>

--- a/frontend/src/features/scoreEngine/pages/ScoreEngineConfiguration.tsx
+++ b/frontend/src/features/scoreEngine/pages/ScoreEngineConfiguration.tsx
@@ -149,7 +149,7 @@ export const ScoreEngineConfiguration = () => {
                 onClick={() => !isEditing && handleEdit(configs.default)}
                 className={`w-full text-left p-4 border rounded-lg transition-all ${
                   selectedConfig?.id === 'default'
-                    ? 'bg-accent-500/10 border-accent-400'
+                    ? 'bg-accent-soft border-accent'
                     : 'bg-surface-1 border-border-default hover:border-border-default'
                 }`}
                 disabled={isEditing}

--- a/frontend/src/features/settings/MFAPolicyPanel.tsx
+++ b/frontend/src/features/settings/MFAPolicyPanel.tsx
@@ -118,7 +118,7 @@ export function MFAPolicyPanel() {
             type="submit"
             disabled={!valid || !dirty || save.isPending}
             className="h-10 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 transition-all disabled:opacity-50"
-            style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+            style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {save.isPending && <Loader2 size={15} className="animate-spin" aria-hidden="true" />}
             {tr('Enregistrer', 'Save')}
@@ -219,7 +219,7 @@ export function MFAAccountPanel() {
           type="button"
           onClick={() => setEnrolling(true)}
           className="h-9 px-4 rounded-[10px] text-[13px] font-semibold text-text-primary transition-all"
-          style={{ border: 'none', background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+          style={{ border: 'none', background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
         >
           {tr('Activer le MFA', 'Enable MFA')}
         </button>

--- a/frontend/src/features/settings/RBACTab.tsx
+++ b/frontend/src/features/settings/RBACTab.tsx
@@ -181,7 +181,7 @@ export const RBACTab = () => {
           )}
 
           {isAdmin && allRoles.length > 0 && (
-            <div className="mt-8 p-4 rounded-lg bg-accent-500/10 border border-accent-400/20">
+            <div className="mt-8 p-4 rounded-lg bg-accent-soft border border-accent-line">
               <h4 className="text-sm font-semibold text-info-text mb-3">Admin - All Available Roles</h4>
               <div className="space-y-2">
                 {allRoles.map((role) => (
@@ -248,7 +248,7 @@ export const RBACTab = () => {
       )}
 
       {/* Info Box */}
-      <div className="mt-8 p-4 rounded-lg bg-accent-500/5 border border-accent-400/20">
+      <div className="mt-8 p-4 rounded-lg bg-accent-soft border border-accent-line">
         <div className="flex gap-3">
           <Shield className="w-5 h-5 text-info-text flex-shrink-0 mt-0.5" />
           <div className="text-sm text-info-text">

--- a/frontend/src/features/settings/TeamTab.tsx
+++ b/frontend/src/features/settings/TeamTab.tsx
@@ -212,7 +212,7 @@ export const TeamTab = () => {
                                 <tr key={member.id} className="hover:bg-surface-1/5 transition-colors">
                                     <td className="px-6 py-4">
                                         <div className="flex items-center gap-3">
-                                            <div className="w-8 h-8 rounded-full bg-accent-500 flex items-center justify-center font-bold text-text-primary text-sm">
+                                            <div className="w-8 h-8 rounded-full bg-accent-soft flex items-center justify-center font-bold text-accent-strong text-sm">
                                                 {member.avatar}
                                             </div>
                                             <div>

--- a/frontend/src/features/users/CreateUserModal.tsx
+++ b/frontend/src/features/users/CreateUserModal.tsx
@@ -198,7 +198,7 @@ export const CreateUserModal = ({ isOpen, onClose, onSuccess }: CreateUserModalP
                   </div>
                 </div>
 
-                <div className="bg-accent-500/10 border border-accent-400/20 rounded-lg p-3">
+                <div className="bg-accent-soft border border-accent-line rounded-lg p-3">
                   <p className="text-xs text-info-text">
                     💡 The user will be sent an email to verify their account and set a custom password.
                   </p>

--- a/frontend/src/features/vulnerabilities/IngestModal.tsx
+++ b/frontend/src/features/vulnerabilities/IngestModal.tsx
@@ -96,7 +96,7 @@ export function IngestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
 
         <div className="px-5 py-4 flex justify-end gap-2" style={{ borderTop: '1px solid var(--border)' }}>
           <button onClick={onClose} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold" style={{ border: '1px solid var(--border-strong)', color: 'var(--text-secondary)' }}>{tr('Annuler', 'Cancel')}</button>
-          <button onClick={submit} disabled={ingest.isPending || !raw.trim()} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-primary disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+          <button onClick={submit} disabled={ingest.isPending || !raw.trim()} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-on-solid disabled:opacity-60" style={{ background: 'var(--accent-solid)' }}>
             {ingest.isPending ? tr('Import…', 'Importing…') : tr('Importer', 'Import')}
           </button>
         </div>

--- a/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
+++ b/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
@@ -95,7 +95,7 @@ export function IntegrationsPanel({ isOpen, onClose, onImport }: { isOpen: boole
               <button onClick={() => setView('ticketing')} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold inline-flex items-center gap-1.5" style={{ border: '1px solid var(--border-strong)', color: 'var(--text-secondary)' }}>
                 <Ticket size={15} /> {tr('Ticketing', 'Ticketing')}
               </button>
-              <button onClick={onImport} className="ml-auto h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+              <button onClick={onImport} className="ml-auto h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-on-solid inline-flex items-center gap-1.5" style={{ background: 'var(--accent-solid)' }}>
                 <Upload size={15} /> {tr('Import manuel', 'Manual import')}
               </button>
             </div>
@@ -286,7 +286,7 @@ function IntegrationForm({ source, meta, existing, canWrite, onDone }: {
               <PlayCircle size={14} /> {tr('Pull maintenant', 'Pull now')}
             </button>
           )}
-          <button onClick={() => submit(false)} disabled={save.isPending} className="ml-auto h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+          <button onClick={() => submit(false)} disabled={save.isPending} className="ml-auto h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-on-solid inline-flex items-center gap-1.5 disabled:opacity-60" style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
             <Save size={15} /> {tr('Enregistrer', 'Save')}
           </button>
         </div>
@@ -369,7 +369,7 @@ function TicketingForm({ canWrite }: { canWrite: boolean }) {
       </div>
       {canWrite && (
         <div className="px-5 py-3.5 flex justify-end" style={{ borderTop: '1px solid var(--border)' }}>
-          <button onClick={submit} disabled={save.isPending} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-primary inline-flex items-center gap-1.5 disabled:opacity-60" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}>
+          <button onClick={submit} disabled={save.isPending} className="h-9 px-4 rounded-[9px] text-[13px] font-semibold text-text-on-solid inline-flex items-center gap-1.5 disabled:opacity-60" style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}>
             <Save size={15} /> {tr('Enregistrer', 'Save')}
           </button>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -239,9 +239,8 @@
   border-radius: 10px;
   font-size: 13.5px;
   font-weight: 600;
-  color: var(--text-primary);
-  background: var(--accent);
-  box-shadow: 0 4px 16px var(--accent-glow);
+  color: var(--text-on-solid);
+  background: var(--accent-solid);
 }
 .skip-link:focus {
   transform: translateY(0);

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -107,7 +107,7 @@ export default function Analytics() {
       <div className="flex items-center justify-center h-full">
         <div className="text-center">
           <div className="inline-block animate-spin">
-            <div className="h-8 w-8 border-4 border-accent-400 border-t-blue-600 rounded-full"></div>
+            <div className="h-8 w-8 border-4 border-accent border-t-blue-600 rounded-full"></div>
           </div>
           <p className="mt-4 text-text-secondary">Loading analytics...</p>
         </div>
@@ -167,7 +167,7 @@ export default function Analytics() {
           <button
             onClick={fetchDashboard}
             disabled={refreshing}
-            className="flex items-center gap-2 px-4 py-2 bg-accent-500 hover:bg-accent-500 text-text-primary rounded-lg transition disabled:opacity-50"
+            className="flex items-center gap-2 px-4 py-2 bg-accent-solid hover:brightness-110 text-text-on-solid rounded-lg transition disabled:opacity-50"
           >
             <RefreshCw size={18} className={refreshing ? 'animate-spin' : ''} />
             Refresh

--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -135,7 +135,7 @@ const AnalyticsDashboard: React.FC = () => {
               <select
                 value={selectedMetric}
                 onChange={(e) => setSelectedMetric(e.target.value)}
-                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent-400"
+                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-focus"
               >
                 <option value="latency_ms">Latency (ms)</option>
                 <option value="throughput_rps">Throughput (RPS)</option>
@@ -152,7 +152,7 @@ const AnalyticsDashboard: React.FC = () => {
               <select
                 value={selectedPeriod}
                 onChange={(e) => setSelectedPeriod(e.target.value as any)}
-                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent-400"
+                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-focus"
               >
                 <option value="hourly">Hourly</option>
                 <option value="daily">Daily</option>
@@ -206,7 +206,7 @@ const AnalyticsDashboard: React.FC = () => {
           <div className="bg-surface-1 rounded-lg shadow p-6 mb-8">
             <h2 className="text-2xl font-bold text-text-primary mb-4">Trend Analysis</h2>
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-              <div className="border-l-4 border-accent-400 pl-4">
+              <div className="border-l-4 border-accent pl-4">
                 <p className="text-text-muted text-sm">Direction</p>
                 <p className="text-xl font-bold text-text-primary">{trendData.direction}</p>
               </div>

--- a/frontend/src/pages/AuditLogs.tsx
+++ b/frontend/src/pages/AuditLogs.tsx
@@ -116,7 +116,7 @@ export default function AuditLogs() {
           <h1 className="text-3xl font-bold text-text-primary">Audit Logs</h1>
         </div>
         <div className="flex justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent-400"></div>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
         </div>
       </div>
     );
@@ -171,7 +171,7 @@ export default function AuditLogs() {
                 setActionFilter(e.target.value);
                 setPage(1);
               }}
-              className="w-full px-4 py-2 border border-border-subtle rounded-lg focus:ring-2 focus:ring-accent-400 focus:border-transparent"
+              className="w-full px-4 py-2 border border-border-subtle rounded-lg focus:ring-2 focus:ring-focus focus:border-transparent"
             >
               <option value="">All Actions</option>
               <option value="login">Login</option>
@@ -196,7 +196,7 @@ export default function AuditLogs() {
                 setResultFilter(e.target.value);
                 setPage(1);
               }}
-              className="w-full px-4 py-2 border border-border-subtle rounded-lg focus:ring-2 focus:ring-accent-400 focus:border-transparent"
+              className="w-full px-4 py-2 border border-border-subtle rounded-lg focus:ring-2 focus:ring-focus focus:border-transparent"
             >
               <option value="">All Results</option>
               <option value="success">Success</option>
@@ -292,7 +292,7 @@ export default function AuditLogs() {
                 setLimit(Number(e.target.value));
                 setPage(1);
               }}
-              className="px-3 py-1 border border-border-subtle rounded-lg text-sm focus:ring-2 focus:ring-accent-400 focus:border-transparent"
+              className="px-3 py-1 border border-border-subtle rounded-lg text-sm focus:ring-2 focus:ring-focus focus:border-transparent"
             >
               <option value={10}>10</option>
               <option value={20}>20</option>

--- a/frontend/src/pages/BulkOperations.tsx
+++ b/frontend/src/pages/BulkOperations.tsx
@@ -226,7 +226,7 @@ export default function BulkOperations() {
                 onClick={() => setFilter(f.value)}
                 className={`px-4 py-2 rounded transition ${
                   filter === f.value
-                    ? 'bg-accent-500 text-text-primary'
+                    ? 'bg-accent-soft text-accent-strong'
                     : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
                 }`}
               >
@@ -237,7 +237,7 @@ export default function BulkOperations() {
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as any)}
-            className="ml-auto px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary focus:outline-none focus:border-accent-400"
+            className="ml-auto px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary focus:outline-none focus:border-accent"
           >
             <option value="newest">Newest First</option>
             <option value="oldest">Oldest First</option>
@@ -269,9 +269,9 @@ export default function BulkOperations() {
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -10 }}
                         onClick={() => handleSelectOperation(operation)}
-                        className={`bg-surface-1 border rounded-lg p-4 cursor-pointer transition hover:border-accent-400 ${
+                        className={`bg-surface-1 border rounded-lg p-4 cursor-pointer transition hover:border-accent ${
                           selectedOperation?.id === operation.id
-                            ? 'border-accent-400'
+                            ? 'border-accent'
                             : 'border-border-subtle'
                         }`}
                       >
@@ -323,7 +323,7 @@ export default function BulkOperations() {
                                   : operation.status === 'failed'
                                   ? 'bg-danger'
                                   : operation.status === 'in_progress'
-                                  ? 'bg-accent-500'
+                                  ? 'bg-accent'
                                   : 'bg-warning'
                               }`}
                             />
@@ -389,7 +389,7 @@ export default function BulkOperations() {
                   </p>
                   <div className="w-full bg-surface-2 rounded-full h-2 mt-2 overflow-hidden">
                     <div
-                      className="h-full bg-accent-500"
+                      className="h-full bg-accent"
                       style={{ width: `${selectedOperation.progress}%` }}
                     />
                   </div>

--- a/frontend/src/pages/ComplianceReportDashboard.tsx
+++ b/frontend/src/pages/ComplianceReportDashboard.tsx
@@ -176,7 +176,7 @@ const ComplianceReportDashboard: React.FC = () => {
               <select
                 value={timeRange}
                 onChange={(e) => setTimeRange(e.target.value)}
-                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-accent-400"
+                className="rounded border-border-subtle border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-focus"
               >
                 <option value="7d">Last 7 Days</option>
                 <option value="30d">Last 30 Days</option>
@@ -195,7 +195,7 @@ const ComplianceReportDashboard: React.FC = () => {
               onClick={() => setSelectedFramework(framework.name)}
               className={`rounded-lg shadow p-6 text-left transition-all hover:shadow-lg ${
                 selectedFramework === framework.name
-                  ? 'ring-2 ring-accent-400 bg-info-surface'
+                  ? 'ring-2 ring-focus bg-info-surface'
                   : 'bg-surface-1 hover:bg-surface-sunken'
               }`}
             >

--- a/frontend/src/pages/CustomFields.tsx
+++ b/frontend/src/pages/CustomFields.tsx
@@ -227,7 +227,7 @@ export default function CustomFields() {
               });
               setShowCreateModal(true);
             }}
-            className="flex items-center gap-2 px-4 py-2 bg-accent-500 hover:bg-accent-500 rounded-lg transition"
+            className="flex items-center gap-2 px-4 py-2 bg-accent-solid text-text-on-solid hover:brightness-110 rounded-lg transition"
           >
             <Plus className="w-5 h-5" />
             New Field
@@ -240,7 +240,7 @@ export default function CustomFields() {
             onClick={() => setActiveTab('fields')}
             className={`pb-3 px-4 font-medium transition ${
               activeTab === 'fields'
-                ? 'border-b-2 border-accent-400 text-info-text'
+                ? 'border-b-2 border-accent text-info-text'
                 : 'text-text-secondary hover:text-text-primary'
             }`}
           >
@@ -250,7 +250,7 @@ export default function CustomFields() {
             onClick={() => setActiveTab('templates')}
             className={`pb-3 px-4 font-medium transition ${
               activeTab === 'templates'
-                ? 'border-b-2 border-accent-400 text-info-text'
+                ? 'border-b-2 border-accent text-info-text'
                 : 'text-text-secondary hover:text-text-primary'
             }`}
           >
@@ -379,7 +379,7 @@ export default function CustomFields() {
                     {template.fields.map((field) => (
                       <span
                         key={field.id}
-                        className="px-3 py-1 bg-info-surface border border-accent-400/50 rounded-full text-sm text-blue-200"
+                        className="px-3 py-1 bg-info-surface border border-accent-line rounded-full text-sm text-blue-200"
                       >
                         {field.name}
                       </span>
@@ -427,7 +427,7 @@ export default function CustomFields() {
                     onChange={(e) =>
                       setFormData({ ...formData, name: e.target.value })
                     }
-                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent-400"
+                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent"
                     placeholder="e.g., Department, Cost Center"
                   />
                 </div>
@@ -445,7 +445,7 @@ export default function CustomFields() {
                         }
                         className={`p-3 border rounded text-center transition ${
                           formData.type === type.value
-                            ? 'bg-accent-500 border-accent-400'
+                            ? 'bg-accent border-accent'
                             : 'bg-surface-2 border-border-default hover:border-border-default'
                         }`}
                       >
@@ -465,7 +465,7 @@ export default function CustomFields() {
                     onChange={(e) =>
                       setFormData({ ...formData, description: e.target.value })
                     }
-                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent-400 resize-none"
+                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent resize-none"
                     rows={3}
                     placeholder="Field description"
                   />
@@ -480,7 +480,7 @@ export default function CustomFields() {
                     onChange={(e) =>
                       setFormData({ ...formData, scope: e.target.value })
                     }
-                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary focus:outline-none focus:border-accent-400"
+                    className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary focus:outline-none focus:border-accent"
                   >
                     {scopes.map((scope) => (
                       <option key={scope} value={scope}>
@@ -531,7 +531,7 @@ export default function CustomFields() {
                       onChange={(e) =>
                         setFormData({ ...formData, default_value: e.target.value })
                       }
-                      className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent-400"
+                      className="w-full px-3 py-2 bg-surface-2 border border-border-default rounded text-text-primary placeholder-zinc-500 focus:outline-none focus:border-accent"
                       placeholder="Optional default value"
                     />
                   </div>
@@ -552,7 +552,7 @@ export default function CustomFields() {
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
                   onClick={handleCreateField}
-                  className="flex-1 px-4 py-2 bg-accent-500 hover:bg-accent-500 rounded transition font-medium"
+                  className="flex-1 px-4 py-2 bg-accent-solid text-text-on-solid hover:brightness-110 rounded transition font-medium"
                 >
                   {editingField ? 'Update' : 'Create'}
                 </motion.button>

--- a/frontend/src/pages/ImportRisks.tsx
+++ b/frontend/src/pages/ImportRisks.tsx
@@ -211,7 +211,7 @@ export const ImportRisksPage = () => {
             className={cn(
               'relative border-2 border-dashed rounded-xl p-12 text-center',
               'transition-all duration-300 cursor-pointer',
-              dragState === 'dragging' && 'bg-accent-500/10 border-accent-400/50'
+              dragState === 'dragging' && 'bg-accent-soft border-accent-line'
             )}
             onClick={() => fileInputRef.current?.click()}
           >

--- a/frontend/src/pages/Incidents.tsx
+++ b/frontend/src/pages/Incidents.tsx
@@ -43,7 +43,7 @@ export const Incidents = () => {
       case 'medium':
         return 'bg-warning/10 text-warning-text border-warning/20';
       case 'low':
-        return 'bg-accent-500/10 text-info-text border-accent-400/20';
+        return 'bg-accent-soft text-info-text border-accent-line';
       default:
         return 'bg-surface-3/10 text-text-secondary border-border-strong/20';
     }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -75,7 +75,7 @@ export const Login = () => {
       id: 'azure',
       name: 'Azure AD',
       icon: Shield,
-      color: 'hover:bg-info-surface hover:border-accent-400',
+      color: 'hover:bg-info-surface hover:border-accent',
     },
     {
       id: 'saml',
@@ -88,7 +88,7 @@ export const Login = () => {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4 relative overflow-hidden">
         {/* Background Effects */}
-        <div className="absolute top-[-20%] left-[-10%] w-[500px] h-[500px] bg-accent-500/20 rounded-full blur-[120px]" />
+        <div className="absolute top-[-20%] left-[-10%] w-[500px] h-[500px] bg-accent-soft rounded-full blur-[120px]" />
         <div className="absolute bottom-[-20%] right-[-10%] w-[500px] h-[500px] bg-purple-600/20 rounded-full blur-[120px]" />
 
         <motion.div 

--- a/frontend/src/pages/Marketplace.tsx
+++ b/frontend/src/pages/Marketplace.tsx
@@ -198,7 +198,7 @@ export default function Marketplace() {
       case 'installed':
         return 'bg-success/20 text-success-text';
       case 'beta':
-        return 'bg-accent-500/20 text-info-text';
+        return 'bg-accent-soft text-info-text';
       case 'pending':
         return 'bg-warning/20 text-warning-text';
       case 'error':
@@ -240,7 +240,7 @@ export default function Marketplace() {
             onClick={() => setActiveTab('connectors')}
             className={`pb-4 px-4 font-medium transition-colors ${
               activeTab === 'connectors'
-                ? 'text-info-text border-b-2 border-accent-400'
+                ? 'text-info-text border-b-2 border-accent'
                 : 'text-text-secondary hover:text-text-secondary'
             }`}
           >
@@ -253,14 +253,14 @@ export default function Marketplace() {
             onClick={() => setActiveTab('installed')}
             className={`pb-4 px-4 font-medium transition-colors ${
               activeTab === 'installed'
-                ? 'text-info-text border-b-2 border-accent-400'
+                ? 'text-info-text border-b-2 border-accent'
                 : 'text-text-secondary hover:text-text-secondary'
             }`}
           >
             <div className="flex items-center gap-2">
               <CheckCircle className="w-4 h-4" />
               My Applications
-              <span className="bg-accent-500/20 text-info-text px-2 py-0.5 rounded text-sm">
+              <span className="bg-accent-soft text-info-text px-2 py-0.5 rounded text-sm">
                 {installedApps.length}
               </span>
             </div>
@@ -286,7 +286,7 @@ export default function Marketplace() {
                     placeholder="Search connectors..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="w-full pl-12 pr-4 py-2 bg-surface-2 text-text-primary rounded-lg border border-border-default focus:border-accent-400 outline-none transition-colors"
+                    className="w-full pl-12 pr-4 py-2 bg-surface-2 text-text-primary rounded-lg border border-border-default focus:border-accent outline-none transition-colors"
                   />
                 </div>
 
@@ -298,7 +298,7 @@ export default function Marketplace() {
                       onClick={() => setSelectedCategory(cat.id)}
                       className={`px-4 py-2 rounded-lg whitespace-nowrap transition-colors ${
                         selectedCategory === cat.id
-                          ? 'bg-accent-500 text-text-primary'
+                          ? 'bg-accent-soft text-accent-strong'
                           : 'bg-surface-2 text-text-secondary hover:bg-surface-3'
                       }`}
                     >
@@ -353,7 +353,7 @@ export default function Marketplace() {
                         {connector.capabilities.slice(0, 3).map((cap) => (
                           <span
                             key={cap}
-                            className="px-2 py-1 text-xs bg-accent-500/10 text-info-text rounded"
+                            className="px-2 py-1 text-xs bg-accent-soft text-info-text rounded"
                           >
                             {cap}
                           </span>
@@ -382,7 +382,7 @@ export default function Marketplace() {
                             setAppName(`${connector.name} Instance`);
                             setShowInstallModal(true);
                           }}
-                          className="flex-1 px-4 py-2 bg-accent-500 hover:bg-accent-500 text-text-primary rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+                          className="flex-1 px-4 py-2 bg-accent-solid hover:brightness-110 text-text-on-solid rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
                         >
                           <Plus className="w-4 h-4" />
                           Install
@@ -425,7 +425,7 @@ export default function Marketplace() {
                   <p className="text-text-secondary mb-4">No installed applications yet</p>
                   <button
                     onClick={() => setActiveTab('connectors')}
-                    className="px-4 py-2 bg-accent-500 hover:bg-accent-500 text-text-primary rounded-lg font-medium transition-colors"
+                    className="px-4 py-2 bg-accent-solid hover:brightness-110 text-text-on-solid rounded-lg font-medium transition-colors"
                   >
                     Browse Marketplace
                   </button>
@@ -524,7 +524,7 @@ export default function Marketplace() {
                       type="text"
                       value={appName}
                       onChange={(e) => setAppName(e.target.value)}
-                      className="w-full px-4 py-2 bg-surface-2 text-text-primary rounded-lg border border-border-default focus:border-accent-400 outline-none"
+                      className="w-full px-4 py-2 bg-surface-2 text-text-primary rounded-lg border border-border-default focus:border-accent outline-none"
                       placeholder="e.g., My Splunk Connector"
                     />
                   </div>
@@ -540,7 +540,7 @@ export default function Marketplace() {
                   <button
                     onClick={() => handleInstall(selectedConnector.id)}
                     disabled={!appName.trim()}
-                    className="flex-1 px-4 py-2 bg-accent-500 hover:bg-accent-500 disabled:bg-surface-3 disabled:cursor-not-allowed text-text-primary rounded-lg font-medium transition-colors"
+                    className="flex-1 px-4 py-2 bg-accent-solid hover:brightness-110 disabled:bg-surface-3 disabled:cursor-not-allowed text-text-on-solid rounded-lg font-medium transition-colors"
                   >
                     Install
                   </button>

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -92,7 +92,7 @@ export const Register = () => {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4 relative overflow-hidden">
       {/* Background Effects */}
-      <div className="absolute top-[-20%] left-[-10%] w-[500px] h-[500px] bg-accent-500/20 rounded-full blur-[120px]" />
+      <div className="absolute top-[-20%] left-[-10%] w-[500px] h-[500px] bg-accent-soft rounded-full blur-[120px]" />
       <div className="absolute bottom-[-20%] right-[-10%] w-[500px] h-[500px] bg-purple-600/20 rounded-full blur-[120px]" />
 
       <motion.div 

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -29,7 +29,7 @@ export const Reports = () => {
   const getTypeColor = (type: string) => {
     switch (type) {
       case 'executive':
-        return 'bg-accent-500/10 text-info-text border-accent-400/20';
+        return 'bg-accent-soft text-info-text border-accent-line';
       case 'technical':
         return 'bg-purple-500/10 text-purple-400 border-purple-500/20';
       case 'compliance':
@@ -104,7 +104,7 @@ export const Reports = () => {
       {/* Action & Filters */}
       <div className="flex flex-col gap-4 mb-6">
         <div className="flex justify-between items-center">
-          <Button variant="primary" className="shadow-lg shadow-blue-500/20">
+          <Button variant="primary">
             <FileText size={16} className="mr-2" /> Generate New Report
           </Button>
           <div className="flex gap-4">

--- a/frontend/src/pages/RoleManagement.tsx
+++ b/frontend/src/pages/RoleManagement.tsx
@@ -35,7 +35,7 @@ interface RoleWithPermissions extends Role {
 
 const levelLabels: Record<number, { name: string; color: string; badge: string }> = {
   0: { name: 'Viewer', color: 'bg-surface-3', badge: 'text-text-secondary' },
-  3: { name: 'Analyst', color: 'bg-accent-500', badge: 'text-info-text' },
+  3: { name: 'Analyst', color: 'bg-accent', badge: 'text-info-text' },
   6: { name: 'Manager', color: 'bg-purple-500', badge: 'text-purple-300' },
   9: { name: 'Admin', color: 'bg-danger', badge: 'text-danger-text' },
 };
@@ -160,7 +160,7 @@ export const RoleManagement = () => {
 
   const getResourceColor = (resource: string) => {
     const colors: Record<string, string> = {
-      reports: 'bg-accent-500/10 text-info-text border-accent-400/20',
+      reports: 'bg-accent-soft text-info-text border-accent-line',
       audit: 'bg-warning/10 text-warning-text border-warning/20',
       connector: 'bg-purple-500/10 text-purple-400 border-purple-500/20',
       user: 'bg-success/10 text-success-text border-success/20',

--- a/frontend/src/pages/TokenManagement.tsx
+++ b/frontend/src/pages/TokenManagement.tsx
@@ -269,7 +269,7 @@ export const TokenManagement = () => {
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   placeholder="e.g., CI/CD Pipeline, DataSync"
-                  className="w-full bg-surface-2 border border-border-default rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent-400"
+                  className="w-full bg-surface-2 border border-border-default rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent"
                 />
               </div>
               <div>
@@ -280,7 +280,7 @@ export const TokenManagement = () => {
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   placeholder="What is this token for?"
-                  className="w-full bg-surface-2 border border-border-default rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent-400 resize-none"
+                  className="w-full bg-surface-2 border border-border-default rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent resize-none"
                   rows={3}
                 />
               </div>
@@ -308,7 +308,7 @@ export const TokenManagement = () => {
             placeholder="Search tokens..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="flex-1 bg-surface-1 border border-border-subtle rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent-400"
+            className="flex-1 bg-surface-1 border border-border-subtle rounded px-3 py-2 text-text-primary text-sm focus:outline-none focus:border-accent"
           />
         </div>
 
@@ -380,7 +380,7 @@ export const TokenManagement = () => {
                           {token.permissions.map((perm) => (
                             <span
                               key={perm}
-                              className="text-xs bg-accent-500/10 text-info-text border border-accent-400/20 rounded px-2 py-1"
+                              className="text-xs bg-accent-soft text-info-text border border-accent-line rounded px-2 py-1"
                             >
                               {perm}
                             </span>
@@ -394,7 +394,7 @@ export const TokenManagement = () => {
                       <>
                         <button
                           onClick={() => handleRotateToken(token.id)}
-                          className="p-2 text-info-text hover:bg-accent-500/10 rounded transition"
+                          className="p-2 text-info-text hover:bg-accent-soft rounded transition"
                           title="Rotate token"
                         >
                           <ChevronDown className="w-4 h-4" />

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -101,7 +101,7 @@ export const Users = () => {
       case 'admin':
         return 'bg-danger/10 text-danger-text border-danger/20';
       case 'analyst':
-        return 'bg-accent-500/10 text-info-text border-accent-400/20';
+        return 'bg-accent-soft text-info-text border-accent-line';
       case 'viewer':
         return 'bg-surface-3/10 text-text-secondary border-border-strong/20';
       default:
@@ -132,7 +132,7 @@ export const Users = () => {
                 <p className="text-sm text-text-secondary">Manage users and permissions</p>
               </div>
             </div>
-            <Button variant="primary" className="shadow-lg shadow-blue-500/20" onClick={() => setShowCreateModal(true)}>
+            <Button variant="primary" onClick={() => setShowCreateModal(true)}>
               <Plus size={16} className="mr-2" /> Create User
             </Button>
           </div>

--- a/frontend/src/shared/ProgressState.tsx
+++ b/frontend/src/shared/ProgressState.tsx
@@ -32,7 +32,7 @@ export function ProgressState({ title, steps = [], activeStep = 0, stat, percent
           ) : (
             <div
               className="h-full rounded-full"
-              style={{ width: `${Math.min(100, Math.max(0, percent))}%`, background: 'linear-gradient(90deg,var(--accent),var(--accent-2))', transition: 'width .4s var(--ease-out, ease)' }}
+              style={{ width: `${Math.min(100, Math.max(0, percent))}%`, background: 'var(--accent)', transition: 'width .4s var(--ease-out, ease)' }}
             />
           )}
         </div>

--- a/frontend/src/shared/ScoreExplainer.tsx
+++ b/frontend/src/shared/ScoreExplainer.tsx
@@ -331,7 +331,7 @@ function FactorBar({
           className="h-full rounded-full"
           style={{
             width: `${width}%`,
-            background: 'linear-gradient(90deg,var(--accent),var(--accent-2))',
+            background: 'var(--accent)',
           }}
         />
       </div>

--- a/frontend/src/shared/UpsellLock.tsx
+++ b/frontend/src/shared/UpsellLock.tsx
@@ -35,7 +35,7 @@ export function UpsellLock({ title, description, ctaLabel, onUpgrade, moment, ch
         style={{ background: 'radial-gradient(120% 90% at 50% 30%, transparent, var(--bg-primary) 78%)' }}
       >
         <div className="max-w-sm" style={{ animation: 'or-fadeup .4s ease' }}>
-          <div className="w-12 h-12 rounded-2xl mx-auto mb-4 flex items-center justify-center text-text-primary" style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-2))', boxShadow: '0 4px 16px var(--accent-glow)' }}>
+          <div className="w-12 h-12 rounded-2xl mx-auto mb-4 flex items-center justify-center text-accent-strong" style={{ background: 'var(--accent-soft)' }}>
             <Lock size={22} />
           </div>
           {moment && (
@@ -48,7 +48,7 @@ export function UpsellLock({ title, description, ctaLabel, onUpgrade, moment, ch
           <button
             onClick={onUpgrade}
             className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary transition-[filter] hover:brightness-110"
-            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))', boxShadow: '0 4px 14px var(--accent-glow)' }}
+            style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             {ctaLabel} <ArrowRight size={16} />
           </button>

--- a/frontend/src/shared/system/Maintenance.tsx
+++ b/frontend/src/shared/system/Maintenance.tsx
@@ -21,7 +21,7 @@ export function Maintenance() {
         <button
           onClick={() => window.location.reload()}
           className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
-          style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+          style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
         >
           <RefreshCw size={16} /> {tr('Réessayer', 'Retry')}
         </button>

--- a/frontend/src/shared/system/NotFound.tsx
+++ b/frontend/src/shared/system/NotFound.tsx
@@ -31,7 +31,7 @@ export function NotFound() {
           <button
             onClick={() => navigate('/')}
             className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
-            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+            style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             <Home size={16} /> {tr('Tableau de bord', 'Dashboard')}
           </button>

--- a/frontend/src/shared/system/ServerError.tsx
+++ b/frontend/src/shared/system/ServerError.tsx
@@ -30,7 +30,7 @@ export function ServerError({ errorId, onRetry }: ServerErrorProps) {
           <button
             onClick={() => (onRetry ? onRetry() : window.location.reload())}
             className="h-10 px-5 rounded-[11px] inline-flex items-center gap-2 text-[13.5px] font-semibold text-text-primary"
-            style={{ background: 'linear-gradient(135deg,var(--accent),var(--accent-hover))' }}
+            style={{ background: 'var(--accent-solid)', color: 'var(--text-on-solid)' }}
           >
             <RefreshCw size={16} /> {tr('Réessayer', 'Try again')}
           </button>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -228,11 +228,12 @@
 
   /* ---- legacy aliases: resolve to the tokens above ----
      DEPRECATED. Kept so the ~2000 call sites written before the contract keep
-     rendering. Nothing new should reference one. --accent-glow in particular
-     is an anti-pattern the design guide names by hand ("never with a glow");
-     its 27 remaining call sites are tracked separately. */
+     rendering. Nothing new should reference one.
+
+     --accent-glow used to live here. It is gone: the design guide names the
+     glow by hand ("never with a glow"), and a token that exists is a token
+     someone reaches for. Deleting the value is what makes the rule stick. */
   --accent-2: var(--info);
-  --accent-glow: rgba(91, 124, 255, 0.35);
   --shadow-sm: var(--elev-1);
   --shadow-md: var(--elev-2);
   --shadow-lg: var(--elev-3);
@@ -371,7 +372,6 @@
 
   /* ---- legacy aliases — see the dark block ---- */
   --accent-2: var(--info);
-  --accent-glow: rgba(27, 58, 224, 0.25);
   --shadow-sm: var(--elev-1);
   --shadow-md: var(--elev-2);
   --shadow-lg: var(--elev-3);
@@ -433,7 +433,6 @@
   --accent-hover: #7ab4ff;
   --accent-soft: rgba(79, 155, 255, 0.14);
   --accent-line: rgba(79, 155, 255, 0.32);
-  --accent-glow: rgba(79, 155, 255, 0.35);
   --font-display: 'Inter';
 }
 
@@ -443,7 +442,6 @@
   --accent-hover: #094e97;
   --accent-soft: rgba(11, 98, 189, 0.1);
   --accent-line: rgba(11, 98, 189, 0.3);
-  --accent-glow: rgba(11, 98, 189, 0.25);
 }
 
 :root[data-variant='iris'] {
@@ -452,7 +450,6 @@
   --accent-hover: #b6acff;
   --accent-soft: rgba(157, 144, 255, 0.16);
   --accent-line: rgba(157, 144, 255, 0.34);
-  --accent-glow: rgba(157, 144, 255, 0.35);
   --font-display: 'DM Sans';
 }
 
@@ -462,5 +459,4 @@
   --accent-hover: #48369f;
   --accent-soft: rgba(91, 70, 201, 0.1);
   --accent-line: rgba(91, 70, 201, 0.3);
-  --accent-glow: rgba(91, 70, 201, 0.25);
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -156,7 +156,6 @@ export default {
           2: 'var(--accent-2)',
           soft: 'var(--accent-soft)',
           line: 'var(--accent-line)',
-          glow: 'var(--accent-glow)',
         },
         // ---- text ----
         ink: {
@@ -219,7 +218,6 @@ export default {
           2: 'var(--accent-2)',
           soft: 'var(--accent-soft)',
           line: 'var(--accent-line)',
-          glow: 'var(--accent-glow)',
         },
       },
 


### PR DESCRIPTION
Closes #424

**Stacked on #423** (`design/422-canonical-token-contract`). Review that first;
this PR's base is that branch, not master, because it deletes a token #423
introduced as deprecated.

## What was wrong

The design guide's anti-cliché list names two things by hand, and the console
did both on its most-used control: a 135° accent gradient as the primary button
fill, under a 12px accent glow.

The shared `Button` component was already correct. The problem was the ~35
buttons that bypass it and hand-roll the fill in an inline style — which is
exactly why the visual suite never caught it: the gallery renders the
design-system components, not the ad-hoc ones.

## The part that was not cosmetic

Twenty of those buttons set `text-text-primary` on the accent fill. Measured in
the light theme:

| | contrast |
| --- | --- |
| `--text-primary` on the gradient's first stop | **2.53:1** |
| `--text-primary` on its second stop | **1.93:1** |
| `--text-on-solid` on `--accent-solid` (now) | **7.70:1** light, 6.49:1 dark |

Both failing values predate this branch. The gradient was not hiding the
problem — it never had enough contrast at either end. Five hardcoded
`color: '#fff'` fall out with the fix.

## The rules applied

| Was | Now |
| --- | --- |
| `linear-gradient(135deg, --accent, --accent-hover)` button | `--accent-solid` + `--text-on-solid` |
| `linear-gradient(135deg, --accent, --accent-2)` icon tile | `--accent-soft` + `accent-strong` glyph — the pattern already used by SessionsPanel, LeaderboardPage, SettingsScreen |
| `linear-gradient(90deg, --accent, --accent-2)` progress fill | flat `--accent` |
| every `box-shadow: … var(--accent-glow)` | removed |
| `--accent-glow` token + 2 Tailwind utilities | deleted |

Two judgement calls, both following the guide rather than inventing:

- **Sidebar avatars** drop the accent gradient. The guide names "the accent
  gradient on Avatar" explicitly — brand decoration on every row showing an owner.
- **The sidebar score bar** blended `--accent` *into* the severity colour, so it
  read as part brand and part critical. A score is a measurement; it is now flat
  severity.

The auth narrative panel keeps its documented dark-in-both-themes exemption, but
is retinted from cool navy `#0a0b12` to the warm neutrals the product now uses,
and loses its two blurred glow blobs.

## Verification

Run against the **full stack** — Postgres + Redis + the Go API + the SPA — not
just the token math:

```
npx tsc -b                     clean
npm run build                  built in 5.72s
npx vitest run                 32 files, 353 tests passed
npx playwright test e2e/visual  41 passed, zero baselines needed regenerating
npm run check:tokens           274 tokens 0 drifting · 164 pairs 0 failing
npx eslint .                   338 problems — down from 342 (the raw #fff)
GET /api/v1/health             {"db":"CONNECTED","status":"UP"}
```

Then driven for real: registered a tenant over the API, completed the
onboarding wizard, and captured sign-in, the wizard, the risk register and
settings in **both themes** at 1600×1000. Flat fills, legible labels, tinted
avatars, no glow anywhere.

**That zero-baseline result is itself the finding.** The gallery covers the DS
components, which were already correct, so it could not have caught this and
did not. The coverage gap is real and is why these 35 buttons drifted.

## Honest remainders

- **The ~35 hand-rolled buttons still bypass `<Button>`.** This PR makes them
  match it; it does not make them *be* it. The gallery still cannot see them,
  so nothing stops the next one drifting. Migrating them to the component is
  the actual fix and is a much larger change — worth its own issue.
- Non-accent gradients are untouched and out of scope per criterion 1: the
  severity tints in WarRoom and DashboardPage, the UpsellLock fade mask, the
  skeleton shimmer.
- `src/App.css` contains three theme-blind hardcoded gradients and appears to be
  imported by nothing. Left alone rather than deleted on a guess.
