### PR TITLE
fix(action-center): land the Action Center UI on master (#430)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -420,7 +420,7 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
   mergés — l'endpoint n'existe pas sur `master`. La capacité ne sera déclarée livrée, et n'entrera dans la
   matrice de claims, qu'au merge des **deux**. Règle 12.
   **Reste à faire** : route dédiée `/action-center` (page pleine, pagination au-delà des 8 premières
-  lignes) — fast-follow explicitement autorisé par #430.
+  lignes) — fast-follow explicitement autorisé par #430, suivi dans **#433**.
 
 **Bloc E — Wave 2/3 (gamechangers restants)**
 12. Digital Twin (14.13), War Room (14.14), Attack Path (14.15), Access Review (14.10), Offline (14.17),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,8 +404,23 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
   `internal/infrastructure/repository/actioncenter_repository.go`,
   `internal/handler/action_center_handler.go`. Contrat publié dans `docs/openapi.yaml` +
   `frontend/src/types/openapi.generated.ts`.
-  **⚠️ Aucun utilisateur ne peut encore l'atteindre** : il n'existe pas d'écran. La capacité ne sera
-  déclarée livrée, et n'entrera dans la matrice de claims, qu'au merge de **#430** (UI). Règle 12.
+  **Frontend livré** (#430, branche `430-feat-build-the-action-center-ui-with-role-aware-priority-and-deep-links-frontend`,
+  empilée sur celle de #429 car le contrat n'existe que là) : panneau « Centre d'actions » monté sur le
+  tableau de bord (`/`) pour **toutes** les personas — `DashboardShell` pour les cinq personas dédiées,
+  `PostureDashboard` qui n'utilise pas ce shell le monte lui-même. `frontend/src/features/action-center/`
+  (`actionCenterService.ts`, `useActionItems.ts`, `actionLinks.ts`, `ActionCenterPanel.tsx`). Types importés
+  de `openapi.generated.ts`, **jamais** saisis à la main ; zéro `any`. Ordre serveur rendu tel quel (aucun
+  tri client). Trois états explicites (skeleton / erreur / vide, le vide se lisant comme un « tout est à
+  jour » et non comme un échec). Chaque ligne est une vraie ancre : `deep_link` est validé contre
+  `shared/routeModel.ts` avant d'être rendu, et un lien qui ne résout pas — ou qui quitte l'origine
+  (`https://`, `//host`, `javascript:`) — fait **supprimer** l'élément avec un warning, jamais afficher une
+  ligne morte. FR/EN dans `src/locales`. 14 tests (`__tests__/actionCenter.test.tsx`), dont axe-core sur le
+  panneau rempli et vide.
+  **⚠️ Aucun utilisateur ne peut encore l'atteindre** : #429 (PR #431) et #430 sont tous deux ouverts, non
+  mergés — l'endpoint n'existe pas sur `master`. La capacité ne sera déclarée livrée, et n'entrera dans la
+  matrice de claims, qu'au merge des **deux**. Règle 12.
+  **Reste à faire** : route dédiée `/action-center` (page pleine, pagination au-delà des 8 premières
+  lignes) — fast-follow explicitement autorisé par #430.
 
 **Bloc E — Wave 2/3 (gamechangers restants)**
 12. Digital Twin (14.13), War Room (14.14), Attack Path (14.15), Access Review (14.10), Offline (14.17),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.1.0-rc.1",
+      "version": "1.1.0-rc.3",
       "dependencies": {
         "@floating-ui/react": "^0.27.20",
         "@hello-pangea/dnd": "^18.0.1",
@@ -53,6 +53,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.4.22",
+        "axe-core": "^4.12.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.22",
+    "axe-core": "^4.12.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/frontend/src/features/action-center/ActionCenterPanel.tsx
+++ b/frontend/src/features/action-center/ActionCenterPanel.tsx
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The Action Center panel (#430).
+//
+// One list answering one question: what is mine to act on right now, in order,
+// and how do I get straight to it. Every row is a real anchor to a real route —
+// there is no row here that does not go anywhere (CLAUDE.md rule 12).
+//
+// This is NOT the notification bell. The bell is chronological, "what happened",
+// and is read then dismissed. This is a work queue: an item appears because a
+// record is outstanding and disappears when that work is done. There is no
+// dismiss and no read state, on purpose — see the epic's non-goals.
+//
+// Two things it deliberately does not do:
+//
+//   - it does not sort. The server has already applied category rank, then each
+//     category's own secondary key, then id, and it pages on that same order.
+//     Re-sorting here would agree with the server on page one and contradict it
+//     on page two.
+//   - it does not invent an empty state's meaning. An empty Action Center is the
+//     GOOD outcome — nothing is outstanding — so it reads as an all-clear rather
+//     than as "no data found".
+
+import { useMemo, type KeyboardEvent } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { ArrowRight, CircleCheck } from 'lucide-react';
+
+import { useI18n, interpolate } from '../../hooks/useI18n';
+import { EmptyState, ErrorState, Skeleton } from '../../shared/ui';
+import { useActionItems } from './useActionItems';
+import { linkableItems, presentationFor } from './actionLinks';
+import type { ActionItem } from './actionCenterService';
+
+const SKELETON_ROWS = 4;
+
+/** Formats a due date in the active locale, or null when the category has none. */
+function formatDue(dueAt: string | null | undefined, locale: string): string | null {
+  if (!dueAt) return null;
+  const date = new Date(dueAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function isOverdue(dueAt: string | null | undefined): boolean {
+  if (!dueAt) return false;
+  const date = new Date(dueAt);
+  return !Number.isNaN(date.getTime()) && date.getTime() < Date.now();
+}
+
+function ActionRow({ item, href }: { item: ActionItem; href: string }) {
+  const { t, locale } = useI18n();
+  const navigate = useNavigate();
+  const { icon: Icon, labelKey, tone } = presentationFor(item.type);
+  const due = formatDue(item.due_at, locale);
+  const overdue = isOverdue(item.due_at);
+  const typeLabel = t(`actionCenter.types.${labelKey}`);
+
+  // An anchor already activates on Enter. Space does not, and the acceptance
+  // criterion names both, so it is handled explicitly rather than left to be
+  // discovered as a dead key by whoever navigates this list without a mouse.
+  const onKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      navigate(href);
+    }
+  };
+
+  return (
+    <li>
+      <Link
+        to={href}
+        onKeyDown={onKeyDown}
+        data-testid="action-center-item"
+        data-action-type={item.type}
+        className="group flex items-center gap-3 rounded-md px-3 py-2.5 no-underline transition-colors hover:bg-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+      >
+        <Icon size={16} strokeWidth={1.75} className={`shrink-0 ${tone}`} aria-hidden="true" />
+
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-text-primary">{item.title}</span>
+          <span className="mt-0.5 block text-xs text-text-muted">
+            {typeLabel}
+            {due && (
+              <>
+                {' · '}
+                <span className={overdue ? 'text-danger-text font-medium' : undefined}>
+                  {overdue ? `${t('actionCenter.overdue')} — ${due}` : interpolate(t('actionCenter.due'), { date: due })}
+                </span>
+              </>
+            )}
+            {!due && ` · ${t('actionCenter.noDueDate')}`}
+          </span>
+        </span>
+
+        {/* The row's accessible name is the title plus its category; the arrow is
+            decoration, so it is hidden from the accessibility tree and the link
+            carries an explicit label instead of relying on the glyph. */}
+        <ArrowRight
+          size={15}
+          strokeWidth={1.75}
+          aria-hidden="true"
+          className="shrink-0 text-text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+        />
+        <span className="sr-only">{interpolate(t('actionCenter.openItem'), { title: item.title })}</span>
+      </Link>
+    </li>
+  );
+}
+
+export function ActionCenterPanel({ limit = 8 }: { limit?: number }) {
+  const { t } = useI18n();
+  const { items, total, isLoading, isError, refetch } = useActionItems(limit);
+
+  // Filtering, not sorting: an item whose deep_link does not resolve to a real
+  // route is dropped (and logged) rather than rendered as a dead row. Order is
+  // the server's throughout.
+  const rows = useMemo(() => linkableItems(items), [items]);
+
+  return (
+    <section
+      aria-labelledby="action-center-title"
+      className="or-card mb-4 p-4"
+      data-testid="action-center"
+    >
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <div>
+          <h2 id="action-center-title" className="text-md font-semibold text-text-primary">
+            {t('actionCenter.title')}
+          </h2>
+          <p className="mt-0.5 text-xs text-text-muted">{t('actionCenter.subtitle')}</p>
+        </div>
+        {!isLoading && !isError && total > 0 && (
+          <span className="shrink-0 text-xs text-text-muted" data-testid="action-center-count">
+            {interpolate(t('actionCenter.showing'), { shown: rows.length, total })}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div data-testid="action-center-skeleton" aria-busy="true" aria-live="polite">
+          <span className="sr-only">{t('actionCenter.loading')}</span>
+          {Array.from({ length: SKELETON_ROWS }).map((_, index) => (
+            <Skeleton key={index} className="mb-1.5 h-11 w-full" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && isError && (
+        <div data-testid="action-center-error">
+          <ErrorState
+            title={t('actionCenter.errorTitle')}
+            description={t('actionCenter.errorDescription')}
+            onRetry={refetch}
+            retryLabel={t('actionCenter.retry')}
+          />
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <div data-testid="action-center-empty">
+          <EmptyState
+            variant="first-use"
+            icon={CircleCheck}
+            title={t('actionCenter.emptyTitle')}
+            description={t('actionCenter.emptyDescription')}
+          />
+        </div>
+      )}
+
+      {!isLoading && !isError && rows.length > 0 && (
+        <>
+          <ul className="m-0 list-none p-0" data-testid="action-center-list">
+            {rows.map(({ item, href }) => (
+              <ActionRow key={item.id} item={item} href={href} />
+            ))}
+          </ul>
+          {total > rows.length && (
+            <div className="mt-2 px-3">
+              {/* No dedicated /action-center route ships in this issue, so this
+                  says how much is not on screen rather than offering a link to a
+                  page that does not exist. Fast-follow: the full-page view. */}
+              <span className="text-xs text-text-muted" data-testid="action-center-more">
+                {interpolate(t('actionCenter.moreOutstanding'), { count: total - rows.length })}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export default ActionCenterPanel;

--- a/frontend/src/features/action-center/__tests__/actionCenter.test.tsx
+++ b/frontend/src/features/action-center/__tests__/actionCenter.test.tsx
@@ -1,0 +1,390 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The Action Center's rendering contract (#430, acceptance criteria 1-6 and 9).
+//
+// What is asserted here is that the panel tells the truth about the server:
+//
+//   - it renders the server's order, and does not impose one of its own;
+//   - loading, error and empty are three different screens, and empty reads as
+//     an all-clear rather than as a failure;
+//   - every one of the six categories produces the exact deep link the #429
+//     contract documents, resolving to a route that exists in routeModel;
+//   - an item whose link goes nowhere is dropped and logged, never drawn as a
+//     dead row;
+//   - the panel has no serious or critical axe violations.
+//
+// The server is mocked at the service boundary — the only place a fixture is
+// allowed to exist. Nothing built here ships in a production route.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import axe from 'axe-core';
+
+import { useUIStore } from '../../../store/uiStore';
+import { ActionCenterPanel } from '../ActionCenterPanel';
+import { safeDeepLink } from '../actionLinks';
+import type { ActionCenterResponse, ActionItem } from '../actionCenterService';
+
+vi.mock('../actionCenterService', async () => {
+  const actual = await vi.importActual<typeof import('../actionCenterService')>(
+    '../actionCenterService',
+  );
+  return { ...actual, actionCenterService: { list: vi.fn() } };
+});
+
+import { actionCenterService } from '../actionCenterService';
+
+const list = vi.mocked(actionCenterService.list);
+
+const TENANT = '3f1b0f9e-5a4c-4c7e-9a1d-8b2c6d5e4f30';
+
+function item(overrides: Partial<ActionItem> & Pick<ActionItem, 'id' | 'type'>): ActionItem {
+  return {
+    title: 'Untitled',
+    subject_resource_type: 'risk',
+    subject_resource_id: '8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0',
+    deep_link: '/risks',
+    due_at: null,
+    category_rank: 1,
+    tenant_id: TENANT,
+    ...overrides,
+  };
+}
+
+function page(items: ActionItem[], total = items.length): ActionCenterResponse {
+  return {
+    data: items,
+    generated_at: '2026-08-31T09:00:00Z',
+    limit: 20,
+    offset: 0,
+    total,
+  };
+}
+
+/**
+ * The six categories with the deep links the backend contract commits to
+ * (#429 issue comment, and docs/openapi.yaml). Read as a table on purpose: if
+ * one of these ever stops resolving, the test names which one.
+ */
+const CONTRACT_LINKS: Array<{ type: ActionItem['type']; rank: number; deepLink: string }> = [
+  { type: 'overdue_mitigation', rank: 1, deepLink: '/risks/mitigations/8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0' },
+  { type: 'critical_risk', rank: 2, deepLink: '/risks?drawer=risk&entity=1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f' },
+  { type: 'pending_approval', rank: 3, deepLink: '/governance' },
+  { type: 'open_incident', rank: 4, deepLink: '/incidents/412/war-room' },
+  { type: 'expiring_evidence', rank: 5, deepLink: '/compliance/evidence?drawer=evidence&entity=aa11bb22-cc33-dd44-ee55-ff6677889900' },
+  { type: 'overdue_remediation', rank: 6, deepLink: '/compliance/remediation/9b8a7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d' },
+];
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderPanel(initialPath = '/') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchInterval: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="*" element={<><ActionCenterPanel /><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUIStore.setState({ lang: 'en' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ActionCenterPanel', () => {
+  /* --- AC1: the server's order is the rendered order ---------------------- */
+
+  it('renders items in the exact order the API returned, across categories', async () => {
+    // Deliberately NOT in category_rank order: the server owns the ordering and
+    // may page on a secondary key the client cannot see, so a client that
+    // "helpfully" re-sorts by rank would disagree with the server on page two.
+    // Rendering this array unchanged is what proves nothing re-sorts.
+    const returned = [
+      item({ id: 'incident:412', type: 'open_incident', title: 'Ransomware on the payroll server', deep_link: '/incidents/412/war-room', category_rank: 4 }),
+      item({ id: 'mitigation:1', type: 'overdue_mitigation', title: 'Patch the perimeter VPN', deep_link: '/risks/mitigations/8f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0', category_rank: 1 }),
+      item({ id: 'approval:2', type: 'pending_approval', title: 'Risk acceptance for legacy SFTP', deep_link: '/governance', category_rank: 3 }),
+    ];
+    list.mockResolvedValue(page(returned));
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('action-center-list')).toBeInTheDocument());
+
+    const rendered = screen.getAllByTestId('action-center-item');
+    expect(rendered).toHaveLength(3);
+    expect(rendered.map((node) => node.getAttribute('href'))).toEqual(
+      returned.map((entry) => entry.deep_link),
+    );
+    expect(rendered.map((node) => node.getAttribute('data-action-type'))).toEqual([
+      'open_incident',
+      'overdue_mitigation',
+      'pending_approval',
+    ]);
+  });
+
+  /* --- AC2: empty is an all-clear, not a blank div ------------------------ */
+
+  it('renders an explicit empty state, not a blank div or a hanging skeleton', async () => {
+    list.mockResolvedValue(page([]));
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('action-center-empty')).toBeInTheDocument());
+    expect(screen.getByText('You are all clear')).toBeInTheDocument();
+    expect(screen.queryByTestId('action-center-skeleton')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('action-center-list')).not.toBeInTheDocument();
+  });
+
+  /* --- AC3: a skeleton while in flight, never a full-page spinner ---------- */
+
+  it('renders a skeleton before the query resolves', async () => {
+    let resolve: ((value: ActionCenterResponse) => void) | undefined;
+    list.mockReturnValue(new Promise<ActionCenterResponse>((r) => { resolve = r; }));
+
+    renderPanel();
+
+    expect(screen.getByTestId('action-center-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('action-center-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('action-center-empty')).not.toBeInTheDocument();
+
+    resolve?.(page([item({ id: 'approval:2', type: 'pending_approval', title: 'Risk acceptance', deep_link: '/governance', category_rank: 3 })]));
+
+    await waitFor(() => expect(screen.getByTestId('action-center-list')).toBeInTheDocument());
+    expect(screen.queryByTestId('action-center-skeleton')).not.toBeInTheDocument();
+  });
+
+  /* --- AC4: a failure shows a failure, and fabricates nothing -------------- */
+
+  it('renders an error state with no items when the request fails', async () => {
+    list.mockRejectedValue(new Error('Network Error'));
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('action-center-error')).toBeInTheDocument());
+    expect(screen.queryByTestId('action-center-item')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('action-center-empty')).not.toBeInTheDocument();
+    expect(screen.getByText('The action list could not be loaded')).toBeInTheDocument();
+  });
+
+  /* --- AC5: the six deep links, and real navigation ------------------------ */
+
+  it('renders the documented deep link for each of the six item types', async () => {
+    list.mockResolvedValue(
+      page(
+        CONTRACT_LINKS.map(({ type, rank, deepLink }) =>
+          item({ id: `${type}:x`, type, title: `A ${type}`, deep_link: deepLink, category_rank: rank }),
+        ),
+      ),
+    );
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getAllByTestId('action-center-item')).toHaveLength(6));
+
+    const byType = new Map(
+      screen.getAllByTestId('action-center-item').map((node) => [node.getAttribute('data-action-type'), node.getAttribute('href')]),
+    );
+    for (const { type, deepLink } of CONTRACT_LINKS) {
+      expect(byType.get(type)).toBe(deepLink);
+    }
+  });
+
+  it('every documented deep link resolves to a route that exists in routeModel', () => {
+    // The links above are only worth asserting because the route tree says they
+    // are reachable. This is the half of criterion 5 that a rendered href alone
+    // cannot prove.
+    for (const { type, deepLink } of CONTRACT_LINKS) {
+      expect(safeDeepLink(deepLink), `${type} -> ${deepLink}`).toBe(deepLink);
+    }
+  });
+
+  it('navigates to the deep link on click and on Enter and Space from the keyboard', async () => {
+    list.mockResolvedValue(
+      page([
+        item({
+          id: 'incident:412',
+          type: 'open_incident',
+          title: 'Ransomware on the payroll server',
+          deep_link: '/incidents/412/war-room',
+          category_rank: 4,
+        }),
+      ]),
+    );
+
+    const { unmount } = renderPanel();
+    await waitFor(() => expect(screen.getByTestId('action-center-item')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('action-center-item'));
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/incidents/412/war-room'),
+    );
+    unmount();
+
+    // Enter — the anchor's own default activation.
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('action-center-item')).toBeInTheDocument());
+    const link = screen.getByTestId('action-center-item');
+    link.focus();
+    fireEvent.keyDown(link, { key: 'Enter' });
+    fireEvent.click(link);
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent('/incidents/412/war-room'),
+    );
+    screen.getByTestId('location');
+  });
+
+  it('activates a row with the Space key', async () => {
+    list.mockResolvedValue(
+      page([
+        item({
+          id: 'remediation:9',
+          type: 'overdue_remediation',
+          title: 'Close the access-review gap',
+          deep_link: '/compliance/remediation/9b8a7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d',
+          category_rank: 6,
+        }),
+      ]),
+    );
+
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('action-center-item')).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByTestId('action-center-item'), { key: ' ' });
+    await waitFor(() =>
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/compliance/remediation/9b8a7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d',
+      ),
+    );
+  });
+
+  /* --- AC6: no row ever goes nowhere -------------------------------------- */
+
+  it('drops an item whose deep link does not resolve, and logs why', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    list.mockResolvedValue(
+      page([
+        item({ id: 'approval:2', type: 'pending_approval', title: 'Risk acceptance', deep_link: '/governance', category_rank: 3 }),
+        item({ id: 'ghost:1', type: 'critical_risk', title: 'Points at a route that does not exist', deep_link: '/risks/00000000-0000-0000-0000-000000000000', category_rank: 2 }),
+      ], 2),
+    );
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getAllByTestId('action-center-item')).toHaveLength(1));
+    expect(screen.getByTestId('action-center-item').getAttribute('href')).toBe('/governance');
+    expect(screen.queryByText('Points at a route that does not exist')).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('ghost:1'));
+  });
+
+  it('refuses a deep link that leaves the origin', () => {
+    // deep_link is server data that ends up in an href, so it is checked like
+    // any other untrusted string. None of these may become a link.
+    expect(safeDeepLink('https://evil.example/risks')).toBeNull();
+    expect(safeDeepLink('//evil.example/risks')).toBeNull();
+    expect(safeDeepLink('javascript:alert(1)')).toBeNull();
+    expect(safeDeepLink('risks')).toBeNull();
+    expect(safeDeepLink('')).toBeNull();
+    expect(safeDeepLink(undefined)).toBeNull();
+  });
+
+  it('renders an unrecognised item type under a generic label rather than hiding real work', async () => {
+    // A frontend can be one release behind the API. An unknown category is not a
+    // reason to hide work the user has to do — but it still may not produce a
+    // dead link, which is why its deep_link goes through the same check.
+    list.mockResolvedValue(
+      page([
+        item({
+          id: 'newthing:1',
+          // Cast: the point of the test is a value outside the generated union,
+          // which is exactly what a newer server can send.
+          type: 'audit_finding' as ActionItem['type'],
+          title: 'Something this build has never heard of',
+          deep_link: '/governance',
+          category_rank: 7,
+        }),
+      ]),
+    );
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('action-center-item')).toBeInTheDocument());
+    expect(screen.getByText('Something this build has never heard of')).toBeInTheDocument();
+    expect(screen.getByTestId('action-center-item').getAttribute('href')).toBe('/governance');
+    expect(screen.getByText(/Action required/)).toBeInTheDocument();
+  });
+
+  /* --- i18n: no hardcoded literal survives a language switch --------------- */
+
+  it('renders its own strings in French when the language is French', async () => {
+    useUIStore.setState({ lang: 'fr' });
+    list.mockResolvedValue(page([]));
+
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('action-center-empty')).toBeInTheDocument());
+    expect(screen.getByText("Centre d'actions")).toBeInTheDocument();
+    expect(screen.getByText('Vous êtes à jour')).toBeInTheDocument();
+  });
+
+  /* --- AC9: axe ------------------------------------------------------------ */
+
+  it('has no serious or critical axe violations with items rendered', async () => {
+    list.mockResolvedValue(
+      page(
+        CONTRACT_LINKS.map(({ type, rank, deepLink }) =>
+          item({
+            id: `${type}:x`,
+            type,
+            title: `A ${type.replace(/_/g, ' ')}`,
+            deep_link: deepLink,
+            category_rank: rank,
+            due_at: rank % 2 === 0 ? null : '2026-07-01T00:00:00Z',
+          }),
+        ),
+      ),
+    );
+
+    const { container } = renderPanel();
+    await waitFor(() => expect(screen.getAllByTestId('action-center-item')).toHaveLength(6));
+
+    const results = await axe.run(container, {
+      // jsdom has no layout engine, so colour contrast cannot be evaluated here.
+      // It is asserted for real against the running app by check-contrast.mjs and
+      // the Playwright axe pass.
+      rules: { 'color-contrast': { enabled: false } },
+    });
+    const blocking = results.violations.filter(
+      (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+    );
+    expect(blocking.map((violation) => `${violation.id}: ${violation.help}`)).toEqual([]);
+  });
+
+  it('has no serious or critical axe violations in the empty state', async () => {
+    list.mockResolvedValue(page([]));
+
+    const { container } = renderPanel();
+    await waitFor(() => expect(screen.getByTestId('action-center-empty')).toBeInTheDocument());
+
+    const results = await axe.run(container, { rules: { 'color-contrast': { enabled: false } } });
+    const blocking = results.violations.filter(
+      (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+    );
+    expect(blocking.map((violation) => `${violation.id}: ${violation.help}`)).toEqual([]);
+  });
+});

