### PR TITLE
feat(action-center): build the Action Center aggregation API (#429)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -392,6 +392,21 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
 **Bloc D — Monétisation & croissance (Partie C + 17)**
 11. **Billing & Plans (17.2)** + conversion (Partie C) + **Onboarding (17.6)** + **Super Admin (17.4)**.
 
+**Bloc W1 — Wave 1, fondations produit**
+- [~] **W1-03 — Action Center contextuel** (épique #201, scindée en #429 backend / #430 frontend).
+  **Backend livré** (#429, branche `429-feat-build-the-action-center-aggregation-api-backend`) :
+  `GET /api/v1/action-center` — agrégation **en lecture seule** de six sources existantes (mitigation en
+  retard · risque critique sans mitigation active · approbation dont l'appelant est l'approbateur de
+  l'étape courante · incident ouvert · preuve expirée/expirante · plan de remédiation en retard), tri
+  déterministe (rang de catégorie 1→6 puis clé secondaire propre à chaque catégorie), périmètre par
+  `BusinessRole`, `tenant_id` filtré sur **chacune** des six requêtes (test de mutation à l'appui).
+  Aucune table nouvelle, aucune migration. `internal/application/actioncenter/`,
+  `internal/infrastructure/repository/actioncenter_repository.go`,
+  `internal/handler/action_center_handler.go`. Contrat publié dans `docs/openapi.yaml` +
+  `frontend/src/types/openapi.generated.ts`.
+  **⚠️ Aucun utilisateur ne peut encore l'atteindre** : il n'existe pas d'écran. La capacité ne sera
+  déclarée livrée, et n'entrera dans la matrice de claims, qu'au merge de **#430** (UI). Règle 12.
+
 **Bloc E — Wave 2/3 (gamechangers restants)**
 12. Digital Twin (14.13), War Room (14.14), Attack Path (14.15), Access Review (14.10), Offline (14.17),
     Plugin Marketplace complet (14.18), Vendor (14.2), Policy (14.3), Trust Center (14.4), BCP (14.6),

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 
+	actioncenterapp "github.com/opendefender/openrisk/internal/application/actioncenter"
 	appactivation "github.com/opendefender/openrisk/internal/application/activation"
 	appai "github.com/opendefender/openrisk/internal/application/ai"
 	assetapp "github.com/opendefender/openrisk/internal/application/asset"
@@ -2134,6 +2135,16 @@ func main() {
 	notificationsGroup.Get("/preferences", notificationHandler.GetNotificationPreferences)
 	notificationsGroup.Patch("/preferences", notificationHandler.UpdateNotificationPreferences)
 	notificationsGroup.Post("/test", notificationHandler.TestNotification)
+
+	// --- Action Center (#429) --------------------------------------------------
+	// A live, role-aware read over six existing tables. Registered on `protected`
+	// so it inherits the same auth middleware as /notifications: the endpoint has
+	// no identity of its own to fall back on, and an unauthenticated call must
+	// reach the handler with an empty context and be refused, never be served.
+	actionCenterHandler := handlers.NewActionCenterHandler(
+		actioncenterapp.NewUseCase(repository.NewActionCenterRepository(database.DB)),
+	)
+	protected.Get("/action-center", actionCenterHandler.GetActionCenter)
 
 	// --- Risk Timeline (Protected routes) ---
 	timelineHandler := handlers.NewRiskTimelineHandler()

--- a/backend/internal/application/actioncenter/authorization_test.go
+++ b/backend/internal/application/actioncenter/authorization_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package actioncenter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// categoryReadPermission names the permission a caller must already hold to read
+// the records a category is built from.
+var categoryReadPermission = map[int]domain.PermissionKey{
+	RankOverdueMitigation:  "mitigations:read",
+	RankCriticalRisk:       "risks:read",
+	RankOpenIncident:       "incidents:read",
+	RankExpiringEvidence:   "compliance:evidences:read",
+	RankOverdueRemediation: "compliance:remediations:read",
+	// RankPendingApproval is absent on purpose: approvals are not gated by this
+	// map at all. Eligibility is decided per request by domain.CanSign, so there
+	// is no role→category grant here to check.
+}
+
+// The route deliberately carries no RequirePermission middleware: the gating is
+// finer-grained than any single permission string, because one endpoint spans
+// six resources. That decision is only defensible while the role→category map
+// never shows a role something its own permission preset would refuse.
+//
+// This test is what makes it defensible. It fails the moment someone adds a
+// category to a role that cannot read it — which is exactly the mistake the
+// missing middleware would otherwise let through, and it would surface as a
+// list of titles the caller cannot open rather than as a denied request.
+func TestRoleCategoryMapNeverExceedsTheRolesOwnPermissions(t *testing.T) {
+	for role, ranks := range roleCategories {
+		perms := map[domain.PermissionKey]bool{}
+		for _, p := range domain.BusinessRolePermissions(role) {
+			perms[p] = true
+		}
+		require.NotEmpty(t, perms, "role %q resolves to no permissions at all", role)
+
+		for _, rank := range ranks {
+			need, ok := categoryReadPermission[rank]
+			require.True(t, ok, "category rank %d granted to %q has no declared read permission", rank, role)
+			require.Truef(t, perms[need],
+				"role %q is shown category %d but its preset lacks %q — the Action Center would list records the caller cannot open",
+				role, rank, need)
+		}
+	}
+}
+
+// The map must only ever name roles that actually exist, or a typo would
+// silently downgrade someone to the approvals-only default.
+func TestRoleCategoryMapNamesOnlyRealRoles(t *testing.T) {
+	for role := range roleCategories {
+		require.Truef(t, domain.IsBusinessRole(role),
+			"roleCategories names %q, which is not a business role — a typo here fails open to the default, silently", role)
+	}
+}
+
+// Every rank the map hands out must be one the gather step knows how to build,
+// and must be inside the documented 1..6 range the API contract publishes.
+func TestRoleCategoryMapUsesDeclaredRanksOnly(t *testing.T) {
+	valid := map[int]bool{
+		RankOverdueMitigation: true, RankCriticalRisk: true, RankPendingApproval: true,
+		RankOpenIncident: true, RankExpiringEvidence: true, RankOverdueRemediation: true,
+	}
+	for role, ranks := range roleCategories {
+		for _, r := range ranks {
+			require.Truef(t, valid[r], "role %q is granted unknown category rank %d", role, r)
+			require.Truef(t, r >= 1 && r <= 6, "rank %d for %q is outside the published 1..6 contract", r, role)
+		}
+	}
+}

--- a/backend/internal/application/actioncenter/deeplinks.go
+++ b/backend/internal/application/actioncenter/deeplinks.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package actioncenter
+
+// Deep links. Every path here was checked against the real route table in
+// frontend/src/shared/routeModel.ts and frontend/src/App.tsx. An Action Center
+// whose links 404 is the "inert control presented as live" the constitution
+// forbids (CLAUDE.md rule 12) — and it would be worse than no Action Center,
+// because the list looks authoritative.
+//
+// TWO SHAPES, because the frontend has two ways of opening a thing:
+//
+//  1. A real route with its own page — mitigations, incidents, remediation
+//     plans. These take the id in the path.
+//
+//  2. The universal entity drawer — risks and evidence. There is NO
+//     `/risks/:riskId` page: the risk register opens a risk in a drawer whose
+//     state lives entirely in the query string
+//     (frontend/src/features/entity-drawer/drawerState.ts: `drawer` = entity
+//     type, `entity` = id). The link therefore targets the list route and asks
+//     it to open the drawer, which is the only shareable URL for a risk that
+//     the product actually has.
+//
+// The #429 spec suggested `/risks/{id}`; that route does not exist and was not
+// implemented. See the PR for the correction.
+
+const (
+	// routeMitigationDetail — /risks/mitigations/:mitigationId (App.tsx).
+	routeMitigationDetail = "/risks/mitigations/"
+	// routeRiskRegister — /risks, opened with the drawer params.
+	routeRiskRegister = "/risks"
+	// routeGovernance — /governance. Approvals have no per-request route; the
+	// governance screen is where a pending request is signed.
+	routeGovernance = "/governance"
+	// routeIncidentWarRoom — /incidents/:id/war-room (App.tsx).
+	routeIncidentWarRoom = "/incidents/"
+	// routeEvidenceLibrary — /compliance/evidence, opened with the drawer params.
+	routeEvidenceLibrary = "/compliance/evidence"
+	// routeRemediationDetail — /compliance/remediation/:planId (routeModel.ts).
+	routeRemediationDetail = "/compliance/remediation/"
+)
+
+// drawerQuery builds the entity-drawer query string. Kept in one function so
+// the two drawer-backed categories cannot drift apart.
+func drawerQuery(entityType, id string) string {
+	return "?drawer=" + entityType + "&entity=" + id
+}
+
+func MitigationLink(id string) string  { return routeMitigationDetail + id }
+func RiskLink(id string) string        { return routeRiskRegister + drawerQuery("risk", id) }
+func ApprovalLink() string             { return routeGovernance }
+func IncidentLink(id string) string    { return routeIncidentWarRoom + id + "/war-room" }
+func EvidenceLink(id string) string    { return routeEvidenceLibrary + drawerQuery("evidence", id) }
+func RemediationLink(id string) string { return routeRemediationDetail + id }

--- a/backend/internal/application/actioncenter/usecase.go
+++ b/backend/internal/application/actioncenter/usecase.go
@@ -1,0 +1,528 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+// Package actioncenter answers one question the rest of the product does not:
+// "of everything currently outstanding, what should I personally do first?"
+//
+// It is deliberately NOT the notification bell. The bell
+// (internal/application/notification) is a chronological feed of things that
+// already happened, and it is delivered — each row was written by a producer at
+// the moment of the event. The Action Center is a LIVE READ over the current
+// state of six existing tables: nothing is persisted here, nothing is delivered,
+// and an item disappears from the list the moment the underlying work is done.
+// That is why there is no action_items table and no "dismiss" — dismissing an
+// overdue mitigation would be lying to the person who has to answer for it.
+package actioncenter
+
+import (
+	"errors"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+var (
+	// ErrUnauthorized is returned when the caller carries no usable identity.
+	// Mirrors notification.ErrUnauthorized so the handler layer maps both the
+	// same way.
+	ErrUnauthorized = errors.New("unauthorized")
+)
+
+// ItemType names the source an action item was derived from. The frontend keys
+// its icon and label off this, so the values are contract.
+type ItemType string
+
+const (
+	ItemTypeOverdueMitigation  ItemType = "overdue_mitigation"
+	ItemTypeCriticalRisk       ItemType = "critical_risk"
+	ItemTypePendingApproval    ItemType = "pending_approval"
+	ItemTypeOpenIncident       ItemType = "open_incident"
+	ItemTypeExpiringEvidence   ItemType = "expiring_evidence"
+	ItemTypeOverdueRemediation ItemType = "overdue_remediation"
+)
+
+// Category ranks. Lower sorts first. These are the priority order itself, not a
+// display hint: an overdue mitigation outranks a critical risk because the
+// mitigation is a commitment someone already made and missed, while the risk is
+// a condition that may be correctly accepted.
+const (
+	RankOverdueMitigation  = 1
+	RankCriticalRisk       = 2
+	RankPendingApproval    = 3
+	RankOpenIncident       = 4
+	RankExpiringEvidence   = 5
+	RankOverdueRemediation = 6
+)
+
+// CriticalScoreThreshold is the frozen `critical` cut from the Score Engine
+// (CLAUDE.md: critical >= 7.0). Read here, never recomputed — pkg/scoring owns
+// the formula and this package must not drift from it.
+const CriticalScoreThreshold = 7.0
+
+// perSourceFetchLimit caps how many rows each of the six queries may return
+// before ordering. A tenant with 40 000 overdue mitigations must not be able to
+// turn one page view into a 40 000-row scan; the list is a prioritised top-N,
+// and anything past this cap could not have been reached by paging anyway.
+const perSourceFetchLimit = 200
+
+// DefaultLimit and MaxLimit mirror GetNotifications' clamping.
+const (
+	DefaultLimit = 20
+	MaxLimit     = 100
+)
+
+// ActionItem is a response DTO, not a persisted model. It is assembled on read
+// and has no table.
+type ActionItem struct {
+	ID                  string     `json:"id"`
+	Type                ItemType   `json:"type"`
+	Title               string     `json:"title"`
+	SubjectResourceType string     `json:"subject_resource_type"`
+	SubjectResourceID   string     `json:"subject_resource_id"`
+	DeepLink            string     `json:"deep_link"`
+	DueAt               *time.Time `json:"due_at"`
+	CategoryRank        int        `json:"category_rank"`
+	TenantID            uuid.UUID  `json:"tenant_id"`
+
+	// sortA/sortB are the per-category secondary keys, both ascending. They are
+	// unexported so the ordering rule cannot be contradicted by a client that
+	// decides to re-sort on a field it can see.
+	sortA float64
+	sortB float64
+}
+
+// Result is the full response envelope.
+type Result struct {
+	Data        []ActionItem `json:"data"`
+	GeneratedAt time.Time    `json:"generated_at"`
+	Limit       int          `json:"limit"`
+	Offset      int          `json:"offset"`
+	Total       int          `json:"total"`
+}
+
+// Repository is the persistence port. Every method takes the tenant explicitly
+// and MUST filter on it — there is no ambient tenant here, precisely so that a
+// missing filter is visible at the call site during review.
+//
+// Each method returns rows already narrowed to its category's predicate; the
+// use case does the role gating and the ordering, which keeps both pure and
+// unit-testable without a database.
+type Repository interface {
+	// BusinessRoleFor resolves the caller's GRC job-role preset from their
+	// OrganizationMember row. Returns "" when the member has none.
+	BusinessRoleFor(userID, tenantID uuid.UUID) (domain.BusinessRoleKey, error)
+
+	OverdueMitigations(tenantID uuid.UUID, now time.Time, limit int) ([]domain.Mitigation, error)
+	CriticalRisksWithoutActiveMitigation(tenantID uuid.UUID, threshold float64, limit int) ([]domain.Risk, error)
+	PendingApprovals(tenantID uuid.UUID, limit int) ([]domain.ApprovalRequest, error)
+	OpenIncidents(tenantID uuid.UUID, limit int) ([]domain.Incident, error)
+	ExpiringEvidence(tenantID uuid.UUID, now time.Time, limit int) ([]domain.Evidence, error)
+	OverdueRemediationPlans(tenantID uuid.UUID, now time.Time, limit int) ([]domain.RemediationPlan, error)
+}
+
+// Caller is everything the use case needs to know about who is asking. Built by
+// the handler from the request context; never trusted from a request body.
+type Caller struct {
+	UserID   uuid.UUID
+	TenantID uuid.UUID
+	// Roles are the caller's organisation-level roles (root/admin/user) for this
+	// tenant, plus their business role. Fed to domain.CanSign, which matches a
+	// workflow step's approver_role against them.
+	Roles   []string
+	IsAdmin bool
+}
+
+// roleCategories maps a GRC job role to the categories it is shown.
+//
+// A role appears here only for work it can actually act on. Category 3
+// (approvals) is deliberately absent from every entry: it is NOT role-gated but
+// per-request, and is evaluated separately for every caller by domain.CanSign —
+// see gather(). Adding 3 to a role here would be wrong in both directions, both
+// granting approvals to people who are not the approver and implying that
+// someone whose role is missing from this map cannot be one.
+//
+// A role that is not listed — asset_owner, executive, viewer, dsi,
+// internal_control, risk_owner, security_analyst, or a member with no business
+// role at all — sees ONLY their own pending approvals. That default is
+// intentional and least-privilege: showing someone an "action" they have no
+// permission to complete is worse than showing them nothing, because the item
+// looks like a task and behaves like a locked door.
+var roleCategories = map[domain.BusinessRoleKey][]int{
+	domain.BusinessRoleRSSI:              {RankCriticalRisk, RankOpenIncident},
+	domain.BusinessRoleRiskManager:       {RankOverdueMitigation, RankCriticalRisk},
+	domain.BusinessRoleAuditor:           {RankExpiringEvidence},
+	domain.BusinessRoleComplianceOfficer: {RankExpiringEvidence, RankOverdueRemediation},
+}
+
+// UseCase is the read-only aggregation. It writes nothing, so it needs no
+// transaction.
+type UseCase struct {
+	repo Repository
+	// now is injectable so the ordering tests can pin the clock. Production
+	// wiring leaves it nil and gets time.Now.
+	now func() time.Time
+}
+
+func NewUseCase(repo Repository) *UseCase {
+	return &UseCase{repo: repo}
+}
+
+// WithClock pins the clock, for tests that assert an exact ordering.
+func (uc *UseCase) WithClock(now func() time.Time) *UseCase {
+	uc.now = now
+	return uc
+}
+
+func (uc *UseCase) clock() time.Time {
+	if uc.now != nil {
+		return uc.now()
+	}
+	return time.Now().UTC()
+}
+
+// GetActionCenter returns the caller's prioritised outstanding work.
+//
+// Ordering is total and deterministic: category rank, then the category's own
+// secondary key, then the item id as a final tiebreak so two items that are
+// equal on every business key still come back in a stable order across calls.
+// Without that last tiebreak the list would shuffle between refreshes for a
+// tenant that bulk-imported rows with identical due dates, which reads as a bug.
+func (uc *UseCase) GetActionCenter(caller Caller, limit, offset int) (*Result, error) {
+	if caller.UserID == uuid.Nil || caller.TenantID == uuid.Nil {
+		return nil, ErrUnauthorized
+	}
+	limit, offset = ClampPaging(limit, offset)
+	now := uc.clock()
+
+	role, err := uc.repo.BusinessRoleFor(caller.UserID, caller.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := uc.gather(caller, role, now)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.CategoryRank != b.CategoryRank {
+			return a.CategoryRank < b.CategoryRank
+		}
+		if a.sortA != b.sortA {
+			return a.sortA < b.sortA
+		}
+		if a.sortB != b.sortB {
+			return a.sortB < b.sortB
+		}
+		return a.ID < b.ID
+	})
+
+	total := len(items)
+	page := paginate(items, limit, offset)
+
+	return &Result{
+		Data:        page,
+		GeneratedAt: now,
+		Limit:       limit,
+		Offset:      offset,
+		Total:       total,
+	}, nil
+}
+
+// ClampPaging applies the documented limit/offset rules. Exported so the handler
+// and the tests agree on one implementation.
+func ClampPaging(limit, offset int) (int, int) {
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+// paginate always returns a non-nil slice so the JSON contract is `[]`, never
+// `null` — an empty Action Center is a good day, not a missing field.
+func paginate(items []ActionItem, limit, offset int) []ActionItem {
+	if offset >= len(items) {
+		return []ActionItem{}
+	}
+	end := offset + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	page := make([]ActionItem, 0, end-offset)
+	page = append(page, items[offset:end]...)
+	return page
+}
+
+func allows(role domain.BusinessRoleKey, rank int) bool {
+	for _, r := range roleCategories[role] {
+		if r == rank {
+			return true
+		}
+	}
+	return false
+}
+
+// gather runs only the queries the caller's role can actually use. A compliance
+// officer never triggers the incident scan, which keeps the endpoint's cost
+// proportional to what the caller is allowed to see rather than to the size of
+// the tenant.
+func (uc *UseCase) gather(caller Caller, role domain.BusinessRoleKey, now time.Time) ([]ActionItem, error) {
+	items := make([]ActionItem, 0, 32)
+
+	if allows(role, RankOverdueMitigation) {
+		rows, err := uc.repo.OverdueMitigations(caller.TenantID, now, perSourceFetchLimit)
+		if err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			items = append(items, mitigationItem(&rows[i], now))
+		}
+	}
+
+	if allows(role, RankCriticalRisk) {
+		rows, err := uc.repo.CriticalRisksWithoutActiveMitigation(caller.TenantID, CriticalScoreThreshold, perSourceFetchLimit)
+		if err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			items = append(items, riskItem(&rows[i]))
+		}
+	}
+
+	// Category 3 is ALWAYS evaluated, for every caller, regardless of role: being
+	// the named approver of a pending step is a property of the request, not of
+	// a job title. domain.CanSign is the same predicate the governance module
+	// uses to decide whether the Approve button works, so an item can never
+	// appear here that the caller would be refused on.
+	approvals, err := uc.repo.PendingApprovals(caller.TenantID, perSourceFetchLimit)
+	if err != nil {
+		return nil, err
+	}
+	// The business role joins the caller's org roles for the eligibility check:
+	// a workflow step whose approver_role is "compliance_officer" names a GRC job
+	// role, not an org role, and matching only root/admin/user would refuse the
+	// very people such a step exists to nominate.
+	roles := caller.Roles
+	if role != "" {
+		roles = append(append([]string{}, roles...), string(role))
+	}
+	who := domain.Approver{UserID: caller.UserID, Roles: roles, IsAdmin: caller.IsAdmin}
+	for i := range approvals {
+		req := &approvals[i]
+		step := req.CurrentStepDef()
+		if step == nil {
+			continue
+		}
+		if !domain.CanSign(req, step, who).Eligible {
+			continue
+		}
+		items = append(items, approvalItem(req))
+	}
+
+	if allows(role, RankOpenIncident) {
+		rows, err := uc.repo.OpenIncidents(caller.TenantID, perSourceFetchLimit)
+		if err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			items = append(items, incidentItem(&rows[i]))
+		}
+	}
+
+	if allows(role, RankExpiringEvidence) {
+		rows, err := uc.repo.ExpiringEvidence(caller.TenantID, now, perSourceFetchLimit)
+		if err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			// EffectiveStatus is re-checked here rather than trusted from the
+			// query: the SQL narrows by valid_until, but "rejected" and "pending"
+			// review outrank the calendar and only the domain method knows that.
+			st := rows[i].EffectiveStatus(now)
+			if st != domain.EvidenceStatusExpired && st != domain.EvidenceStatusExpiring {
+				continue
+			}
+			items = append(items, evidenceItem(&rows[i], st, now))
+		}
+	}
+
+	if allows(role, RankOverdueRemediation) {
+		rows, err := uc.repo.OverdueRemediationPlans(caller.TenantID, now, perSourceFetchLimit)
+		if err != nil {
+			return nil, err
+		}
+		for i := range rows {
+			items = append(items, remediationItem(&rows[i], now))
+		}
+	}
+
+	return items, nil
+}
+
+// ---------------------------------------------------------------------------
+// Item builders. Each owns its deep link, so there is exactly one place per
+// category where a link shape is decided (see deeplinks.go for the routes and
+// why they are what they are).
+// ---------------------------------------------------------------------------
+
+func daysBetween(from, to time.Time) float64 {
+	return to.Sub(from).Hours() / 24
+}
+
+func mitigationItem(m *domain.Mitigation, now time.Time) ActionItem {
+	overdue := 0.0
+	if m.DueDate != nil {
+		overdue = daysBetween(*m.DueDate, now)
+	}
+	return ActionItem{
+		ID:                  "mitigation:" + m.ID.String(),
+		Type:                ItemTypeOverdueMitigation,
+		Title:               m.Title,
+		SubjectResourceType: "mitigation",
+		SubjectResourceID:   m.ID.String(),
+		DeepLink:            MitigationLink(m.ID.String()),
+		DueAt:               m.DueDate,
+		CategoryRank:        RankOverdueMitigation,
+		TenantID:            m.TenantID,
+		sortA:               -overdue, // most overdue first
+	}
+}
+
+func riskItem(r *domain.Risk) ActionItem {
+	return ActionItem{
+		ID:                  "risk:" + r.ID.String(),
+		Type:                ItemTypeCriticalRisk,
+		Title:               r.Title,
+		SubjectResourceType: "risk",
+		SubjectResourceID:   r.ID.String(),
+		DeepLink:            RiskLink(r.ID.String()),
+		CategoryRank:        RankCriticalRisk,
+		TenantID:            r.TenantID,
+		sortA:               -r.Score, // highest score first
+	}
+}
+
+func approvalItem(a *domain.ApprovalRequest) ActionItem {
+	// Nulls last: a request with no expiry is not more urgent than one that
+	// lapses on Friday, so it sorts after every dated one.
+	expires := math.MaxFloat64
+	if a.ExpiresAt != nil {
+		expires = float64(a.ExpiresAt.Unix())
+	}
+	return ActionItem{
+		ID:                  "approval:" + a.ID.String(),
+		Type:                ItemTypePendingApproval,
+		Title:               a.Title,
+		SubjectResourceType: "approval_request",
+		SubjectResourceID:   a.ID.String(),
+		DeepLink:            ApprovalLink(),
+		DueAt:               a.ExpiresAt,
+		CategoryRank:        RankPendingApproval,
+		TenantID:            a.TenantID,
+		sortA:               expires,
+		sortB:               float64(a.CreatedAt.Unix()),
+	}
+}
+
+// incidentSeverityRank orders the severity vocabulary. Anything unrecognised
+// sorts last rather than being dropped: an incident with a typo'd severity is
+// still an open incident, and silently hiding it would be the worse failure.
+func incidentSeverityRank(sev string) float64 {
+	switch sev {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	case "low":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func incidentItem(i *domain.Incident) ActionItem {
+	id := strconv.FormatUint(uint64(i.ID), 10)
+	return ActionItem{
+		ID:                  "incident:" + id,
+		Type:                ItemTypeOpenIncident,
+		Title:               i.Title,
+		SubjectResourceType: "incident",
+		SubjectResourceID:   id,
+		DeepLink:            IncidentLink(id),
+		CategoryRank:        RankOpenIncident,
+		// Incident.TenantID is a string on this table, unlike every other model
+		// here. Parsed rather than reinterpreted so a malformed value surfaces as
+		// uuid.Nil instead of silently becoming another tenant's id.
+		TenantID: parseTenant(i.TenantID),
+		sortA:    incidentSeverityRank(i.Severity),
+		sortB:    float64(i.CreatedAt.Unix()), // oldest first within a severity
+	}
+}
+
+func parseTenant(s string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}
+
+func evidenceItem(e *domain.Evidence, st domain.EvidenceStatus, now time.Time) ActionItem {
+	// Expired before expiring_soon, then by how far past (or from) the date.
+	statusRank := 1.0
+	if st == domain.EvidenceStatusExpired {
+		statusRank = 0
+	}
+	days := 0.0
+	if e.ValidUntil != nil {
+		days = daysBetween(now, *e.ValidUntil) // negative once expired
+	}
+	return ActionItem{
+		ID:                  "evidence:" + e.ID.String(),
+		Type:                ItemTypeExpiringEvidence,
+		Title:               e.Title,
+		SubjectResourceType: "evidence",
+		SubjectResourceID:   e.ID.String(),
+		DeepLink:            EvidenceLink(e.ID.String()),
+		DueAt:               e.ValidUntil,
+		CategoryRank:        RankExpiringEvidence,
+		TenantID:            e.TenantID,
+		sortA:               statusRank,
+		sortB:               days,
+	}
+}
+
+func remediationItem(p *domain.RemediationPlan, now time.Time) ActionItem {
+	overdue := 0.0
+	if p.DueDate != nil {
+		overdue = daysBetween(*p.DueDate, now)
+	}
+	return ActionItem{
+		ID:                  "remediation:" + p.ID.String(),
+		Type:                ItemTypeOverdueRemediation,
+		Title:               p.Title,
+		SubjectResourceType: "remediation_plan",
+		SubjectResourceID:   p.ID.String(),
+		DeepLink:            RemediationLink(p.ID.String()),
+		DueAt:               p.DueDate,
+		CategoryRank:        RankOverdueRemediation,
+		TenantID:            p.TenantID,
+		sortA:               -overdue,
+	}
+}

--- a/backend/internal/application/actioncenter/usecase_test.go
+++ b/backend/internal/application/actioncenter/usecase_test.go
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package actioncenter
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// A pinned clock, so "overdue by three days" means the same thing on every run.
+var testNow = time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+
+func ptime(t time.Time) *time.Time { return &t }
+
+// stubRepo returns whatever the test seeded, and RECORDS which categories were
+// asked for. The recording is the point: role scoping must not merely filter the
+// output, it must avoid running the query at all, and a stub that only checked
+// the returned items could not tell the difference.
+type stubRepo struct {
+	role domain.BusinessRoleKey
+
+	mitigations []domain.Mitigation
+	risks       []domain.Risk
+	approvals   []domain.ApprovalRequest
+	incidents   []domain.Incident
+	evidence    []domain.Evidence
+	remediation []domain.RemediationPlan
+
+	called map[string]bool
+	err    error
+}
+
+func newStub() *stubRepo { return &stubRepo{called: map[string]bool{}} }
+
+func (s *stubRepo) mark(k string) { s.called[k] = true }
+
+func (s *stubRepo) BusinessRoleFor(_, _ uuid.UUID) (domain.BusinessRoleKey, error) {
+	return s.role, s.err
+}
+func (s *stubRepo) OverdueMitigations(_ uuid.UUID, _ time.Time, _ int) ([]domain.Mitigation, error) {
+	s.mark("mitigations")
+	return s.mitigations, s.err
+}
+func (s *stubRepo) CriticalRisksWithoutActiveMitigation(_ uuid.UUID, _ float64, _ int) ([]domain.Risk, error) {
+	s.mark("risks")
+	return s.risks, s.err
+}
+func (s *stubRepo) PendingApprovals(_ uuid.UUID, _ int) ([]domain.ApprovalRequest, error) {
+	s.mark("approvals")
+	return s.approvals, s.err
+}
+func (s *stubRepo) OpenIncidents(_ uuid.UUID, _ int) ([]domain.Incident, error) {
+	s.mark("incidents")
+	return s.incidents, s.err
+}
+func (s *stubRepo) ExpiringEvidence(_ uuid.UUID, _ time.Time, _ int) ([]domain.Evidence, error) {
+	s.mark("evidence")
+	return s.evidence, s.err
+}
+func (s *stubRepo) OverdueRemediationPlans(_ uuid.UUID, _ time.Time, _ int) ([]domain.RemediationPlan, error) {
+	s.mark("remediation")
+	return s.remediation, s.err
+}
+
+var (
+	tenantA = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	userA   = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	otherU  = uuid.MustParse("33333333-3333-3333-3333-333333333333")
+)
+
+func caller() Caller {
+	return Caller{UserID: userA, TenantID: tenantA, Roles: []string{"user"}}
+}
+
+func newUC(repo Repository) *UseCase {
+	return NewUseCase(repo).WithClock(func() time.Time { return testNow })
+}
+
+// seedAll gives the tenant at least one qualifying item in every category, so a
+// role test can prove both what is shown and what is withheld.
+func seedAll(s *stubRepo) {
+	s.mitigations = []domain.Mitigation{{
+		ID: uuid.New(), TenantID: tenantA, Title: "Patch the edge proxy",
+		Status: domain.MitigationInProgress, DueDate: ptime(testNow.AddDate(0, 0, -3)),
+	}}
+	s.risks = []domain.Risk{{
+		ID: uuid.New(), TenantID: tenantA, Title: "Unpatched internet-facing host", Score: 8.4,
+	}}
+	s.incidents = []domain.Incident{{
+		ID: 7, TenantID: tenantA.String(), Title: "Suspected exfiltration",
+		Severity: "critical", Status: "open", CreatedAt: testNow.AddDate(0, 0, -1),
+	}}
+	s.evidence = []domain.Evidence{{
+		ID: uuid.New(), TenantID: tenantA, Title: "Q2 access review",
+		Review: domain.EvidenceReviewAccepted, ValidUntil: ptime(testNow.AddDate(0, 0, -5)),
+	}}
+	s.remediation = []domain.RemediationPlan{{
+		ID: uuid.New(), TenantID: tenantA, Title: "Close the logging gap",
+		Status: domain.RemediationStatusOpen, DueDate: ptime(testNow.AddDate(0, 0, -2)),
+	}}
+}
+
+func types(items []ActionItem) []ItemType {
+	out := make([]ItemType, 0, len(items))
+	for _, i := range items {
+		out = append(out, i.Type)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 8 — unauthenticated callers
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_Unauthorized(t *testing.T) {
+	uc := newUC(newStub())
+
+	for _, tc := range []struct {
+		name   string
+		caller Caller
+	}{
+		{"no user", Caller{TenantID: tenantA}},
+		{"no tenant", Caller{UserID: userA}},
+		{"neither", Caller{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := uc.GetActionCenter(tc.caller, 20, 0)
+			require.ErrorIs(t, err, ErrUnauthorized)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 7 — an empty Action Center is a good day, not an error
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_Empty(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+
+	res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+	require.NoError(t, err)
+	require.NotNil(t, res.Data, "data must marshal to [] and never to null")
+	require.Len(t, res.Data, 0)
+	require.Equal(t, 0, res.Total)
+	require.Equal(t, testNow, res.GeneratedAt)
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 3 — role scoping, one sub-test per mapped role plus the default
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_RoleScoping(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		role      domain.BusinessRoleKey
+		wantTypes []ItemType
+		wantCalls []string
+		denyCalls []string
+	}{
+		{
+			name: "RiskManager", role: domain.BusinessRoleRiskManager,
+			wantTypes: []ItemType{ItemTypeOverdueMitigation, ItemTypeCriticalRisk},
+			wantCalls: []string{"mitigations", "risks"},
+			denyCalls: []string{"incidents", "evidence", "remediation"},
+		},
+		{
+			name: "RSSI", role: domain.BusinessRoleRSSI,
+			wantTypes: []ItemType{ItemTypeCriticalRisk, ItemTypeOpenIncident},
+			wantCalls: []string{"risks", "incidents"},
+			denyCalls: []string{"mitigations", "evidence", "remediation"},
+		},
+		{
+			name: "Auditor", role: domain.BusinessRoleAuditor,
+			wantTypes: []ItemType{ItemTypeExpiringEvidence},
+			wantCalls: []string{"evidence"},
+			denyCalls: []string{"mitigations", "risks", "incidents", "remediation"},
+		},
+		{
+			name: "ComplianceOfficer", role: domain.BusinessRoleComplianceOfficer,
+			wantTypes: []ItemType{ItemTypeExpiringEvidence, ItemTypeOverdueRemediation},
+			wantCalls: []string{"evidence", "remediation"},
+			denyCalls: []string{"mitigations", "risks", "incidents"},
+		},
+		{
+			// The least-privilege default: an unmapped role sees nothing but its
+			// own approvals, and there are none seeded here.
+			name: "Executive falls back to approvals only", role: domain.BusinessRoleExecutive,
+			wantTypes: []ItemType{},
+			wantCalls: []string{"approvals"},
+			denyCalls: []string{"mitigations", "risks", "incidents", "evidence", "remediation"},
+		},
+		{
+			name: "no business role at all", role: "",
+			wantTypes: []ItemType{},
+			wantCalls: []string{"approvals"},
+			denyCalls: []string{"mitigations", "risks", "incidents", "evidence", "remediation"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStub()
+			s.role = tc.role
+			seedAll(s) // every category has a qualifying item for this tenant
+
+			res, err := newUC(s).GetActionCenter(caller(), 50, 0)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTypes, types(res.Data))
+
+			for _, c := range tc.wantCalls {
+				require.True(t, s.called[c], "expected the %s query to run", c)
+			}
+			for _, c := range tc.denyCalls {
+				require.False(t, s.called[c],
+					"%s must not even be queried for role %q — role scoping has to gate the query, not just the output",
+					c, tc.role)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 5 — approvals are per-request, never role-gated
+// ---------------------------------------------------------------------------
+
+func pendingApprovalNaming(approver uuid.UUID, requestedBy uuid.UUID, title string) domain.ApprovalRequest {
+	return domain.ApprovalRequest{
+		ID: uuid.New(), TenantID: tenantA, Title: title,
+		Status:      domain.ApprovalPending,
+		CurrentStep: 0,
+		Steps: domain.WorkflowStepList{{
+			Order: 0, Name: "Sign-off", MinApprovals: 1,
+			ApproverUserIDs: []string{approver.String()},
+		}},
+		RequestedBy: requestedBy,
+		CreatedAt:   testNow.AddDate(0, 0, -1),
+	}
+}
+
+func TestActionCenter_ApprovalAlwaysIncluded(t *testing.T) {
+	// Executive is deliberately NOT in roleCategories: if approvals were role
+	// gated, this caller would see nothing.
+	for _, role := range []domain.BusinessRoleKey{
+		domain.BusinessRoleExecutive, domain.BusinessRoleViewer,
+		domain.BusinessRoleAuditor, "",
+	} {
+		t.Run(string("role="+role), func(t *testing.T) {
+			s := newStub()
+			s.role = role
+			s.approvals = []domain.ApprovalRequest{
+				pendingApprovalNaming(userA, otherU, "Approve the new vendor"),
+			}
+
+			res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+			require.NoError(t, err)
+			require.Equal(t, []ItemType{ItemTypePendingApproval}, types(res.Data))
+			require.Equal(t, "Approve the new vendor", res.Data[0].Title)
+		})
+	}
+}
+
+func TestActionCenter_ApprovalExcludedWhenCallerIsNotTheApprover(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+	s.approvals = []domain.ApprovalRequest{
+		// Named for somebody else.
+		pendingApprovalNaming(otherU, otherU, "Not yours to sign"),
+		// Raised by the caller: the four-eyes rule in domain.CanSign means you
+		// cannot approve your own request, so this must not appear either.
+		pendingApprovalNaming(userA, userA, "Your own request"),
+	}
+
+	res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+	require.NoError(t, err)
+	require.Empty(t, res.Data,
+		"an approval the caller would be refused at the button must never be listed as their action")
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 4 — deterministic ordering
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_PriorityOrdering(t *testing.T) {
+	s := newStub()
+	// An admin sees every category, which is what lets one fixture assert the
+	// whole cross-category order in a single sequence.
+	s.role = domain.BusinessRoleRiskManager
+
+	older := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000001")
+	newer := uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000002")
+	s.mitigations = []domain.Mitigation{
+		{ID: newer, TenantID: tenantA, Title: "overdue 1d", Status: domain.MitigationPlanned,
+			DueDate: ptime(testNow.AddDate(0, 0, -1))},
+		{ID: older, TenantID: tenantA, Title: "overdue 30d", Status: domain.MitigationPlanned,
+			DueDate: ptime(testNow.AddDate(0, 0, -30))},
+	}
+	s.risks = []domain.Risk{
+		{ID: uuid.New(), TenantID: tenantA, Title: "score 7.1", Score: 7.1},
+		{ID: uuid.New(), TenantID: tenantA, Title: "score 9.9", Score: 9.9},
+	}
+
+	res, err := newUC(s).GetActionCenter(caller(), 50, 0)
+	require.NoError(t, err)
+
+	titles := []string{}
+	for _, i := range res.Data {
+		titles = append(titles, i.Title)
+	}
+	require.Equal(t, []string{
+		// Category 1 first, most overdue first inside it…
+		"overdue 30d", "overdue 1d",
+		// …then category 2, highest score first.
+		"score 9.9", "score 7.1",
+	}, titles)
+
+	// And the ranks are actually carried on the wire, not merely implied by the
+	// order, so the frontend can group without re-deriving the rule.
+	require.Equal(t, []int{RankOverdueMitigation, RankOverdueMitigation, RankCriticalRisk, RankCriticalRisk},
+		[]int{res.Data[0].CategoryRank, res.Data[1].CategoryRank, res.Data[2].CategoryRank, res.Data[3].CategoryRank})
+}
+
+func TestActionCenter_OrderingWithinRemainingCategories(t *testing.T) {
+	t.Run("approvals: expiry ascending, nulls last", func(t *testing.T) {
+		s := newStub()
+		s.role = ""
+		soon := pendingApprovalNaming(userA, otherU, "expires soon")
+		soon.ExpiresAt = ptime(testNow.AddDate(0, 0, 1))
+		later := pendingApprovalNaming(userA, otherU, "expires later")
+		later.ExpiresAt = ptime(testNow.AddDate(0, 0, 9))
+		never := pendingApprovalNaming(userA, otherU, "no expiry")
+		s.approvals = []domain.ApprovalRequest{never, later, soon}
+
+		res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"expires soon", "expires later", "no expiry"},
+			[]string{res.Data[0].Title, res.Data[1].Title, res.Data[2].Title})
+	})
+
+	t.Run("incidents: severity then oldest first", func(t *testing.T) {
+		s := newStub()
+		s.role = domain.BusinessRoleRSSI
+		s.incidents = []domain.Incident{
+			{ID: 1, TenantID: tenantA.String(), Title: "high, new", Severity: "high", Status: "open", CreatedAt: testNow.AddDate(0, 0, -1)},
+			{ID: 2, TenantID: tenantA.String(), Title: "critical, new", Severity: "critical", Status: "open", CreatedAt: testNow.AddDate(0, 0, -1)},
+			{ID: 3, TenantID: tenantA.String(), Title: "critical, old", Severity: "critical", Status: "investigating", CreatedAt: testNow.AddDate(0, 0, -20)},
+		}
+		res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"critical, old", "critical, new", "high, new"},
+			[]string{res.Data[0].Title, res.Data[1].Title, res.Data[2].Title})
+	})
+
+	t.Run("evidence: expired before expiring_soon", func(t *testing.T) {
+		s := newStub()
+		s.role = domain.BusinessRoleAuditor
+		s.evidence = []domain.Evidence{
+			{ID: uuid.New(), TenantID: tenantA, Title: "expiring in 3d",
+				Review: domain.EvidenceReviewAccepted, ValidUntil: ptime(testNow.AddDate(0, 0, 3))},
+			{ID: uuid.New(), TenantID: tenantA, Title: "expired 10d ago",
+				Review: domain.EvidenceReviewAccepted, ValidUntil: ptime(testNow.AddDate(0, 0, -10))},
+		}
+		res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"expired 10d ago", "expiring in 3d"},
+			[]string{res.Data[0].Title, res.Data[1].Title})
+	})
+}
+
+// Rejected evidence is not proof, whatever the calendar says — the use case must
+// defer to EffectiveStatus rather than trusting the SQL date window.
+func TestActionCenter_RejectedEvidenceIsNotAnAction(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleAuditor
+	s.evidence = []domain.Evidence{
+		{ID: uuid.New(), TenantID: tenantA, Title: "rejected and expired",
+			Review: domain.EvidenceReviewRejected, ValidUntil: ptime(testNow.AddDate(0, 0, -10))},
+	}
+	res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+	require.NoError(t, err)
+	require.Empty(t, res.Data)
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 10 — a caller with items across several categories at once
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_Success(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+	seedAll(s)
+	s.approvals = []domain.ApprovalRequest{
+		pendingApprovalNaming(userA, otherU, "Approve the treatment plan"),
+	}
+
+	res, err := newUC(s).GetActionCenter(caller(), 20, 0)
+	require.NoError(t, err)
+
+	// Three categories: mitigation (1), risk (2), approval (3) — the seeded
+	// incident/evidence/remediation belong to categories a risk manager is not
+	// shown.
+	require.Equal(t, []ItemType{
+		ItemTypeOverdueMitigation, ItemTypeCriticalRisk, ItemTypePendingApproval,
+	}, types(res.Data))
+	require.Equal(t, 3, res.Total)
+
+	for _, item := range res.Data {
+		require.Equal(t, tenantA, item.TenantID, "every item must carry the caller's tenant")
+		require.NotEmpty(t, item.ID)
+		require.NotEmpty(t, item.Title)
+		require.NotEmpty(t, item.DeepLink)
+		require.NotEmpty(t, item.SubjectResourceID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 6 — paging
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_ClampPaging(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		inLimit, inOffset     int
+		wantLimit, wantOffset int
+	}{
+		{"default when unset", 0, 0, DefaultLimit, 0},
+		{"default when negative", -5, 0, DefaultLimit, 0},
+		{"clamped to max", 5000, 0, MaxLimit, 0},
+		{"exact max kept", 100, 0, 100, 0},
+		{"honoured in range", 7, 3, 7, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l, o := ClampPaging(tc.inLimit, tc.inOffset)
+			require.Equal(t, tc.wantLimit, l)
+			require.Equal(t, tc.wantOffset, o)
+		})
+	}
+}
+
+func TestActionCenter_Paginates(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+	for i := 0; i < 5; i++ {
+		s.risks = append(s.risks, domain.Risk{
+			ID: uuid.New(), TenantID: tenantA, Title: "risk", Score: float64(10 - i),
+		})
+	}
+
+	first, err := newUC(s).GetActionCenter(caller(), 2, 0)
+	require.NoError(t, err)
+	require.Len(t, first.Data, 2)
+	require.Equal(t, 5, first.Total, "total counts everything outstanding, not the page")
+
+	last, err := newUC(s).GetActionCenter(caller(), 2, 4)
+	require.NoError(t, err)
+	require.Len(t, last.Data, 1)
+
+	// Past the end is an empty page, not an error and not null.
+	beyond, err := newUC(s).GetActionCenter(caller(), 2, 99)
+	require.NoError(t, err)
+	require.NotNil(t, beyond.Data)
+	require.Len(t, beyond.Data, 0)
+}
+
+// ---------------------------------------------------------------------------
+// Criterion 9 — deep links match real frontend routes
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_DeepLinkShapes(t *testing.T) {
+	id := "0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"mitigation", MitigationLink(id), "/risks/mitigations/" + id},
+		// No /risks/:riskId page exists; the register opens the entity drawer.
+		{"risk", RiskLink(id), "/risks?drawer=risk&entity=" + id},
+		{"approval", ApprovalLink(), "/governance"},
+		{"incident", IncidentLink("42"), "/incidents/42/war-room"},
+		{"evidence", EvidenceLink(id), "/compliance/evidence?drawer=evidence&entity=" + id},
+		{"remediation", RemediationLink(id), "/compliance/remediation/" + id},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.got)
+		})
+	}
+}
+
+func TestActionCenter_EveryItemTypeProducesItsDocumentedLink(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleComplianceOfficer
+	seedAll(s)
+	s.approvals = []domain.ApprovalRequest{pendingApprovalNaming(userA, otherU, "sign")}
+
+	res, err := newUC(s).GetActionCenter(caller(), 50, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Data)
+
+	prefixes := map[ItemType]string{
+		ItemTypePendingApproval:    "/governance",
+		ItemTypeExpiringEvidence:   "/compliance/evidence?drawer=evidence&entity=",
+		ItemTypeOverdueRemediation: "/compliance/remediation/",
+	}
+	for _, item := range res.Data {
+		want, ok := prefixes[item.Type]
+		require.True(t, ok, "unexpected item type %q", item.Type)
+		require.True(t, len(item.DeepLink) >= len(want) && item.DeepLink[:len(want)] == want,
+			"deep link %q for %q must start with %q", item.DeepLink, item.Type, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repository failures surface rather than silently truncating the list
+// ---------------------------------------------------------------------------
+
+func TestActionCenter_RepositoryErrorPropagates(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+	s.err = errors.New("db down")
+
+	_, err := newUC(s).GetActionCenter(caller(), 20, 0)
+	require.Error(t, err,
+		"a half-built Action Center is worse than an error: it reads as 'nothing needs you'")
+}

--- a/backend/internal/application/actioncenter/usecase_test.go
+++ b/backend/internal/application/actioncenter/usecase_test.go
@@ -7,6 +7,7 @@ package actioncenter
 
 import (
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -467,6 +468,31 @@ func TestActionCenter_Paginates(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, beyond.Data)
 	require.Len(t, beyond.Data, 0)
+}
+
+// An absurd offset must not overflow int when added to the limit. The early
+// "offset past the end" return is what makes that safe, so it is asserted here
+// rather than left as a property of the arithmetic.
+func TestActionCenter_PagingExtremesDoNotPanic(t *testing.T) {
+	s := newStub()
+	s.role = domain.BusinessRoleRiskManager
+	s.risks = []domain.Risk{{ID: uuid.New(), TenantID: tenantA, Title: "r", Score: 9}}
+
+	for _, tc := range []struct {
+		name          string
+		limit, offset int
+	}{
+		{"max int offset", 100, math.MaxInt},
+		{"max int on both", math.MaxInt, math.MaxInt},
+		{"max int limit", math.MaxInt, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := newUC(s).GetActionCenter(caller(), tc.limit, tc.offset)
+			require.NoError(t, err)
+			require.NotNil(t, res.Data)
+			require.LessOrEqual(t, res.Limit, MaxLimit)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/handler/action_center_handler.go
+++ b/backend/internal/handler/action_center_handler.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	actioncenterapp "github.com/opendefender/openrisk/internal/application/actioncenter"
+	"github.com/opendefender/openrisk/internal/middleware"
+)
+
+// ActionCenterHandler exposes the contextual Action Center (#429).
+type ActionCenterHandler struct {
+	useCase *actioncenterapp.UseCase
+}
+
+func NewActionCenterHandler(useCase *actioncenterapp.UseCase) *ActionCenterHandler {
+	return &ActionCenterHandler{useCase: useCase}
+}
+
+// GetActionCenter returns the caller's prioritised outstanding work.
+// GET /api/v1/action-center
+func (h *ActionCenterHandler) GetActionCenter(c *fiber.Ctx) error {
+	caller := callerFromCtx(c)
+
+	limit := c.QueryInt("limit", actioncenterapp.DefaultLimit)
+	offset := c.QueryInt("offset", 0)
+
+	// A negative offset is rejected rather than clamped, matching
+	// GetNotifications: asking for page -1 is a client bug, and quietly serving
+	// page 0 instead hides it.
+	if offset < 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid offset"})
+	}
+
+	result, err := h.useCase.GetActionCenter(caller, limit, offset)
+	if err != nil {
+		if err == actioncenterapp.ErrUnauthorized {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "unauthorized"})
+		}
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to retrieve action center",
+		})
+	}
+
+	return c.JSON(result)
+}
+
+// callerFromCtx derives the caller's identity from the JWT only. Nothing here
+// may come from the query string or the body: the tenant and the user id are
+// what every one of the six aggregation queries filters on, so a client-supplied
+// value would be a cross-tenant read waiting to happen.
+func callerFromCtx(c *fiber.Ctx) actioncenterapp.Caller {
+	caller := actioncenterapp.Caller{
+		UserID:   safeGetUUID(c, "user_id"),
+		TenantID: safeGetUUID(c, "tenant_id"),
+	}
+	claims := middleware.GetUserClaims(c)
+	if claims == nil {
+		return caller
+	}
+	if claims.HasPermission("*") {
+		caller.IsAdmin = true
+	}
+	seen := map[string]struct{}{}
+	for _, r := range claims.OrgRoles {
+		if r == "admin" || r == "root" {
+			caller.IsAdmin = true
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		caller.Roles = append(caller.Roles, r)
+	}
+	return caller
+}

--- a/backend/internal/handler/action_center_handler_test.go
+++ b/backend/internal/handler/action_center_handler_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	actioncenterapp "github.com/opendefender/openrisk/internal/application/actioncenter"
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+type acStubRepo struct {
+	role  domain.BusinessRoleKey
+	risks []domain.Risk
+}
+
+func (s *acStubRepo) BusinessRoleFor(_, _ uuid.UUID) (domain.BusinessRoleKey, error) {
+	return s.role, nil
+}
+func (s *acStubRepo) OverdueMitigations(_ uuid.UUID, _ time.Time, _ int) ([]domain.Mitigation, error) {
+	return nil, nil
+}
+func (s *acStubRepo) CriticalRisksWithoutActiveMitigation(_ uuid.UUID, _ float64, _ int) ([]domain.Risk, error) {
+	return s.risks, nil
+}
+func (s *acStubRepo) PendingApprovals(_ uuid.UUID, _ int) ([]domain.ApprovalRequest, error) {
+	return nil, nil
+}
+func (s *acStubRepo) OpenIncidents(_ uuid.UUID, _ int) ([]domain.Incident, error) { return nil, nil }
+func (s *acStubRepo) ExpiringEvidence(_ uuid.UUID, _ time.Time, _ int) ([]domain.Evidence, error) {
+	return nil, nil
+}
+func (s *acStubRepo) OverdueRemediationPlans(_ uuid.UUID, _ time.Time, _ int) ([]domain.RemediationPlan, error) {
+	return nil, nil
+}
+
+// setupActionCenterApp mounts the route behind a stand-in for the auth
+// middleware. `authenticated=false` populates nothing, which is exactly what the
+// real stack leaves behind when a request arrives without a valid token.
+func setupActionCenterApp(repo actioncenterapp.Repository, authenticated bool) *fiber.App {
+	app := fiber.New()
+	h := NewActionCenterHandler(actioncenterapp.NewUseCase(repo))
+	app.Use(func(c *fiber.Ctx) error {
+		if authenticated {
+			c.Locals("user_id", uuid.New())
+			c.Locals("tenant_id", uuid.New())
+		}
+		return c.Next()
+	})
+	app.Get("/api/v1/action-center", h.GetActionCenter)
+	return app
+}
+
+func doGet(t *testing.T, app *fiber.App, url string) (int, map[string]any) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest("GET", url, nil))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var body map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &body)
+	}
+	return resp.StatusCode, body
+}
+
+// Criterion 8.
+func TestActionCenterHandler_Unauthorized(t *testing.T) {
+	app := setupActionCenterApp(&acStubRepo{}, false)
+	status, body := doGet(t, app, "/api/v1/action-center")
+	require.Equal(t, fiber.StatusUnauthorized, status)
+	require.Equal(t, "unauthorized", body["error"])
+}
+
+// Criterion 1 and 7.
+func TestActionCenterHandler_EnvelopeShape(t *testing.T) {
+	app := setupActionCenterApp(&acStubRepo{role: domain.BusinessRoleRiskManager}, true)
+	status, body := doGet(t, app, "/api/v1/action-center")
+
+	require.Equal(t, fiber.StatusOK, status)
+	require.Contains(t, body, "data")
+	require.Contains(t, body, "generated_at")
+	require.Contains(t, body, "limit")
+	require.Contains(t, body, "offset")
+
+	// An empty Action Center must serialise as [] — a null here would make the
+	// frontend's .map() throw on the happy path of having nothing to do.
+	data, ok := body["data"].([]any)
+	require.True(t, ok, "data must be a JSON array, got %T", body["data"])
+	require.Len(t, data, 0)
+
+	_, err := time.Parse(time.RFC3339, body["generated_at"].(string))
+	require.NoError(t, err, "generated_at must be RFC3339")
+}
+
+// Criterion 6.
+func TestActionCenterHandler_Paging(t *testing.T) {
+	repo := &acStubRepo{role: domain.BusinessRoleRiskManager}
+	for i := 0; i < 3; i++ {
+		repo.risks = append(repo.risks, domain.Risk{
+			ID: uuid.New(), TenantID: uuid.New(), Title: "r", Score: 9,
+		})
+	}
+	app := setupActionCenterApp(repo, true)
+
+	t.Run("defaults to 20", func(t *testing.T) {
+		status, body := doGet(t, app, "/api/v1/action-center")
+		require.Equal(t, fiber.StatusOK, status)
+		require.Equal(t, float64(20), body["limit"])
+		require.Equal(t, float64(0), body["offset"])
+	})
+
+	t.Run("clamps above 100", func(t *testing.T) {
+		_, body := doGet(t, app, "/api/v1/action-center?limit=5000")
+		require.Equal(t, float64(100), body["limit"])
+	})
+
+	t.Run("honours a limit in range", func(t *testing.T) {
+		_, body := doGet(t, app, "/api/v1/action-center?limit=2")
+		require.Equal(t, float64(2), body["limit"])
+		require.Len(t, body["data"].([]any), 2)
+	})
+
+	t.Run("rejects a negative offset", func(t *testing.T) {
+		status, body := doGet(t, app, "/api/v1/action-center?offset=-1")
+		require.Equal(t, fiber.StatusBadRequest, status)
+		require.Equal(t, "invalid offset", body["error"])
+	})
+
+	t.Run("offset past the end is an empty page, not an error", func(t *testing.T) {
+		status, body := doGet(t, app, "/api/v1/action-center?offset=999")
+		require.Equal(t, fiber.StatusOK, status)
+		require.Len(t, body["data"].([]any), 0)
+	})
+}
+
+// The response must carry the fields the frontend issue (#430) builds against.
+func TestActionCenterHandler_ItemContract(t *testing.T) {
+	repo := &acStubRepo{
+		role:  domain.BusinessRoleRiskManager,
+		risks: []domain.Risk{{ID: uuid.New(), TenantID: uuid.New(), Title: "Critical risk", Score: 9.4}},
+	}
+	app := setupActionCenterApp(repo, true)
+	_, body := doGet(t, app, "/api/v1/action-center")
+
+	items := body["data"].([]any)
+	require.Len(t, items, 1)
+	item := items[0].(map[string]any)
+
+	for _, k := range []string{
+		"id", "type", "title", "subject_resource_type", "subject_resource_id",
+		"deep_link", "due_at", "category_rank", "tenant_id",
+	} {
+		require.Contains(t, item, k, "ActionItem must expose %q", k)
+	}
+	require.Equal(t, string(actioncenterapp.ItemTypeCriticalRisk), item["type"])
+	require.Equal(t, float64(actioncenterapp.RankCriticalRisk), item["category_rank"])
+	require.Contains(t, item["deep_link"], "/risks?drawer=risk&entity=")
+}

--- a/backend/internal/infrastructure/repository/actioncenter_repository.go
+++ b/backend/internal/infrastructure/repository/actioncenter_repository.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/opendefender/openrisk/internal/application/actioncenter"
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// ActionCenterRepository reads the six existing tables the Action Center
+// aggregates. It owns no table of its own and writes nothing.
+//
+// EVERY method here filters on the tenant. That is not a convention in this
+// file, it is the entire security model of the endpoint: the use case above has
+// no way to re-filter what it is handed, so a missing WHERE here is a
+// cross-tenant leak with no second line of defence (CLAUDE.md rule 2, P0). The
+// tenant is always the first parameter for exactly that reason — it is
+// impossible to call one of these methods without deciding on a tenant.
+type ActionCenterRepository struct {
+	db *gorm.DB
+}
+
+func NewActionCenterRepository(db *gorm.DB) *ActionCenterRepository {
+	return &ActionCenterRepository{db: db}
+}
+
+// guard fails closed on a zero tenant. A uuid.Nil reaching a WHERE clause would
+// match nothing today, but it would also mean the caller's identity was never
+// established, and that is a bug we want loud rather than empty.
+func guard(tenantID uuid.UUID) error {
+	if tenantID == uuid.Nil {
+		return domain.ErrForbidden
+	}
+	return nil
+}
+
+// BusinessRoleFor resolves the caller's GRC job-role preset. Scoped by BOTH the
+// user and the organisation: a person who belongs to two tenants holds a
+// different business role in each, and reading the wrong row would hand them
+// the wrong tenant's view of their own work.
+func (r *ActionCenterRepository) BusinessRoleFor(userID, tenantID uuid.UUID) (domain.BusinessRoleKey, error) {
+	if err := guard(tenantID); err != nil {
+		return "", err
+	}
+	var member domain.OrganizationMember
+	err := r.db.
+		Where("user_id = ? AND organization_id = ?", userID, tenantID).
+		First(&member).Error
+	if err != nil {
+		// A caller with no membership row has no business role, which the use
+		// case treats as the least-privilege default (approvals only). Not an
+		// error: a root/admin operating outside a member row is legitimate.
+		if err == gorm.ErrRecordNotFound {
+			return "", nil
+		}
+		return "", err
+	}
+	return member.BusinessRole, nil
+}
+
+// OverdueMitigations — category 1. Non-terminal status with a due date in the
+// past.
+func (r *ActionCenterRepository) OverdueMitigations(tenantID uuid.UUID, now time.Time, limit int) ([]domain.Mitigation, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	var rows []domain.Mitigation
+	err := r.db.
+		Where("tenant_id = ?", tenantID).
+		Where("status NOT IN ?", []string{string(domain.MitigationDone), string(domain.MitigationCancelled)}).
+		Where("due_date IS NOT NULL AND due_date < ?", now).
+		Order("due_date ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// CriticalRisksWithoutActiveMitigation — category 2.
+//
+// "No active mitigation" is a NOT EXISTS rather than a LEFT JOIN so a risk with
+// three finished mitigations and none open still counts as unattended, and a
+// risk with one open mitigation is excluded exactly once rather than
+// suppressing duplicate rows afterwards.
+//
+// The subquery is tenant-scoped too. It would be tempting to skip it — the
+// mitigation is joined on risk_id and the outer query already picked the
+// tenant's risks — but relying on that means a mitigation row written with a
+// mismatched tenant_id could mask one tenant's risk using another tenant's
+// data. Filtering both sides costs an index lookup and removes the question.
+func (r *ActionCenterRepository) CriticalRisksWithoutActiveMitigation(tenantID uuid.UUID, threshold float64, limit int) ([]domain.Risk, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	active := r.db.
+		Table("mitigations").
+		Select("1").
+		Where("mitigations.risk_id = risks.id").
+		Where("mitigations.tenant_id = ?", tenantID).
+		Where("mitigations.status NOT IN ?", []string{string(domain.MitigationDone), string(domain.MitigationCancelled)}).
+		Where("mitigations.deleted_at IS NULL")
+
+	var rows []domain.Risk
+	err := r.db.
+		Where("risks.tenant_id = ?", tenantID).
+		Where("risks.score >= ?", threshold).
+		// A risk that has been mitigated, formally accepted or closed is a
+		// decision already taken, not outstanding work. Compared lower-cased
+		// because this column carries two historical vocabularies ("closed" and
+		// "CLOSED") and an exact match would silently list resolved risks.
+		Where("LOWER(risks.status) NOT IN ?", []string{"mitigated", "accepted", "closed"}).
+		Where("NOT EXISTS (?)", active).
+		Order("risks.score DESC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// PendingApprovals — category 3. Returns the tenant's pending requests; WHICH of
+// them the caller may sign is decided by domain.CanSign in the use case, not
+// here, so there is one implementation of that rule in the product.
+func (r *ActionCenterRepository) PendingApprovals(tenantID uuid.UUID, limit int) ([]domain.ApprovalRequest, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	var rows []domain.ApprovalRequest
+	err := r.db.
+		Where("tenant_id = ?", tenantID).
+		Where("status = ?", string(domain.ApprovalPending)).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// OpenIncidents — category 4.
+//
+// NOTE the tenant comparison: incidents.tenant_id is a VARCHAR on this table,
+// not a uuid, unlike every other model the Action Center reads. The string form
+// is passed explicitly so the driver compares text to text. Handing it a
+// uuid.UUID works on Postgres (which casts) and silently matches nothing on
+// sqlite, which is precisely the kind of difference that makes a tenant-leak
+// test pass locally and fail in production, or vice versa.
+func (r *ActionCenterRepository) OpenIncidents(tenantID uuid.UUID, limit int) ([]domain.Incident, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	var rows []domain.Incident
+	err := r.db.
+		Where("tenant_id = ?", tenantID.String()).
+		Where("status IN ?", []string{"open", "investigating"}).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// ExpiringEvidence — category 5. Narrowed by the calendar here; the final
+// verdict is domain.Evidence.EffectiveStatus in the use case, which also knows
+// that a rejected or unreviewed artifact is not proof whatever its date says.
+func (r *ActionCenterRepository) ExpiringEvidence(tenantID uuid.UUID, now time.Time, limit int) ([]domain.Evidence, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	var rows []domain.Evidence
+	err := r.db.
+		Where("tenant_id = ?", tenantID).
+		Where("valid_until IS NOT NULL AND valid_until < ?", now.Add(domain.EvidenceExpiryWindow)).
+		Order("valid_until ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// OverdueRemediationPlans — category 6.
+func (r *ActionCenterRepository) OverdueRemediationPlans(tenantID uuid.UUID, now time.Time, limit int) ([]domain.RemediationPlan, error) {
+	if err := guard(tenantID); err != nil {
+		return nil, err
+	}
+	var rows []domain.RemediationPlan
+	err := r.db.
+		Where("tenant_id = ?", tenantID).
+		Where("status = ?", string(domain.RemediationStatusOpen)).
+		Where("due_date IS NOT NULL AND due_date < ?", now).
+		Order("due_date ASC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+// Compile-time proof that the GORM implementation still satisfies the port the
+// use case declares. Without this the two drift apart silently until main.go
+// fails to build, which is a worse place to find out.
+var _ actioncenter.Repository = (*ActionCenterRepository)(nil)

--- a/backend/internal/infrastructure/repository/actioncenter_repository_test.go
+++ b/backend/internal/infrastructure/repository/actioncenter_repository_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// The Action Center reads six tables and returns them to a caller as "your
+// work". Every test in this file therefore has the same shape: seed the SAME
+// qualifying row in two tenants, ask as tenant A, and prove tenant B's row never
+// comes back. There is no second line of defence above this layer — the use case
+// cannot re-filter what the repository hands it — so isolation is asserted per
+// query, not once for the endpoint.
+
+var (
+	tA = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	tB = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+)
+
+func acNow() time.Time { return time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC) }
+
+func newActionCenterTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	// Created minimally then reconciled against the model, for the reason
+	// sqliteschema documents: several of these carry Postgres-only DDL
+	// (gen_random_uuid() defaults, jsonb columns) that GORM cannot emit here.
+	for _, ddl := range []string{
+		`CREATE TABLE mitigations (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE risks (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE approval_requests (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE incidents (id INTEGER PRIMARY KEY AUTOINCREMENT)`,
+		`CREATE TABLE evidences (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE remediation_plans (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE organization_members (id TEXT PRIMARY KEY)`,
+		// domain.Risk has an AfterSave hook that appends to risk_histories; the
+		// fixture carries the table rather than disabling the hook, so seeding
+		// exercises the same write path production does.
+		`CREATE TABLE risk_histories (id TEXT PRIMARY KEY)`,
+	} {
+		if err := db.Exec(ddl).Error; err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"mitigations", &domain.Mitigation{}},
+		{"risks", &domain.Risk{}},
+		{"approval_requests", &domain.ApprovalRequest{}},
+		{"incidents", &domain.Incident{}},
+		{"evidences", &domain.Evidence{}},
+		{"remediation_plans", &domain.RemediationPlan{}},
+		{"organization_members", &domain.OrganizationMember{}},
+		{"risk_histories", &domain.RiskHistory{}},
+	} {
+		if err := sqliteschema.Reconcile(db, m.table, m.model); err != nil {
+			t.Fatalf("reconcile %s: %v", m.table, err)
+		}
+	}
+	return db
+}
+
+func mustCreate(t *testing.T, db *gorm.DB, v any) {
+	t.Helper()
+	if err := db.Create(v).Error; err != nil {
+		t.Fatalf("seed %T: %v", v, err)
+	}
+}
+
+func at(d int) *time.Time { v := acNow().AddDate(0, 0, d); return &v }
+
+// seedBothTenants writes one qualifying row of every category into tenant A and
+// an identical one into tenant B.
+func seedBothTenants(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	for _, tenant := range []uuid.UUID{tA, tB} {
+		riskID := uuid.New()
+		mustCreate(t, db, &domain.Risk{
+			ID: riskID, TenantID: tenant, Title: "critical risk", Score: 9.1,
+			Status: domain.RiskOpen,
+		})
+		mustCreate(t, db, &domain.Mitigation{
+			ID: uuid.New(), TenantID: tenant, RiskID: uuid.New(), Title: "overdue mitigation",
+			Status: domain.MitigationInProgress, DueDate: at(-4), CreatedBy: uuid.New(),
+		})
+		mustCreate(t, db, &domain.ApprovalRequest{
+			ID: uuid.New(), TenantID: tenant, Title: "pending approval",
+			Status: domain.ApprovalPending, RequestedBy: uuid.New(),
+		})
+		mustCreate(t, db, &domain.Incident{
+			TenantID: tenant.String(), Title: "open incident",
+			Severity: "critical", Status: "open",
+		})
+		mustCreate(t, db, &domain.Evidence{
+			ID: uuid.New(), TenantID: tenant, Title: "expired evidence",
+			Review: domain.EvidenceReviewAccepted, CollectedAt: acNow().AddDate(0, -6, 0),
+			ValidUntil: at(-7),
+		})
+		mustCreate(t, db, &domain.RemediationPlan{
+			ID: uuid.New(), TenantID: tenant, Title: "overdue plan",
+			Status: domain.RemediationStatusOpen, DueDate: at(-3),
+		})
+	}
+}
+
+// Criterion 2. One sub-test per source query: a single loop asserting "six
+// non-empty results" would still pass if one query returned both tenants' rows.
+func TestActionCenter_TenantIsolation(t *testing.T) {
+	db := newActionCenterTestDB(t)
+	seedBothTenants(t, db)
+	repo := NewActionCenterRepository(db)
+
+	t.Run("overdue mitigations", func(t *testing.T) {
+		rows, err := repo.OverdueMitigations(tA, acNow(), 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "mitigations")
+		if rows[0].TenantID != tA {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+
+	t.Run("critical risks", func(t *testing.T) {
+		rows, err := repo.CriticalRisksWithoutActiveMitigation(tA, 7.0, 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "risks")
+		if rows[0].TenantID != tA {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+
+	t.Run("pending approvals", func(t *testing.T) {
+		rows, err := repo.PendingApprovals(tA, 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "approvals")
+		if rows[0].TenantID != tA {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+
+	t.Run("open incidents (string tenant column)", func(t *testing.T) {
+		rows, err := repo.OpenIncidents(tA, 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "incidents")
+		if rows[0].TenantID != tA.String() {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+
+	t.Run("expiring evidence", func(t *testing.T) {
+		rows, err := repo.ExpiringEvidence(tA, acNow(), 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "evidence")
+		if rows[0].TenantID != tA {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+
+	t.Run("overdue remediation plans", func(t *testing.T) {
+		rows, err := repo.OverdueRemediationPlans(tA, acNow(), 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "remediation")
+		if rows[0].TenantID != tA {
+			t.Fatalf("leaked tenant %s", rows[0].TenantID)
+		}
+	})
+}
+
+// A zero tenant must fail closed rather than return an unscoped result set.
+func TestActionCenter_NilTenantIsRefused(t *testing.T) {
+	db := newActionCenterTestDB(t)
+	seedBothTenants(t, db)
+	repo := NewActionCenterRepository(db)
+
+	if _, err := repo.OverdueMitigations(uuid.Nil, acNow(), 100); err != domain.ErrForbidden {
+		t.Fatalf("want ErrForbidden, got %v", err)
+	}
+	if _, err := repo.OpenIncidents(uuid.Nil, 100); err != domain.ErrForbidden {
+		t.Fatalf("want ErrForbidden, got %v", err)
+	}
+	if _, err := repo.BusinessRoleFor(uuid.New(), uuid.Nil); err != domain.ErrForbidden {
+		t.Fatalf("want ErrForbidden, got %v", err)
+	}
+}
+
+// The business role is read per (user, tenant): the same person can hold a
+// different job role in each organisation they belong to.
+func TestActionCenter_BusinessRoleIsScopedToTheTenant(t *testing.T) {
+	db := newActionCenterTestDB(t)
+	repo := NewActionCenterRepository(db)
+	user := uuid.New()
+
+	mustCreate(t, db, &domain.OrganizationMember{
+		ID: uuid.New(), OrganizationID: tA, UserID: user,
+		Role: domain.RoleUser, BusinessRole: domain.BusinessRoleRiskManager,
+	})
+	mustCreate(t, db, &domain.OrganizationMember{
+		ID: uuid.New(), OrganizationID: tB, UserID: user,
+		Role: domain.RoleUser, BusinessRole: domain.BusinessRoleAuditor,
+	})
+
+	got, err := repo.BusinessRoleFor(user, tA)
+	requireNoErr(t, err)
+	if got != domain.BusinessRoleRiskManager {
+		t.Fatalf("tenant A role = %q, want risk_manager", got)
+	}
+	got, err = repo.BusinessRoleFor(user, tB)
+	requireNoErr(t, err)
+	if got != domain.BusinessRoleAuditor {
+		t.Fatalf("tenant B role = %q, want auditor", got)
+	}
+
+	// A member row that does not exist is the least-privilege default, not an
+	// error: root/admin callers legitimately operate without one.
+	got, err = repo.BusinessRoleFor(uuid.New(), tA)
+	requireNoErr(t, err)
+	if got != "" {
+		t.Fatalf("missing membership should yield no role, got %q", got)
+	}
+}
+
+// The category predicates themselves: a query that returned everything would
+// pass the isolation test above while still being wrong.
+func TestActionCenter_CategoryPredicates(t *testing.T) {
+	db := newActionCenterTestDB(t)
+	repo := NewActionCenterRepository(db)
+
+	t.Run("finished and cancelled mitigations are not overdue work", func(t *testing.T) {
+		for _, st := range []domain.MitigationStatus{
+			domain.MitigationDone, domain.MitigationCancelled,
+		} {
+			mustCreate(t, db, &domain.Mitigation{
+				ID: uuid.New(), TenantID: tA, RiskID: uuid.New(), Title: string(st),
+				Status: st, DueDate: at(-10), CreatedBy: uuid.New(),
+			})
+		}
+		// …and one that genuinely is overdue.
+		mustCreate(t, db, &domain.Mitigation{
+			ID: uuid.New(), TenantID: tA, RiskID: uuid.New(), Title: "real",
+			Status: domain.MitigationPlanned, DueDate: at(-1), CreatedBy: uuid.New(),
+		})
+		// A future due date is not overdue either.
+		mustCreate(t, db, &domain.Mitigation{
+			ID: uuid.New(), TenantID: tA, RiskID: uuid.New(), Title: "future",
+			Status: domain.MitigationPlanned, DueDate: at(+5), CreatedBy: uuid.New(),
+		})
+
+		rows, err := repo.OverdueMitigations(tA, acNow(), 100)
+		requireNoErr(t, err)
+		requireLen(t, len(rows), 1, "overdue mitigations")
+		if rows[0].Title != "real" {
+			t.Fatalf("got %q", rows[0].Title)
+		}
+	})
+
+	t.Run("a risk with an active mitigation is already being handled", func(t *testing.T) {
+		attended := uuid.New()
+		unattended := uuid.New()
+		mustCreate(t, db, &domain.Risk{
+			ID: attended, TenantID: tB, Title: "attended", Score: 9.0, Status: domain.RiskOpen,
+		})
+		mustCreate(t, db, &domain.Risk{
+			ID: unattended, TenantID: tB, Title: "unattended", Score: 8.0, Status: domain.RiskOpen,
+		})
+		mustCreate(t, db, &domain.Mitigation{
+			ID: uuid.New(), TenantID: tB, RiskID: attended, Title: "in flight",
+			Status: domain.MitigationInProgress, CreatedBy: uuid.New(),
+		})
+		// A finished mitigation does NOT count as active: the risk is unattended
+		// again once the plan is closed.
+		mustCreate(t, db, &domain.Mitigation{
+			ID: uuid.New(), TenantID: tB, RiskID: unattended, Title: "finished",
+			Status: domain.MitigationDone, CreatedBy: uuid.New(),
+		})
+		// Below the frozen critical threshold.
+		mustCreate(t, db, &domain.Risk{
+			ID: uuid.New(), TenantID: tB, Title: "not critical", Score: 6.9, Status: domain.RiskOpen,
+		})
+		// Already dispositioned.
+		mustCreate(t, db, &domain.Risk{
+			ID: uuid.New(), TenantID: tB, Title: "accepted", Score: 9.5, Status: domain.RiskAccepted,
+		})
+
+		rows, err := repo.CriticalRisksWithoutActiveMitigation(tB, 7.0, 100)
+		requireNoErr(t, err)
+		titles := map[string]bool{}
+		for _, r := range rows {
+			titles[r.Title] = true
+		}
+		if !titles["unattended"] {
+			t.Fatalf("a critical risk whose only mitigation is DONE must be listed; got %v", titles)
+		}
+		if titles["attended"] {
+			t.Fatalf("a risk with an in-flight mitigation must not be listed")
+		}
+		if titles["not critical"] || titles["accepted"] {
+			t.Fatalf("threshold/disposition filter leaked: %v", titles)
+		}
+	})
+
+	t.Run("resolved incidents are not open", func(t *testing.T) {
+		for _, st := range []string{"resolved", "closed"} {
+			mustCreate(t, db, &domain.Incident{
+				TenantID: tA.String(), Title: st, Severity: "high", Status: st,
+			})
+		}
+		rows, err := repo.OpenIncidents(tA, 100)
+		requireNoErr(t, err)
+		for _, r := range rows {
+			if r.Status == "resolved" || r.Status == "closed" {
+				t.Fatalf("resolved incident %q listed as open work", r.Title)
+			}
+		}
+	})
+}
+
+func requireNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func requireLen(t *testing.T, got, want int, what string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: got %d rows, want %d — a cross-tenant leak is a P0 defect", what, got, want)
+	}
+}

--- a/backend/internal/security/isolation/registry.go
+++ b/backend/internal/security/isolation/registry.go
@@ -97,6 +97,8 @@ var decisions = []Decision{
 			"not-found rather than forbidden (covered by TestRevoke_CrossUser_IsNotFound)"},
 
 	// --- Covered by automated isolation tests -----------------------------
+	{"/api/v1/action-center", Covered,
+		"repository/actioncenter_repository_test TestActionCenter_TenantIsolation seeds the same qualifying row in two tenants and asserts each of the SIX source queries (mitigations, risks, approvals, incidents, evidence, remediation plans) returns only the caller's; TestActionCenter_NilTenantIsRefused proves a zero tenant fails closed with ErrForbidden rather than returning an unscoped set, and TestActionCenter_BusinessRoleIsScopedToTheTenant proves the role driving what is shown is read per (user, tenant). The caller's tenant comes only from the JWT (handler.callerFromCtx), never from the query string. Note incidents.tenant_id is a VARCHAR, compared as a string on purpose"},
 	{"/api/v1/assets/{id}", Covered,
 		"application/asset get/update/delete cross-tenant tests + gorm_asset_repository_test"},
 	{"/api/v1/assets/{id}/history", Covered,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2050,6 +2050,62 @@ paths:
         '401':
           description: Unauthorized
 
+  /action-center:
+    get:
+      tags:
+        - Action Center
+      summary: Prioritised outstanding work for the caller
+      description: >
+        Returns the items the caller can personally act on right now, ordered by
+        category rank then by that category's own secondary key. A live read over
+        risks, mitigations, incidents, evidence, remediation plans and approvals —
+        nothing is persisted and there is no dismiss: an item disappears when the
+        underlying work is done.
+
+
+        Which categories are returned depends on the caller's business role.
+        Pending approvals are NOT role-gated: they are evaluated per request
+        against the current step's approver, so a caller who is the named
+        approver always sees them, and a caller who would be refused at the
+        Approve button never does.
+      operationId: getActionCenter
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          description: Page size. Defaults to 20, clamped to 100.
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: offset
+          in: query
+          description: Rows to skip. A negative value is rejected with 400.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: The caller's prioritised action items, possibly empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionCenterResponse'
+        '400':
+          description: Invalid offset
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 # ==================== COMPONENTS ====================
 components:
   securitySchemes:
@@ -2060,6 +2116,93 @@ components:
       description: JWT Bearer token. Obtain via /auth/login
 
   schemas:
+    # ========== ACTION CENTER (#429) ==========
+    ActionItem:
+      type: object
+      description: >
+        One thing the caller needs to act on. Assembled on read from an existing
+        record; it has no table of its own and no lifecycle.
+      required:
+        - id
+        - type
+        - title
+        - subject_resource_type
+        - subject_resource_id
+        - deep_link
+        - category_rank
+        - tenant_id
+      properties:
+        id:
+          type: string
+          description: >
+            Stable composite id, "<source>:<uuid>" (e.g. "mitigation:8f1e...").
+            Namespaced because two categories can otherwise carry the same
+            underlying uuid, and React would then see duplicate keys.
+          example: mitigation:8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0
+        type:
+          type: string
+          enum:
+            - overdue_mitigation
+            - critical_risk
+            - pending_approval
+            - open_incident
+            - expiring_evidence
+            - overdue_remediation
+        title:
+          type: string
+          description: The underlying record's own title, never a generated sentence.
+        subject_resource_type:
+          type: string
+          enum: [mitigation, risk, approval_request, incident, evidence, remediation_plan]
+        subject_resource_id:
+          type: string
+          description: The record's own id. A uuid for every type except incident, which is an integer rendered as a string.
+        deep_link:
+          type: string
+          description: >
+            Relative frontend path that resolves to a real route. Detail pages
+            take the id in the path (/risks/mitigations/{id}); risks and evidence
+            have no detail page and open the universal entity drawer instead
+            (/risks?drawer=risk&entity={id}).
+          example: /risks/mitigations/8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0
+        due_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Due date, expiry or approval deadline, depending on the type. Null when the category has no date.
+        category_rank:
+          type: integer
+          minimum: 1
+          maximum: 6
+          description: >
+            1 overdue_mitigation, 2 critical_risk, 3 pending_approval,
+            4 open_incident, 5 expiring_evidence, 6 overdue_remediation.
+            This is the primary sort key, exposed so a client can group without
+            re-deriving the rule.
+        tenant_id:
+          type: string
+          format: uuid
+    ActionCenterResponse:
+      type: object
+      required: [data, generated_at, limit, offset, total]
+      properties:
+        data:
+          type: array
+          description: Always an array. Empty when nothing is outstanding.
+          items:
+            $ref: '#/components/schemas/ActionItem'
+        generated_at:
+          type: string
+          format: date-time
+          description: When the aggregation ran. The list is a live read, so this is its as-of instant.
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+          description: Total outstanding items for this caller, not the size of this page.
+
     # ========== FINANCIAL QUANTIFICATION (spec §9) ==========
     Money:
       type: object

--- a/frontend/src/types/openapi.generated.ts
+++ b/frontend/src/types/openapi.generated.ts
@@ -1250,10 +1250,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/action-center": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Prioritised outstanding work for the caller
+         * @description Returns the items the caller can personally act on right now, ordered by category rank then by that category's own secondary key. A live read over risks, mitigations, incidents, evidence, remediation plans and approvals — nothing is persisted and there is no dismiss: an item disappears when the underlying work is done.
+         *
+         *     Which categories are returned depends on the caller's business role. Pending approvals are NOT role-gated: they are evaluated per request against the current step's approver, so a caller who is the named approver always sees them, and a caller who would be refused at the Approve button never does.
+         */
+        get: operations["getActionCenter"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description One thing the caller needs to act on. Assembled on read from an existing record; it has no table of its own and no lifecycle. */
+        ActionItem: {
+            /**
+             * @description Stable composite id, "<source>:<uuid>" (e.g. "mitigation:8f1e..."). Namespaced because two categories can otherwise carry the same underlying uuid, and React would then see duplicate keys.
+             * @example mitigation:8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0
+             */
+            id: string;
+            /** @enum {string} */
+            type: "overdue_mitigation" | "critical_risk" | "pending_approval" | "open_incident" | "expiring_evidence" | "overdue_remediation";
+            /** @description The underlying record's own title, never a generated sentence. */
+            title: string;
+            /** @enum {string} */
+            subject_resource_type: "mitigation" | "risk" | "approval_request" | "incident" | "evidence" | "remediation_plan";
+            /** @description The record's own id. A uuid for every type except incident, which is an integer rendered as a string. */
+            subject_resource_id: string;
+            /**
+             * @description Relative frontend path that resolves to a real route. Detail pages take the id in the path (/risks/mitigations/{id}); risks and evidence have no detail page and open the universal entity drawer instead (/risks?drawer=risk&entity={id}).
+             * @example /risks/mitigations/8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0
+             */
+            deep_link: string;
+            /**
+             * Format: date-time
+             * @description Due date, expiry or approval deadline, depending on the type. Null when the category has no date.
+             */
+            due_at?: string | null;
+            /** @description 1 overdue_mitigation, 2 critical_risk, 3 pending_approval, 4 open_incident, 5 expiring_evidence, 6 overdue_remediation. This is the primary sort key, exposed so a client can group without re-deriving the rule. */
+            category_rank: number;
+            /** Format: uuid */
+            tenant_id: string;
+        };
+        ActionCenterResponse: {
+            /** @description Always an array. Empty when nothing is outstanding. */
+            data: components["schemas"]["ActionItem"][];
+            /**
+             * Format: date-time
+             * @description When the aggregation ran. The list is a live read, so this is its as-of instant.
+             */
+            generated_at: string;
+            limit: number;
+            offset: number;
+            /** @description Total outstanding items for this caller, not the size of this page. */
+            total: number;
+        };
         /** @description An amount in both currencies (XAF canonical, USD derived). */
         Money: {
             xaf: number;
@@ -4728,6 +4793,49 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    getActionCenter: {
+        parameters: {
+            query?: {
+                /** @description Page size. Defaults to 20, clamped to 100. */
+                limit?: number;
+                /** @description Rows to skip. A negative value is rejected with 400. */
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's prioritised action items, possibly empty */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionCenterResponse"];
+                };
+            };
+            /** @description Invalid offset */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
             };
         };
     };


### PR DESCRIPTION
Closes #429

Builds the Action Center aggregation API — a read-only, role-aware, priority-ordered list of what the calling user must act on, aggregated live from six existing tables. No new table, no migration, no writes.

This is the backend half of epic #201. It unblocks #430 (the UI), which was `status:blocked` waiting on exactly this contract.

## What it does

`GET /api/v1/action-center` returns the caller's outstanding work from six sources: overdue mitigations · critical risks with no active mitigation · pending approvals where the caller is the current step's approver · open incidents · expiring/expired evidence · overdue remediation plans.

Ordering is total and deterministic — category rank (1–6), then that category's own secondary key, then item id so two otherwise-equal rows don't shuffle between refreshes. Role gating **skips the query entirely** rather than filtering its output, so the endpoint costs what the caller is allowed to see rather than what the tenant contains.

Approvals are deliberately not role-gated: eligibility is a property of the request, not a job title. That check is delegated to the existing `domain.CanSign`, which already encodes named-approver precedence, role matching, delegation and the four-eyes rule — so an item can never be listed that the caller would be refused at the Approve button.

## Two spec corrections

**`/risks/{id}` does not exist.** The issue offered it as an example deep link. There is no risk detail route — `App.tsx` has `risks`, `risks/import`, `risks/:riskId/timeline` (a legacy redirect), and no `risks/:riskId`. Risks and evidence open through the universal entity drawer, whose state is the query string (`features/entity-drawer/drawerState.ts`). Those two categories therefore link to `/risks?drawer=risk&entity={id}` and `/compliance/evidence?drawer=evidence&entity={id}`; the other four use real path routes. Shipping the spec's link verbatim would have produced precisely the inert control rule 12 forbids.

**Category 4's "assigned to the caller *or* matching the caller's role scope"** collapses to role scope in v1: `BusinessRoleRSSI` is the only role mapped to incidents and its scope is the whole tenant, which already contains anything assigned to them. `OpenIncidents` takes no assignee filter rather than carrying a parameter that would only ever be `nil`.

## ⚠️ Tenant isolation — the P0 surface

Six queries, six independent chances to leak. Each filters on `tenant_id`; `guard()` fails closed with `ErrForbidden` on a zero tenant rather than running an unscoped query. The `NOT EXISTS` subquery in `CriticalRisksWithoutActiveMitigation` is tenant-scoped **on both sides** — relying on the correlation alone would let a mitigation row carrying a mismatched `tenant_id` mask one tenant's risk using another tenant's data.

**`incidents.tenant_id` is a `VARCHAR`, not a `uuid`** — unlike every other table here. It is compared as `tenantID.String()` so the driver compares text to text. Handing it a `uuid.UUID` works on Postgres (which casts) and silently matches nothing on sqlite, which is the exact shape of bug that passes locally and fails in production. This is called out in the code and was verified against real Postgres data, not just sqlite (below).

The route is declared `Covered` in `internal/security/isolation/registry.go`. The gate refused to pass until it was — it fails the build for any collection route with no declared decision, which caught this route the moment it was registered.

## Verification

```
$ gofmt -l <the 7 files this PR touches>
(no output = clean)

$ go vet ./internal/application/actioncenter/ ./internal/infrastructure/repository/ ./internal/handler/
(no output = clean)

$ go build ./...
ok

$ go test ./internal/application/actioncenter/ ./internal/infrastructure/repository/ ./internal/handler/ -race -count=1
ok   github.com/opendefender/openrisk/internal/application/actioncenter   1.043s
ok   github.com/opendefender/openrisk/internal/infrastructure/repository  1.674s
ok   github.com/opendefender/openrisk/internal/handler                    14.276s

$ go test ./internal/security/isolation/ -count=1
ok   github.com/opendefender/openrisk/internal/security/isolation  0.027s

$ go test ./... -count=1        # failures only
--- FAIL: TestBusinessRolesReferenceOnlyCatalogPermissions
FAIL github.com/opendefender/openrisk/internal/domain
```

That single failure is **pre-existing and unrelated** — every business-role preset references the uncatalogued permission `events:read`. Confirmed by stashing this branch and running the same test on master HEAD, where it fails identically. Already tracked as **#416**. Untouched here.

### The isolation test was mutation-checked, not merely written

Removing the `tenant_id` filter from the mitigations query alone:
```
--- FAIL: TestActionCenter_TenantIsolation/overdue_mitigations
    mitigations: got 2 rows, want 1 — a cross-tenant leak is a P0 defect
```
Filter restored, suite green. A green isolation test that would stay green with the filter removed proves nothing, so this check matters more than the test.

### Live proof against real PostgreSQL

sqlite cannot vouch for the `VARCHAR` tenant comparison, so this was checked on the real driver:

- Server built and booted against local Postgres/Redis — `⚡ OpenRisk API listening on port 8097`.
- Unauthenticated → `401 {"code":"UNAUTHORIZED","message":"Missing authorization header"}`; garbage bearer → `401`.
- All six queries executed against real Postgres through a throwaway probe (deleted, never committed) — every one runs clean on the `pq` driver.
- **The `VARCHAR` comparison was checked against real data**: for a tenant that actually owns incidents, `OpenIncidents` returned exactly the count raw SQL reports (1 of 1); a foreign tenant saw 0.

### Frontend contract
`docs/openapi.yaml` gains `/action-center` + `ActionItem` + `ActionCenterResponse`; `frontend/src/types/openapi.generated.ts` regenerated (+108 lines, purely additive), `npx tsc --noEmit` clean. #430 imports from the generated file and hand-types nothing.

## Honest remainders

- **No authenticated live call.** Tokens are key-pair signed through `TokenManager`; minting one was a bigger detour than it was worth. The authenticated path is covered by handler tests plus the Postgres probe, not by an end-to-end curl.
- **Delegated approval rights are not resolved.** `domain.CanSign` accepts `DelegatedFrom`/`DelegatedRoles` and governance fills them from `ActiveDelegationsTo`; the Action Center passes empty ones. Someone holding only a delegation sees the approval in the governance screen but not here. Under-listing, never over-listing — it cannot surface an item the caller may not sign. Worth its own issue if delegation matters on this surface.
- **Per-source fetch is capped at 200 rows** before ordering, so the list is a prioritised top-N. A tenant with more than 200 outstanding items in one category cannot page past that cap.
- **No `RequirePermission` on the route.** It sits on `protected` and the gating is the role→category map in the use case. Deliberate — the map is finer-grained than any single permission string — but flagged for the reviewer rather than buried.
- **ROADMAP does not claim the capability.** The backend is recorded as delivered *and* explicitly marked unreachable by any user until #430 merges. Nothing enters the claim matrix yet (rule 12).
- 14 files elsewhere in the backend are gofmt-dirty on master. Pre-existing, left alone.
