### PR TITLE
docs(action-center): mark W1-03 delivered and reachable on master (#201)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -393,7 +393,7 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
 11. **Billing & Plans (17.2)** + conversion (Partie C) + **Onboarding (17.6)** + **Super Admin (17.4)**.
 
 **Bloc W1 — Wave 1, fondations produit**
-- [~] **W1-03 — Action Center contextuel** (épique #201, scindée en #429 backend / #430 frontend).
+- [x] **W1-03 — Action Center contextuel** (épique #201, scindée en #429 backend / #430 frontend).
   **Backend livré** (#429, branche `429-feat-build-the-action-center-aggregation-api-backend`) :
   `GET /api/v1/action-center` — agrégation **en lecture seule** de six sources existantes (mitigation en
   retard · risque critique sans mitigation active · approbation dont l'appelant est l'approbateur de
@@ -404,8 +404,7 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
   `internal/infrastructure/repository/actioncenter_repository.go`,
   `internal/handler/action_center_handler.go`. Contrat publié dans `docs/openapi.yaml` +
   `frontend/src/types/openapi.generated.ts`.
-  **Frontend livré** (#430, branche `430-feat-build-the-action-center-ui-with-role-aware-priority-and-deep-links-frontend`,
-  empilée sur celle de #429 car le contrat n'existe que là) : panneau « Centre d'actions » monté sur le
+  **Frontend livré** (#430, PR #432 puis **PR #434**) : panneau « Centre d'actions » monté sur le
   tableau de bord (`/`) pour **toutes** les personas — `DashboardShell` pour les cinq personas dédiées,
   `PostureDashboard` qui n'utilise pas ce shell le monte lui-même. `frontend/src/features/action-center/`
   (`actionCenterService.ts`, `useActionItems.ts`, `actionLinks.ts`, `ActionCenterPanel.tsx`). Types importés
@@ -416,11 +415,19 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
   (`https://`, `//host`, `javascript:`) — fait **supprimer** l'élément avec un warning, jamais afficher une
   ligne morte. FR/EN dans `src/locales`. 14 tests (`__tests__/actionCenter.test.tsx`), dont axe-core sur le
   panneau rempli et vide.
-  **⚠️ Aucun utilisateur ne peut encore l'atteindre** : #429 (PR #431) et #430 sont tous deux ouverts, non
-  mergés — l'endpoint n'existe pas sur `master`. La capacité ne sera déclarée livrée, et n'entrera dans la
-  matrice de claims, qu'au merge des **deux**. Règle 12.
-  **Reste à faire** : route dédiée `/action-center` (page pleine, pagination au-delà des 8 premières
-  lignes) — fast-follow explicitement autorisé par #430, suivi dans **#433**.
+  **Atteignable sur `master` depuis le 2026-08-31** : backend mergé par PR #431 (07:54Z), frontend par
+  **PR #434** (08:15Z). PR #432 avait été mergée dans la branche `429-*` — déjà absorbée par `master` — et
+  laissait donc l'UI sur une branche morte ; #434 est la reprise, re-vérifiée contre le `master` courant
+  (`tsc` propre, eslint propre, 367/367, build OK, budget 245,7/250 Ko, `check:tokens` 164 paires 0 échec).
+  **Reste à faire**
+  - Ligne W1-03 dans `docs/MARKETING_CLAIM_MATRIX.md` : **non ajoutée**. Le fichier réserve explicitement
+    le statut `VERIFIED` à l'agent `product-verifier` ; la ligne doit venir de `/verify-claims`, pas d'une
+    saisie manuelle. C'est le dernier élément de la DoD de #201.
+  - Route dédiée `/action-center` (page pleine, pagination au-delà des 8 premières lignes) — fast-follow
+    explicitement autorisé par #430, suivi dans **#433**.
+  - Jamais exercé contre un backend vivant : tous les tests bouchonnent à la frontière du service. Le
+    panneau n'a pas été rendu contre un `GET /api/v1/action-center` en fonctionnement, et la passe axe
+    Playwright sur `/` avec des éléments présents n'a pas été faite.
 
 **Bloc E — Wave 2/3 (gamechangers restants)**
 12. Digital Twin (14.13), War Room (14.14), Attack Path (14.15), Access Review (14.10), Offline (14.17),


### PR DESCRIPTION
Refs #201. **Deliberately does not say "Closes #201"** — see Honest remainders.

## What this is

The epic's `ROADMAP.md` status update, now that both children are actually on `master`:

- **#431** (backend, #429) merged `07:54Z`
- **#434** (frontend, #430) merged `08:15Z`

W1-03 flips from `[~]` to `[x]` for its stated scope, and the entry is rewritten to record what is true today rather than what was true when it was written.

## Why the entry changed as much as it did

The previous text said *"⚠️ Aucun utilisateur ne peut encore l'atteindre … l'endpoint n'existe pas sur `master`"*. That was accurate when written and is now wrong on both counts. It also described the frontend branch as stacked on the backend's "car le contrat n'existe que là" — which was never true: #431 had already merged an hour before that branch was cut. The replacement records the actual sequence, including that **PR #432 merged into the `429-*` branch — already absorbed by `master` — leaving the UI on a dead-end branch until #434 recovered it.**

## Verification

The claim that the capability is reachable was checked directly rather than inferred from the PRs being closed:

```
$ git show origin/master:frontend/src/features/action-center/ActionCenterPanel.tsx
(exists)

$ gh api repos/opendefender/OpenRisk/pulls/434 --jq '{merged,merged_at}'
{"merged":true,"merged_at":"2026-08-31T08:15:27Z"}
```

The #434 branch was verified against current `master` before it merged — `master` had moved six commits (the #431 backend merge plus the design-system accent-token work #424/#425/#426, which rewrote accent classes across 78 files):

```
$ npx tsc --noEmit                 (clean)
$ npx eslint src/features/action-center   (clean)
$ npx vitest run                   Test Files 33 passed · Tests 367 passed
$ npm run build                    ✓ built in 6.14s
$ npm run budget                   ✓ Within budget (245.7 KB ≤ 250 KB)
$ npm run check:tokens             164 pairs checked, 0 failing
```

This PR itself changes one documentation file and no code.

## Honest remainders

- **The claim-matrix row is NOT added, and this PR does not close #201 because of it.** `docs/MARKETING_CLAIM_MATRIX.md` states in its own header that *"Only the `product-verifier` agent may set a status to `VERIFIED`"*, and the file is still at its seed row (`C-001 — _seed row — run /verify-claims to populate_`). Hand-writing a `VERIFIED` row would violate the file's own rule and the spirit of rule 12 in the same motion. **The epic's last DoD item is a `/verify-claims` run**, and it is the owner's to trigger.
- **`docs/JOURNAL.md` untouched**, consistent with how #429 and #430 were handled — neither wrote a journal entry.
- **Nothing has been exercised against a live backend.** Every test mocks at the service boundary. Now that the endpoint is on `master`, rendering the panel against a running `GET /api/v1/action-center` and running the Playwright axe pass on `/` with items present are both still undone; the ROADMAP entry now says so explicitly.
- **CI on this repo is red on `master` independently of this change.** `Frontend Unit Tests` fails at `npm run test -- --coverage` with `MISSING DEPENDENCY  Cannot find dependency '@vitest/coverage-v8'`, reproduced locally and failing identically on the #431 and #426 merge commits. It is not caused by the Action Center work and **has no issue tracking it** — one is needed before anyone can trust that job.
- **#433** (dedicated `/action-center` route with pagination) is `status:ready` and is a fast-follow, not part of this epic's scope.