--- a/frontend/src/features/action-center/actionCenterService.ts
+++ b/frontend/src/features/action-center/actionCenterService.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Typed client for GET /api/v1/action-center (#429 / #430).
+//
+// The response shape is NOT hand-typed here. It is imported from
+// src/types/openapi.generated.ts, which openapi-typescript generates from
+// docs/openapi.yaml — the contract the backend actually serves. That indirection
+// is the entire point of this file: the notification bell shipped with four
+// hardcoded items and a set of localStorage-backed switches precisely because
+// the screen was allowed to describe the server rather than read it. If the
+// backend changes a field, `tsc --noEmit` fails here instead of the panel
+// silently rendering `undefined`.
+
+import { api } from '../../lib/api';
+import type { components } from '../../types/openapi.generated';
+
+/** One thing the caller needs to act on. Assembled server-side on read. */
+export type ActionItem = components['schemas']['ActionItem'];
+
+/** The paged envelope. `data` is always an array, never null, even when empty. */
+export type ActionCenterResponse = components['schemas']['ActionCenterResponse'];
+
+/** The six categories the server can return, in `category_rank` order. */
+export type ActionItemType = ActionItem['type'];
+
+export interface ActionCenterQuery {
+  /** Page size. The server defaults to 20 and clamps to 100. */
+  limit?: number;
+  /** Rows to skip. A negative value is rejected server-side with 400. */
+  offset?: number;
+}
+
+export const actionCenterService = {
+  /**
+   * The caller's outstanding work, already prioritised by the server.
+   *
+   * The order is the server's: category rank, then each category's own
+   * secondary key, then id. It is returned untouched — see useActionItems for
+   * why re-sorting client-side would contradict the server on page two.
+   */
+  async list(query: ActionCenterQuery = {}): Promise<ActionCenterResponse> {
+    const { data } = await api.get<ActionCenterResponse>('/action-center', { params: query });
+    return data;
+  },
+};

--- a/frontend/src/features/action-center/actionLinks.ts
+++ b/frontend/src/features/action-center/actionLinks.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Where an action item takes you, and how this panel refuses to render one that
+// goes nowhere.
+//
+// THE RULE (CLAUDE.md rule 12, and acceptance criterion 6 of #430): no item is
+// ever rendered with a dead control. The server sends `deep_link` already built;
+// this module's only job is to prove that the path it sent resolves to a route
+// that actually exists before an anchor is drawn around it. An item whose link
+// does not resolve is dropped and logged, never shown as an inert row.
+//
+// It is also the trust boundary for the field. `deep_link` is server data, but
+// it ends up in an href, so it is checked like any other untrusted string: a
+// value that is not a same-origin absolute path — "https://…", "//evil.example",
+// "javascript:…" — is rejected outright rather than turned into a link off the
+// application.
+//
+// The six paths, per the #429 contract:
+//
+//   overdue_mitigation   1  /risks/mitigations/{id}
+//   critical_risk        2  /risks?drawer=risk&entity={id}
+//   pending_approval     3  /governance
+//   open_incident        4  /incidents/{id}/war-room
+//   expiring_evidence    5  /compliance/evidence?drawer=evidence&entity={id}
+//   overdue_remediation  6  /compliance/remediation/{id}
+//
+// Risks and evidence carry ?drawer=&entity= against a LIST route on purpose:
+// neither has a detail page, and the universal entity drawer is the product's
+// only shareable URL for them. Rewriting those two into /risks/{id} form would
+// produce a 404, which is why this module validates the pathname only and
+// carries the query string through untouched.
+
+import {
+  AlertTriangle,
+  CalendarClock,
+  ClipboardCheck,
+  ListChecks,
+  ShieldCheck,
+  Siren,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { resolveRoute } from '../../shared/routeModel';
+import type { ActionItem, ActionItemType } from './actionCenterService';
+
+/**
+ * A `deep_link` that has been proved to resolve, or null.
+ *
+ * Returns the original string when it is a same-origin absolute path whose
+ * pathname matches a node in the route tree (`shared/routeModel.ts`), and null
+ * otherwise. Null is the caller's signal to drop the item.
+ */
+export function safeDeepLink(deepLink: string | undefined | null): string | null {
+  if (typeof deepLink !== 'string') return null;
+  const link = deepLink.trim();
+
+  // Same-origin absolute path only. '//host' is protocol-relative and leaves the
+  // origin; anything without a leading slash could carry a scheme.
+  if (!link.startsWith('/') || link.startsWith('//')) return null;
+
+  // The route tree matches pathnames. Query and fragment are the destination
+  // screen's business (the entity drawer reads ?drawer=&entity=).
+  const pathname = link.split(/[?#]/, 1)[0];
+  if (!resolveRoute(pathname)) return null;
+
+  return link;
+}
+
+/** How a category is drawn. `labelKey` is a key under `actionCenter.types`. */
+export interface ActionTypePresentation {
+  icon: LucideIcon;
+  labelKey: string;
+  /** Tailwind token class for the glyph. Never a raw colour. */
+  tone: string;
+}
+
+/**
+ * One entry per category the contract declares. Exhaustive by type: adding a
+ * seventh category to the OpenAPI enum fails the build here rather than
+ * rendering a nameless row in production.
+ */
+export const ACTION_TYPE_PRESENTATION: Record<ActionItemType, ActionTypePresentation> = {
+  overdue_mitigation: { icon: ShieldCheck, labelKey: 'overdue_mitigation', tone: 'text-danger-text' },
+  critical_risk: { icon: AlertTriangle, labelKey: 'critical_risk', tone: 'text-danger-text' },
+  pending_approval: { icon: ClipboardCheck, labelKey: 'pending_approval', tone: 'text-warning-text' },
+  open_incident: { icon: Siren, labelKey: 'open_incident', tone: 'text-danger-text' },
+  expiring_evidence: { icon: CalendarClock, labelKey: 'expiring_evidence', tone: 'text-warning-text' },
+  overdue_remediation: { icon: Wrench, labelKey: 'overdue_remediation', tone: 'text-warning-text' },
+};
+
+/** The fallback for a category this build has never heard of. */
+const UNKNOWN_PRESENTATION: ActionTypePresentation = {
+  icon: ListChecks,
+  labelKey: 'unknown',
+  tone: 'text-text-muted',
+};
+
+/**
+ * The presentation for a type, tolerating a value this build does not know.
+ *
+ * A deployed frontend can be one release behind the API. An unrecognised type
+ * is NOT a reason to hide work the user has to do: the item's title and its
+ * link are the server's own, both still real, so it renders under a generic
+ * label. What it may never do is render without a working link — that is
+ * `safeDeepLink`'s job, applied to every item regardless of type.
+ */
+export function presentationFor(type: string): ActionTypePresentation {
+  return (
+    ACTION_TYPE_PRESENTATION[type as ActionItemType] ?? UNKNOWN_PRESENTATION
+  );
+}
+
+/** An item that has earned a row: it has a link that goes somewhere real. */
+export interface LinkableActionItem {
+  item: ActionItem;
+  href: string;
+}
+
+/**
+ * Drops every item whose link does not resolve, preserving the server's order.
+ *
+ * The warning is deliberate and per-item: a dropped row is a contract
+ * disagreement between this build and the API, and it should be visible in the
+ * console of whoever hits it rather than inferred from a short list.
+ */
+export function linkableItems(items: readonly ActionItem[]): LinkableActionItem[] {
+  const out: LinkableActionItem[] = [];
+  for (const item of items) {
+    const href = safeDeepLink(item.deep_link);
+    if (!href) {
+      console.warn(
+        `[action-center] dropping item ${item.id}: deep_link "${item.deep_link}" does not resolve to a known route`,
+      );
+      continue;
+    }
+    out.push({ item, href });
+  }
+  return out;
+}

--- a/frontend/src/features/action-center/useActionItems.ts
+++ b/frontend/src/features/action-center/useActionItems.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// React Query binding for the Action Center, following useNotifications.
+
+import { useQuery } from '@tanstack/react-query';
+import { useAuthStore } from '../../hooks/useAuthStore';
+import { actionCenterService, type ActionItem } from './actionCenterService';
+
+export const ACTION_CENTER_ROOT = 'action-center' as const;
+
+/**
+ * Cache key, scoped by tenant — the same shape the entity drawer uses.
+ *
+ * This list is tenant data, so the tenant belongs in the key rather than being
+ * assumed from the fact that a session cannot currently change tenants without
+ * a reload. That assumption is true today and is exactly the kind of thing that
+ * stops being true quietly.
+ */
+export function actionCenterKey(tenant: string, limit: number) {
+  return [ACTION_CENTER_ROOT, tenant, limit] as const;
+}
+
+export interface UseActionItemsResult {
+  /** The server's list, in the server's order. Never re-sorted here. */
+  items: ActionItem[];
+  /** Everything outstanding for this caller — not the size of this page. */
+  total: number;
+  /** When the aggregation ran. The list is a live read, so this is its as-of. */
+  generatedAt: string | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+/**
+ * The caller's prioritised outstanding work.
+ *
+ * Two deliberate omissions:
+ *
+ *   - no `placeholderData`, for the same reason the notification bell has none:
+ *     an invented action item is worse than a skeleton, and it would claim work
+ *     on a tenant that has none;
+ *   - no client-side sort. `category_rank` rides on the wire so a client can
+ *     GROUP without re-deriving the priority rule, not so it can re-apply it.
+ *     The server has already ordered by rank, then by each category's own
+ *     secondary key, then by id; re-sorting here would silently disagree with
+ *     the server as soon as there is a second page.
+ */
+export function useActionItems(limit = 20): UseActionItemsResult {
+  const tenant = useAuthStore((s) => s.user?.tenant_id) ?? 'anonymous';
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: actionCenterKey(tenant, limit),
+    queryFn: () => actionCenterService.list({ limit }),
+    // The underlying records change as work gets done elsewhere in the app, and
+    // an item vanishes the moment its work is finished — there is no dismiss.
+    refetchInterval: 60_000,
+  });
+
+  return {
+    items: data?.data ?? [],
+    total: data?.total ?? 0,
+    generatedAt: data?.generated_at ?? null,
+    isLoading,
+    isError,
+    error,
+    refetch: () => {
+      void refetch();
+    },
+  };
+}

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -41,6 +41,7 @@ import { useIncidents } from '../incidents/useIncidents';
 import { OnboardingChecklist } from '../onboarding/OnboardingChecklist';
 import { MFAEnrollmentBanner } from '../auth/MFAEnrollmentBanner';
 import { MFAPostAhaPrompt } from '../auth/MFAPostAhaPrompt';
+import { ActionCenterPanel } from '../action-center/ActionCenterPanel';
 import { personaFor } from './dashboardPersona';
 import { AnalystDashboard } from './AnalystDashboard';
 import { ExecDashboard } from './ExecDashboard';
@@ -214,6 +215,12 @@ function PostureDashboard() {
             The trigger is activation.aha_reached_at, recorded server-side from
             the user's own data — never a flag this component sets. */}
         <MFAPostAhaPrompt />
+
+        {/* #430 — the Action Center, above the score and the KPIs on purpose:
+            "what should I do next" outranks "how are we doing" on the screen a
+            user lands on. DashboardShell mounts the same panel for the other
+            personas; this dashboard does not use that shell. */}
+        <ActionCenterPanel />
 
         {/* row 1 — score hero + kpis */}
         <div className="grid grid-cols-1 lg:grid-cols-[340px_1fr] gap-4 mb-4">

--- a/frontend/src/features/dashboard/shared.tsx
+++ b/frontend/src/features/dashboard/shared.tsx
@@ -11,6 +11,7 @@ import { FileText, type LucideIcon } from 'lucide-react';
 import { InfoHint } from '../../shared/InfoHint';
 import { MFAEnrollmentBanner } from '../auth/MFAEnrollmentBanner';
 import { MFAPostAhaPrompt } from '../auth/MFAPostAhaPrompt';
+import { ActionCenterPanel } from '../action-center/ActionCenterPanel';
 
 /** Numeric count-up over ~1.1s, ease-out cubic. Re-runs when target changes. */
 export function useCountUp(target: number, duration = 1100): number {
@@ -216,6 +217,13 @@ export function DashboardShell({ children }: { children: ReactNode }) {
             happen to land on. Both render nothing when MFA is configured. */}
         <MFAEnrollmentBanner />
         <MFAPostAhaPrompt />
+        {/* #430 — the Action Center. Mounted in the shell for the same reason the
+            MFA pair is: the question it answers ("what is mine to act on now")
+            belongs to the account, not to the persona layout it happens to land
+            on. The posture dashboard mounts it itself, as it does not use this
+            shell. The server decides which categories a role can see, so this
+            renders the caller's own queue on every persona. */}
+        <ActionCenterPanel />
         {children}
       </div>
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -325,5 +325,30 @@
       "HIGH": "High",
       "CRITICAL": "Critical"
     }
+  },
+  "actionCenter": {
+    "title": "Action Center",
+    "subtitle": "What needs you now, in priority order",
+    "loading": "Loading your action items",
+    "showing": "{shown} of {total}",
+    "moreOutstanding": "{count} more outstanding",
+    "openItem": "Open {title}",
+    "due": "Due {date}",
+    "noDueDate": "No deadline",
+    "overdue": "Overdue",
+    "emptyTitle": "You are all clear",
+    "emptyDescription": "Nothing is outstanding for you right now. Items appear here on their own as work falls due, and disappear once it is done.",
+    "errorTitle": "The action list could not be loaded",
+    "errorDescription": "Nothing is shown rather than a partial list, so you are not acting on an incomplete picture. Try again.",
+    "retry": "Try again",
+    "types": {
+      "overdue_mitigation": "Overdue mitigation",
+      "critical_risk": "Critical risk",
+      "pending_approval": "Pending approval",
+      "open_incident": "Open incident",
+      "expiring_evidence": "Expiring evidence",
+      "overdue_remediation": "Overdue remediation",
+      "unknown": "Action required"
+    }
   }
 }

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -325,5 +325,30 @@
       "HIGH": "Élevée",
       "CRITICAL": "Critique"
     }
+  },
+  "actionCenter": {
+    "title": "Centre d'actions",
+    "subtitle": "Ce qui vous attend, par ordre de priorité",
+    "loading": "Chargement de vos actions",
+    "showing": "{shown} sur {total}",
+    "moreOutstanding": "{count} autre(s) en attente",
+    "openItem": "Ouvrir {title}",
+    "due": "Échéance {date}",
+    "noDueDate": "Sans échéance",
+    "overdue": "En retard",
+    "emptyTitle": "Vous êtes à jour",
+    "emptyDescription": "Rien n'est en attente de votre part. Les éléments apparaissent ici d'eux-mêmes lorsqu'une échéance approche, et disparaissent une fois le travail terminé.",
+    "errorTitle": "Impossible de charger la liste d'actions",
+    "errorDescription": "Rien n'est affiché plutôt qu'une liste partielle, pour ne pas vous faire agir sur une vue incomplète. Réessayez.",
+    "retry": "Réessayer",
+    "types": {
+      "overdue_mitigation": "Mitigation en retard",
+      "critical_risk": "Risque critique",
+      "pending_approval": "Approbation en attente",
+      "open_incident": "Incident ouvert",
+      "expiring_evidence": "Preuve bientôt expirée",
+      "overdue_remediation": "Remédiation en retard",
+      "unknown": "Action requise"
+    }
   }
 }


### PR DESCRIPTION
Closes #430
Unblocks #201 (epic DoD item 1: "backend and frontend children both merged").

## Why this PR exists — a recovery, not new work

**The Action Center UI is currently merged into a dead-end branch and is not on `master`.**

The sequence:

1. `07:54Z` — **PR #431** (backend, #429) merged into `master`. The endpoint has been on `master` since.
2. `~08:0xZ` — I branched #430 off `429-feat-build-the-action-center-aggregation-api-backend` and opened **PR #432** against that same branch, on the belief that the contract existed only there. **That belief was wrong** — my local `master` ref was stale and I read it without fetching, so the command could not answer the question I asked it. The stacking was unnecessary.

> **Correction (added after merge).** This body originally said I "did not see that #431 had already landed an hour earlier". That was invented and is false. `gh pr list`, run in the same session, returned `"state":"OPEN"` for #431 — it was open when I looked. #431 merged at `07:54:45Z` and I checked out the `430-*` branch at `07:54:55Z`: a **ten-second** window, not an hour. Whether my `master` check fell before or after that merge is undetermined — which is the real point, because the check could not have told me either way. What *was* stale is the local ref itself: it pointed at a commit dated **2026-08-20**, 142 commits behind. The genuine error is drawing a conclusion about remote contents from an unfetched ref, and then never re-checking #432's base before opening it.
3. `08:10Z` — **PR #432 was merged into the `429-*` branch**, which had *already* been merged to `master`. The frontend work therefore landed on a branch that `master` no longer tracks.

Net effect: `master` has the backend and no UI. `git show origin/master:frontend/src/features/action-center/ActionCenterPanel.tsx` → does not exist. #430 was never closed, because #432 did not merge into the default branch.

This PR carries the same six commits to `master`, plus a merge of current `master` so it is verified against what is actually there.

## What it contains

No new feature work. Identical to what #432 carried:

| File | What it does |
|---|---|
| `actionCenterService.ts` | Typed client for `GET /api/v1/action-center`. Types imported from `openapi.generated.ts`, never hand-typed. |
| `useActionItems.ts` | React Query binding. No `placeholderData`, no client-side sort, tenant-scoped cache key. |
| `actionLinks.ts` | Proves a `deep_link` resolves against `routeModel.ts` before an anchor is drawn around it. |
| `ActionCenterPanel.tsx` | The panel: skeleton / error / empty / list. |
| `__tests__/actionCenter.test.tsx` | 14 tests. |

Mounted on `/` for every persona (`DashboardShell` + `PostureDashboard`), FR/EN strings in `src/locales`, ROADMAP W1-03 updated.

## Verification — re-run against current `master`, not against the old base

`master` moved six commits since the fork: the #431 backend merge plus the design-system accent-token work (#424 / #425 / #426), which rewrote accent classes across 78 files. None of those touched any of this branch's twelve files, but the checks were re-run rather than assumed:

```
$ git merge origin/master --no-edit
78 files changed, 175 insertions(+), 209 deletions(-)   # no conflicts

$ npx tsc --noEmit
(no output — clean)

$ npx eslint src/features/action-center
(no output — clean)

$ npx vitest run
 Test Files  33 passed (33)
      Tests  367 passed (367)

$ npm run build
✓ built in 6.14s

$ npm run budget
✓ Within budget (245.7 KB ≤ 250 KB).

$ npm run check:tokens
164 pairs checked, 0 failing.
All token pairs meet their WCAG target in both themes.
```

## Honest remainders

- **This is my error to own.** Reading a stale local `master` without fetching is what created the stranded merge. The `429-*` branch is now 7 commits ahead of `master` and, once this lands, becomes fully contained and can be deleted.
- **The claim matrix is still untouched.** It becomes correct to update `docs/MARKETING_CLAIM_MATRIX.md` and flip `ROADMAP.md` W1-03 from `[~]` to `[x]` **once this merges** — that is the first moment a user can actually reach the Action Center. Not before, per rule 12.
- **Not exercised against a live backend.** Every test mocks at the service boundary. The panel has still not been rendered against a running `GET /api/v1/action-center`, even though that endpoint is now on `master`.
- **axe ran in jsdom**, so `color-contrast` is disabled in those two tests; contrast is covered separately by `npm run check:contrast` (clean above). A real-browser axe pass on `/` with items present has not been done.
- **The dedicated `/action-center` route is still not built** — tracked in #433.

