### PR TITLE
feat(activation): make the onboarding checklist truthful for configured tenants (#234)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,8 +135,8 @@ il n'est pas encore la plateforme différenciante du Master Prompt V5 (Wave 2/3)
 | **17.2 Billing & Plans (Stripe/Mobile Money)** | ❌ | Rien. | Middleware `CheckPlanLimits`, Stripe, Wave/MTN/Orange. |
 | **17.3 Feature Flags** | 🟡 | Claim `FeatureFlags` dans le JWT (`internal/auth/jwt.go`). | **Pas de table `feature_flags`, pas de middleware `FeatureFlag()`, pas d'admin.** Scaffolding claim seulement. |
 | **17.4 Super Admin Panel** | ❌ | Aucun package superadmin. | Tenants/impersonation/metrics globales/équipe OpenDefender. |
-| **17.5 Accessibilité (WCAG 2.1 AA)** | 🟡 | Design system partiel, Framer Motion. | Pas d'audit `axe-core`, focus/ARIA/contraste non garantis. |
-| **17.6 Onboarding Flow (5 étapes)** | ❌ | Aucun package onboarding. | Critique pour l'activation (« 1er risque en < 5 min »). |
+| **17.5 Accessibilité (WCAG 2.1 AA)** | 🟡 | Balayage `axe-core` automatisé (`tests/e2e/a11y.spec.ts`) : 15 écrans principaux + les 5 routes du wizard d'onboarding et la checklist d'activation, porte à zéro violation *serious/critical*, `A11Y_KNOWN` vide. | Le balayage couvre les écrans principaux, pas encore toutes les modales ni tous les tiroirs ; parcours clavier et lecteur d'écran non audités de bout en bout. |
+| **17.6 Onboarding Flow (5 étapes)** | ✅ | Wizard 5 étapes reprenable (`frontend/src/features/onboarding/wizard/`), garde de route `OnboardingGuard`, état serveur `internal/application/activation/onboarding.go` + `internal/domain/activation.go`, endpoints `/onboarding/*` et `/activation/state`. Checklist d'activation à 7 étapes, dérivée d'événements serveur ; amorcée pour les tenants déjà configurés (`gorm_activation_backfill.go`). | Promesse d'activation : **Aha en < 8 min** (assertion `tests/e2e/activation.spec.ts` ; l'alerte `SlowTimeToAha` à P50 > 12 min est un seuil d'exploitation, pas la promesse). Étapes « intégrations » et « première évaluation » : hors périmètre, voir #234. |
 | **17.7 Sync Engine & Intégrations** | 🟡 | `infrastructure/integrations/thehive` + `SyncEngine` lancé dans `main.go`. | OpenCTI/Splunk/Elastic/AWS Security Hub/Azure Defender/Jira : ❌. |
 
 ### 1.4 Product Growth — Partie C (go-to-market)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -794,6 +794,13 @@ func main() {
 	if err := activationRepo.BackfillExistingMembers(context.Background()); err != nil {
 		log.Printf("Warning: activation backfill failed (existing users may see the onboarding wizard): %v", err)
 	}
+	// The event log is forward-only, so a tenant configured before activation
+	// shipped has no events at all and is told to create the first risk it
+	// created months ago. Seed the checklist from the records the tenant already
+	// holds, dated from those records. Idempotent; safe on every boot.
+	if err := activationRepo.BackfillDerivedEvents(context.Background()); err != nil {
+		log.Printf("Warning: activation derived backfill failed (configured tenants may see completed steps as incomplete): %v", err)
+	}
 	activationRecorder := appactivation.NewRecorder(activationRepo)
 	ahaRecorder := appactivation.NewAhaRecorder(activationRepo)
 	// Legacy handlers that build their own use cases inline (mitigation) read the

--- a/backend/internal/infrastructure/repository/gorm_activation_backfill.go
+++ b/backend/internal/infrastructure/repository/gorm_activation_backfill.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// Seeding the checklist from data that already exists.
+//
+// The activation event log is FORWARD-ONLY: a step ticks because a use case
+// recorded an event as it happened. That is correct for a tenant created after
+// activation shipped, and visibly wrong for every tenant created before it. A
+// bank with two hundred risks, an imported ISO 27001 catalogue and a mapped
+// asset estate is told to "create your first risk" — the one panel whose job is
+// to say where you are says something untrue, and there is no user action that
+// can correct it, because no endpoint lets a client mark a step complete.
+//
+// BackfillExistingMembers already anchors `signup` per organization. This adds
+// the rest: for each checklist step, if the tenant HOLDS the record that step is
+// about, anchor one event dated from that record.
+//
+// Three properties matter more than the feature:
+//
+//  1. Tenancy (RULE #2). Every derivation groups by the source table's own
+//     tenant column and writes that same value back. There is no join between a
+//     source row and a tenant it does not belong to, so there is no arrangement
+//     of the data that can make tenant B's records tick tenant A's checklist.
+//  2. Idempotency. This runs on every boot. A tenant that already has an event
+//     for a key is skipped entirely, so reboots neither duplicate rows nor move
+//     a completed_at. (First-occurrence-wins would protect the DATE anyway; it
+//     would not protect the table from growing without bound.)
+//  3. Honest dates. occurred_at is MIN(created_at) of the underlying record, not
+//     now(). Stamping the boot time would date every historic tenant's first
+//     risk to the deploy and poison openrisk_time_to_aha_seconds — the metric
+//     the launch gate is meant to cite.
+//
+// `profile` is deliberately NOT derived. No stored record proves a user filled
+// in the profile step: BackfillExistingMembers marks pre-existing wizards
+// complete without industry / country / goal, so deriving it from the wizard row
+// would tick a step for work nobody did. An undone step shown as undone is the
+// truthful outcome, and the one the tests pin.
+
+// activationSource declares which stored record proves which checklist step.
+//
+// Model is a domain struct rather than a table name so GORM resolves the table
+// AND applies the soft-delete scope: a tenant whose only risk was deleted has
+// not created a risk, and raw SQL would have silently counted the tombstone.
+type activationSource struct {
+	EventKey  domain.ActivationEventKey
+	Model     any
+	TenantCol string
+	TimeCol   string
+	// Scope narrows what counts as proof. Nil means "any surviving row".
+	Scope func(*gorm.DB) *gorm.DB
+}
+
+// activationBackfillSources maps the six derivable checklist steps to their
+// evidence. `tenant_id` is the canonical column on every model here — Risk and
+// Asset also carry a legacy `organization_id` alias, and every other repository
+// in this package filters on tenant_id, so this does too.
+func activationBackfillSources() []activationSource {
+	return []activationSource{
+		{
+			EventKey:  domain.ActivationRiskCreated,
+			Model:     &domain.Risk{},
+			TenantCol: "tenant_id",
+			TimeCol:   "created_at",
+		},
+		{
+			EventKey:  domain.ActivationFrameworkImported,
+			Model:     &domain.ComplianceFramework{},
+			TenantCol: "tenant_id",
+			TimeCol:   "created_at",
+		},
+		{
+			EventKey:  domain.ActivationAssetConnected,
+			Model:     &domain.Asset{},
+			TenantCol: "tenant_id",
+			TimeCol:   "created_at",
+		},
+		{
+			EventKey:  domain.ActivationMitigationCreated,
+			Model:     &domain.Mitigation{},
+			TenantCol: "tenant_id",
+			TimeCol:   "created_at",
+		},
+		{
+			EventKey:  domain.ActivationReportGenerated,
+			Model:     &domain.Report{},
+			TenantCol: "tenant_id",
+			TimeCol:   "created_at",
+			// A queued or failed run is not a generated report. Only a
+			// succeeded one is something the user actually got.
+			Scope: func(q *gorm.DB) *gorm.DB {
+				return q.Where("run_state = ?", string(domain.ReportRunSucceeded))
+			},
+		},
+		{
+			EventKey:  domain.ActivationMemberInvited,
+			Model:     &domain.OrganizationMember{},
+			TenantCol: "organization_id",
+			TimeCol:   "created_at",
+			// "Invited a teammate" means a member arrived who was not the
+			// founding one. The correlated subquery excludes each organization's
+			// earliest membership row and is correlated ON the tenant column, so
+			// it cannot reach across tenants. Portable to both engines — a window
+			// function would not be, and organizations.owner_id is not reliable
+			// here (ownership can be transferred after the fact).
+			Scope: func(q *gorm.DB) *gorm.DB {
+				return q.Where(`created_at > (
+					SELECT MIN(m2.created_at) FROM organization_members m2
+					WHERE m2.organization_id = organization_members.organization_id
+				)`)
+			},
+		},
+	}
+}
+
+// derivedTenant is one (tenant, earliest evidence) pair.
+type derivedTenant struct {
+	TenantID uuid.UUID
+	FirstAt  time.Time
+}
+
+// BackfillDerivedEvents anchors one activation event per checklist step for
+// every tenant that already holds the underlying record.
+//
+// Runs in a single transaction: a partial seed would leave a tenant with a
+// half-true checklist, which is the exact defect this exists to remove. Safe to
+// call on every boot.
+func (r *GormActivationRepository) BackfillDerivedEvents(ctx context.Context) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, src := range activationBackfillSources() {
+			if err := backfillActivationSource(tx, src); err != nil {
+				return fmt.Errorf("backfill %s: %w", src.EventKey, err)
+			}
+		}
+		return nil
+	})
+}
+
+// backfillActivationSource seeds one step.
+func backfillActivationSource(tx *gorm.DB, src activationSource) error {
+	// A deployment that has not migrated this table yet must not fail the boot
+	// backfill for every other step.
+	if !tx.Migrator().HasTable(src.Model) {
+		return nil
+	}
+
+	seeded, err := tenantsWithEvent(tx, src.EventKey)
+	if err != nil {
+		return err
+	}
+
+	candidates, err := tenantsHoldingEvidence(tx, src)
+	if err != nil {
+		return err
+	}
+
+	events := make([]*domain.ActivationEvent, 0, len(candidates))
+	for _, c := range candidates {
+		if _, done := seeded[c.TenantID]; done {
+			// Already has a first occurrence, from live use or a previous boot.
+			continue
+		}
+		events = append(events, &domain.ActivationEvent{
+			ID:       uuid.New(),
+			TenantID: c.TenantID,
+			// No UserID: the tenant reached this milestone, but which member did
+			// is not recoverable from the record, and inventing one would put a
+			// name on an act that person may not have performed.
+			UserID:     nil,
+			EventKey:   src.EventKey,
+			OccurredAt: c.FirstAt.UTC(),
+		})
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	return tx.CreateInBatches(events, 200).Error
+}
+
+// tenantsWithEvent returns the tenants that already have an occurrence of a key.
+func tenantsWithEvent(tx *gorm.DB, key domain.ActivationEventKey) (map[uuid.UUID]struct{}, error) {
+	out := map[uuid.UUID]struct{}{}
+	rows, err := tx.Model(&domain.ActivationEvent{}).
+		Select("DISTINCT tenant_id").
+		Where("event_key = ?", string(key)).
+		Rows()
+	if err != nil {
+		return nil, fmt.Errorf("read seeded tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var raw any
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("read seeded tenants: %w", err)
+		}
+		if id, ok := asUUID(raw); ok {
+			out[id] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read seeded tenants: %w", err)
+	}
+	return out, nil
+}
+
+// tenantsHoldingEvidence returns, per tenant, the earliest record proving a step.
+//
+// One grouped query per step, never one per tenant: an install with a thousand
+// organizations must not issue a thousand statements at boot.
+func tenantsHoldingEvidence(tx *gorm.DB, src activationSource) ([]derivedTenant, error) {
+	q := tx.Model(src.Model).
+		Select(fmt.Sprintf("%s AS tenant_id, MIN(%s) AS first_at", src.TenantCol, src.TimeCol)).
+		Where(fmt.Sprintf("%s IS NOT NULL", src.TenantCol)).
+		Group(src.TenantCol)
+	if src.Scope != nil {
+		q = src.Scope(q)
+	}
+
+	rows, err := q.Rows()
+	if err != nil {
+		return nil, fmt.Errorf("read evidence: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []derivedTenant
+	for rows.Next() {
+		var rawTenant, rawAt any
+		if err := rows.Scan(&rawTenant, &rawAt); err != nil {
+			return nil, fmt.Errorf("read evidence: %w", err)
+		}
+		tenantID, ok := asUUID(rawTenant)
+		if !ok {
+			// An unparseable or zero tenant is dropped rather than defaulting to
+			// uuid.Nil, which would collect unrelated orphan rows into one
+			// pseudo-tenant and tick a checklist nobody owns.
+			continue
+		}
+		at, ok := asTime(rawAt)
+		if !ok || at.IsZero() {
+			continue
+		}
+		out = append(out, derivedTenant{TenantID: tenantID, FirstAt: at})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read evidence: %w", err)
+	}
+	return out, nil
+}
+
+// asUUID normalises whatever the driver returned for a uuid column. Postgres
+// hands back a uuid.UUID or a string; sqlite (which the repository tests run on)
+// hands back TEXT or a 16-byte BLOB. Same reasoning as asTime: without this the
+// production query could only ever be proven on the engine nobody tests against.
+//
+// uuid.Nil reads as "not a tenant" — never as a valid grouping key.
+func asUUID(v any) (uuid.UUID, bool) {
+	var (
+		id  uuid.UUID
+		err error
+	)
+	switch t := v.(type) {
+	case uuid.UUID:
+		id = t
+	case *uuid.UUID:
+		if t == nil {
+			return uuid.Nil, false
+		}
+		id = *t
+	case string:
+		id, err = uuid.Parse(t)
+	case []byte:
+		if len(t) == 16 {
+			id, err = uuid.FromBytes(t)
+		} else {
+			id, err = uuid.Parse(string(t))
+		}
+	default:
+		return uuid.Nil, false
+	}
+	if err != nil || id == uuid.Nil {
+		return uuid.Nil, false
+	}
+	return id, true
+}

--- a/backend/internal/infrastructure/repository/gorm_activation_backfill_test.go
+++ b/backend/internal/infrastructure/repository/gorm_activation_backfill_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// Minimal tables reconciled against the models, for the reason
+// internal/testsupport/sqliteschema documents: Risk, Asset, Mitigation and
+// ComplianceFramework carry Postgres-only DDL (gen_random_uuid() defaults, jsonb
+// and text[] columns) that GORM cannot emit for sqlite, so AutoMigrate on them
+// fails outright here. ActivationEvent was written to avoid exactly that and
+// migrates directly.
+func setupBackfillRepo(t *testing.T) (*GormActivationRepository, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&domain.ActivationEvent{}))
+
+	for _, ddl := range []string{
+		`CREATE TABLE risks (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE compliance_frameworks (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE assets (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE mitigations (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE reports (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE organization_members (id TEXT PRIMARY KEY)`,
+		// domain.Risk has an AfterSave hook that appends here; carry the table
+		// so seeding exercises the same write path production does.
+		`CREATE TABLE risk_histories (id TEXT PRIMARY KEY)`,
+	} {
+		require.NoError(t, db.Exec(ddl).Error)
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"risks", &domain.Risk{}},
+		{"compliance_frameworks", &domain.ComplianceFramework{}},
+		{"assets", &domain.Asset{}},
+		{"mitigations", &domain.Mitigation{}},
+		{"reports", &domain.Report{}},
+		{"organization_members", &domain.OrganizationMember{}},
+		{"risk_histories", &domain.RiskHistory{}},
+	} {
+		require.NoError(t, sqliteschema.Reconcile(db, m.table, m.model))
+	}
+	return NewGormActivationRepository(db), db
+}
+
+// seedConfiguredTenant gives a tenant one of every record the checklist derives
+// from — the "bank that signed up last quarter" of the issue.
+func seedConfiguredTenant(t *testing.T, db *gorm.DB, tenant uuid.UUID, base time.Time) {
+	t.Helper()
+
+	require.NoError(t, db.Create(&domain.Risk{
+		ID: uuid.New(), TenantID: tenant, OrganizationID: tenant,
+		Name: "Ransomware", Title: "Ransomware",
+		CreatedAt: base.Add(1 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&domain.ComplianceFramework{
+		ID: uuid.New(), TenantID: tenant, Name: "ISO 27001",
+		CreatedAt: base.Add(2 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&domain.Asset{
+		ID: uuid.New(), TenantID: tenant, OrganizationID: tenant, Name: "core-banking",
+		CreatedAt: base.Add(3 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&domain.Mitigation{
+		ID: uuid.New(), TenantID: tenant, RiskID: uuid.New(), Title: "Offline backups",
+		CreatedAt: base.Add(4 * time.Hour),
+	}).Error)
+	require.NoError(t, db.Create(&domain.Report{
+		ID: uuid.New(), TenantID: tenant, Title: "Q2 board report",
+		RunState:  domain.ReportRunSucceeded,
+		CreatedAt: base.Add(5 * time.Hour),
+	}).Error)
+
+	// Two members: the founder, then the teammate they invited. Only the second
+	// proves "invited a teammate".
+	require.NoError(t, db.Create(&domain.OrganizationMember{
+		ID: uuid.New(), OrganizationID: tenant, UserID: uuid.New(),
+		Role: domain.RoleAdmin, CreatedAt: base,
+	}).Error)
+	require.NoError(t, db.Create(&domain.OrganizationMember{
+		ID: uuid.New(), OrganizationID: tenant, UserID: uuid.New(),
+		Role: domain.RoleUser, CreatedAt: base.Add(6 * time.Hour),
+	}).Error)
+}
+
+// Criterion 1: a tenant configured before activation existed sees the truth on
+// first render — six steps complete, each dated from its own record, not from
+// the boot that noticed them.
+func TestBackfillDerived_ConfiguredTenantSeesCompletedSteps(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	tenant := uuid.New()
+	base := time.Date(2026, 3, 2, 8, 0, 0, 0, time.UTC)
+	seedConfiguredTenant(t, db, tenant, base)
+
+	require.NoError(t, repo.BackfillDerivedEvents(context.Background()))
+
+	got, err := repo.FirstOccurrences(context.Background(), tenant)
+	require.NoError(t, err)
+
+	for key, want := range map[domain.ActivationEventKey]time.Time{
+		domain.ActivationRiskCreated:       base.Add(1 * time.Hour),
+		domain.ActivationFrameworkImported: base.Add(2 * time.Hour),
+		domain.ActivationAssetConnected:    base.Add(3 * time.Hour),
+		domain.ActivationMitigationCreated: base.Add(4 * time.Hour),
+		domain.ActivationReportGenerated:   base.Add(5 * time.Hour),
+		domain.ActivationMemberInvited:     base.Add(6 * time.Hour),
+	} {
+		at, ok := got[key]
+		require.Truef(t, ok, "step %s must be seeded for a tenant that holds the record", key)
+		assert.WithinDurationf(t, want, at, time.Second,
+			"%s must be dated from the underlying record, not from the backfill run", key)
+	}
+
+	// profile is not derivable from any stored record and must stay untouched.
+	_, hasProfile := got[domain.ActivationProfileCompleted]
+	assert.False(t, hasProfile, "profile has no proving record and must not be invented")
+}
+
+// Criterion 2: reboots must not duplicate rows, and must not move a date.
+func TestBackfillDerived_IsIdempotentAcrossReboots(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	tenant := uuid.New()
+	base := time.Date(2026, 3, 2, 8, 0, 0, 0, time.UTC)
+	seedConfiguredTenant(t, db, tenant, base)
+	ctx := context.Background()
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+	first, err := repo.FirstOccurrences(ctx, tenant)
+	require.NoError(t, err)
+
+	var afterFirst int64
+	require.NoError(t, db.Model(&domain.ActivationEvent{}).Count(&afterFirst).Error)
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+
+	var afterThird int64
+	require.NoError(t, db.Model(&domain.ActivationEvent{}).Count(&afterThird).Error)
+	assert.Equal(t, afterFirst, afterThird, "re-running the backfill must not append rows")
+
+	second, err := repo.FirstOccurrences(ctx, tenant)
+	require.NoError(t, err)
+	require.Len(t, second, len(first))
+	for key, at := range first {
+		assert.WithinDuration(t, at, second[key], time.Second, "completed_at moved for %s", key)
+	}
+}
+
+// Criterion 2, second half: a step already ticked by live use keeps ITS date.
+// The backfill must never overwrite a real event with a derived one.
+func TestBackfillDerived_DoesNotDisturbLiveEvents(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	tenant := uuid.New()
+	base := time.Date(2026, 3, 2, 8, 0, 0, 0, time.UTC)
+	seedConfiguredTenant(t, db, tenant, base)
+	ctx := context.Background()
+
+	// The tenant created a risk live, AFTER the record the backfill would find.
+	live := base.Add(48 * time.Hour)
+	recordActivation(t, repo, tenant, domain.ActivationRiskCreated, live)
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+
+	var riskEvents int64
+	require.NoError(t, db.Model(&domain.ActivationEvent{}).
+		Where("tenant_id = ? AND event_key = ?", tenant, string(domain.ActivationRiskCreated)).
+		Count(&riskEvents).Error)
+	assert.EqualValues(t, 1, riskEvents, "a tenant with a live event must not gain a derived duplicate")
+
+	got, err := repo.FirstOccurrences(ctx, tenant)
+	require.NoError(t, err)
+	assert.WithinDuration(t, live, got[domain.ActivationRiskCreated], time.Second)
+}
+
+// Criterion 3: no record, no tick. This is the property that keeps the panel
+// worth reading — a step is complete only when something real backs it.
+func TestBackfillDerived_NeverMarksAStepWithoutEvidence(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	tenant := uuid.New()
+	ctx := context.Background()
+
+	// An asset and nothing else. A lone founding member, no invitee. A report
+	// that failed. A soft-deleted risk.
+	base := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&domain.Asset{
+		ID: uuid.New(), TenantID: tenant, OrganizationID: tenant, Name: "vpn",
+		CreatedAt: base,
+	}).Error)
+	require.NoError(t, db.Create(&domain.OrganizationMember{
+		ID: uuid.New(), OrganizationID: tenant, UserID: uuid.New(),
+		Role: domain.RoleAdmin, CreatedAt: base,
+	}).Error)
+	require.NoError(t, db.Create(&domain.Report{
+		ID: uuid.New(), TenantID: tenant, Title: "never finished",
+		RunState: domain.ReportRunFailed, CreatedAt: base,
+	}).Error)
+	deleted := &domain.Risk{
+		ID: uuid.New(), TenantID: tenant, OrganizationID: tenant,
+		Name: "gone", Title: "gone", CreatedAt: base,
+	}
+	require.NoError(t, db.Create(deleted).Error)
+	require.NoError(t, db.Delete(deleted).Error)
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+
+	got, err := repo.FirstOccurrences(ctx, tenant)
+	require.NoError(t, err)
+
+	assert.Contains(t, got, domain.ActivationAssetConnected, "the asset is real and must tick")
+	for _, absent := range []domain.ActivationEventKey{
+		domain.ActivationRiskCreated,       // only a soft-deleted risk
+		domain.ActivationFrameworkImported, // nothing at all
+		domain.ActivationMitigationCreated, // nothing at all
+		domain.ActivationReportGenerated,   // the run failed
+		domain.ActivationMemberInvited,     // the founder is not an invitee
+	} {
+		assert.NotContainsf(t, got, absent, "%s has no proving record and must stay incomplete", absent)
+	}
+}
+
+// Criterion 4 — RULE #2. The backfill reads every tenant's tables at once, which
+// is exactly the shape that leaks. Tenant B's records must never tick tenant A.
+func TestBackfillDerived_TenantIsolation(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	quiet, busy := uuid.New(), uuid.New()
+	base := time.Date(2026, 5, 5, 7, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+
+	// `busy` has everything. `quiet` has one asset and nothing else.
+	seedConfiguredTenant(t, db, busy, base)
+	require.NoError(t, db.Create(&domain.Asset{
+		ID: uuid.New(), TenantID: quiet, OrganizationID: quiet, Name: "laptop",
+		CreatedAt: base.Add(9 * time.Hour),
+	}).Error)
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+
+	quietState, err := repo.FirstOccurrences(ctx, quiet)
+	require.NoError(t, err)
+	require.Len(t, quietState, 1, "the quiet tenant holds one record and must get exactly one step")
+	assert.Contains(t, quietState, domain.ActivationAssetConnected)
+	assert.WithinDuration(t, base.Add(9*time.Hour), quietState[domain.ActivationAssetConnected], time.Second)
+
+	// And no event row on the quiet tenant may carry a busy tenant's date.
+	var rows []domain.ActivationEvent
+	require.NoError(t, db.Where("tenant_id = ?", quiet).Find(&rows).Error)
+	require.Len(t, rows, 1)
+	assert.Equal(t, quiet, rows[0].TenantID)
+
+	busyState, err := repo.FirstOccurrences(ctx, busy)
+	require.NoError(t, err)
+	assert.Len(t, busyState, 6, "the busy tenant keeps its own six steps")
+}
+
+// A tenant that never existed has no state — and asking for one must not return
+// somebody else's. The read path's fail-closed behaviour, pinned here because
+// the backfill is what puts rows in the table for it to leak.
+func TestBackfillDerived_UnknownTenantHasNoState(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	base := time.Date(2026, 5, 5, 7, 0, 0, 0, time.UTC)
+	seedConfiguredTenant(t, db, uuid.New(), base)
+	ctx := context.Background()
+
+	require.NoError(t, repo.BackfillDerivedEvents(ctx))
+
+	got, err := repo.FirstOccurrences(ctx, uuid.New())
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	nilTenant, err := repo.FirstOccurrences(ctx, uuid.Nil)
+	require.NoError(t, err)
+	assert.Empty(t, nilTenant, "no tenant context must mean no state, never everyone's state")
+}
+
+// An empty install must be a no-op rather than an error at boot.
+func TestBackfillDerived_EmptyDatabaseIsANoOp(t *testing.T) {
+	repo, db := setupBackfillRepo(t)
+	require.NoError(t, repo.BackfillDerivedEvents(context.Background()))
+
+	var count int64
+	require.NoError(t, db.Model(&domain.ActivationEvent{}).Count(&count).Error)
+	assert.EqualValues(t, 0, count)
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,79 +5,51 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-### D-007 — #411 criterion 14: the eight registers are not one pattern eight times
-**Context** — Criterion 14 requires all eight registers to open the universal
-drawer on row activation, and the issue's PO note is explicit that the milestone
-is cut by dropping a whole issue, "never by shipping four registers of eight",
-because inconsistent navigation is itself a defect. Surveying the eight on
-2026-08-28 shows the criterion's premise — "one pattern applied eight times, one
-commit each" — does not hold. The universal drawer offers four sections
-(summary, relations, timeline, audit). Several registers currently open
-something substantially richer, so wiring their rows to it **removes
-capability**:
-
-| Register | Current drawer | Swapping it costs |
-|---|---|---|
-| Risks | `RiskDrawer`, 9 tabs: details, lifecycle, score, smart, financial, miti, timeline, cti, ai — plus edit, export, create-mitigation | Financial quantification, SmartScore, CTI and AI tabs disappear from the product's most important screen |
-| Evidence | `EvidenceDrawer`, 232 lines, **mutates** — approve/reject review, update validity | It is an editor. The issue's own rule retains editors (`MitigationDetailDrawer`, `ScanConfigDrawer`), and this one was mis-filed as a detail view |
-| Infrastructure | `ScanConfigDrawer`, a scanner-config editor keyed by PROVIDER | The rows are scanner providers, not assets. Criterion 14 maps this register to `asset`; the mapping does not hold |
-| Incidents | `IncidentDrawer`, 250 lines with actions | Needs a per-action check, not yet done |
-| Compliance | `ControlDrawer`, 220 lines, 2 tabs (details/evidence) | Closest to like-for-like; the evidence tab maps onto relations |
-| Vulnerabilities | `VulnDrawer`, inside the page | Needs a check |
-| Assets / Inventory | `AssetHistoryDrawer`, 94 lines, no tabs, no mutations, opened from a "history" row action | **Nothing** — rows do not currently open a detail view at all, so the universal drawer is pure gain here |
-
-So the eight are roughly: two clean wins, three needing a per-feature check, and
-two that are clear regressions as specified.
-**Options** — **A** wire only the registers where nothing is lost (assets,
-inventory, and whichever of the middle three survive a check), retain the rest
-with a stated reason under criterion 16, and accept mixed navigation · **B**
-give the universal drawer an action that opens the rich view ("Open full risk
-view"), so every row opens the drawer and depth stays one click away — uniform
-navigation, no capability lost, but a design change beyond #411 · **C** keep
-#411 to the two clean registers and move the rich ones to their own issue, where
-each rich drawer's tabs are migrated into the universal drawer's sections
-properly · **D** execute criterion 14 literally and accept the regressions.
-**Recommendation** — **B**, and if it will not fit the milestone, **C**. D ships
-a visible capability loss on the risk register. A is the thing the issue's own
-PO note forbids, and it forbids it for a good reason.
-**Cost of delay** — #411 cannot finish. Criterion 14 is its largest remaining
-chunk and blocks the #200 umbrella DoD. Criteria 15 and 17 are done and shipped
-regardless.
-**Reversible?** — Yes, but B and C both cost more the later they start, because
-every register wired the wrong way is rework.
-**Status** — OPEN
-
-### D-008 — One Time to First Value number: 8 minutes · 2026-08-31
-**Recommendation (po)** — Commit publicly to **8 minutes** from signup to the
-Aha moment, and stop using 5 and 12 as if they meant the same thing.
-**Context** — The tree currently promises three numbers.
-`tests/e2e/activation.spec.ts:6-7,27,279` asserts under 8 min and
-`docs/JOURNAL.md` states 8 min. `ROADMAP.md:139` and the original #234 text say
-5 min. `deployment/monitoring/alerts.yml:195` warns at P50 > 12 min.
-`docs/MARKETING_CLAIM_MATRIX.md` has no onboarding row at all, so none of them
-is backed by anything. #234 is a `launch-gate`.
-**Rationale** — 8 min is the only number an automated test actually asserts, so
-it is the only one we can defend under RULE #12. Five minutes through a
-five-step wizard plus a first risk plus a framework import is not provable
-today. The 12-minute figure is an operational alert threshold with deliberate
-headroom for a warning to be actionable; it is not a promise and must be
-documented as not being one.
-**Cost of delay** — Marketing can publish "5 minutes" while the test asserts 8
-and the alert fires at 12. That is the exact failure mode the claim matrix
-exists to prevent, on a launch-gate claim.
-**Proceeding on** — 8 minutes, written into #234 criterion 5 so the work is not
-blocked. An override to 5 changes one number in that criterion and nothing else
-about the work.
-**Owner call needed on** — whether the public promise is 5 or 8.
-**Reversible?** — Yes. It is one constant in
-`tests/e2e/activation.spec.ts`, one row in `docs/MARKETING_CLAIM_MATRIX.md` and
-one line in the alert description; changing it later costs minutes, but every
-week it sits open is a week marketing could publish the wrong number.
-**Status** — OPEN
+_Nothing open. Last cleared 2026-08-31._
 
 ## Resolved
 
 <!-- Append: date · decision · rationale · issues unblocked -->
+
+### D-008 — One Time to First Value number: 8 minutes · 2026-08-31
+**Decided** — Option A. The committed public promise is **8 minutes** from
+signup to the Aha moment.
+**Rationale (owner)** — Matches the recommendation. Eight is the only number an
+automated test asserts, so it is the only one defensible under RULE #12. Five
+minutes through a five-step wizard, a framework import and a first risk is not
+provable today; publishing it would be the exact failure the claim matrix exists
+to prevent, on a launch-gate claim.
+**Consequence** — `AHA_BUDGET_MS` in `tests/e2e/activation.spec.ts` stays at
+8 minutes and its assertion is the proof. `docs/MARKETING_CLAIM_MATRIX.md` C-002
+carries the promise and names the test; the same file states explicitly that the
+12-minute `SlowTimeToAha` threshold in `deployment/monitoring/alerts.yml` is an
+operational warning with deliberate headroom and **not** the promise.
+`ROADMAP.md` 17.6 no longer says 5. Changing the number later means changing all
+three in one commit.
+**Unblocked** — #234 needed no label change: it was never blocked on this, and
+shipped on 8 in PR #437. The decision confirms what is already in review.
+
+### D-007 — #411 criterion 14: universal drawer keeps an "Open full view" action · 2026-08-31
+**Decided** — Option B. Every register row opens the universal drawer, and the
+drawer carries a prominent action that opens the rich view where one exists.
+**Rationale (owner)** — Matches the recommendation. Navigation becomes uniform
+without deleting capability: the 9-tab risk surface (details · lifecycle · score
+· smart · financial · miti · ai · timeline · cti, inline in
+`features/risks/RiskRegisterPage.tsx`), the Evidence approve/reject editor and
+the Infrastructure scanner-config editor all stay reachable, one click deeper.
+Option D was rejected because it ships a visible capability regression on the
+product's most important screen; option A because the issue's own PO note
+forbids mixed navigation, and forbids it for a good reason.
+**Consequence** — The universal drawer gains an "open full view" affordance, a
+design change beyond #411 as originally written: `art-director` and
+`ux-designer` should confirm the pattern and its copy before it is built. The
+per-register mapping in criterion 14 still needs the per-feature check for
+Incidents, Compliance and Vulnerabilities; Assets and Inventory remain pure gain.
+**Unblocked** — nothing yet, and this needs saying: **#411 is already CLOSED**
+(a merged PR closed it while criterion 14 was unfinished) and still carries a
+stale `status:in-progress`. Option B therefore has no home. It needs either a
+reopen of #411 or a new issue carrying criterion 14 plus this decision; see the
+comment posted on #411.
 
 ### D-001 — Brand: OpenRisk everywhere · 2026-08-28
 **Decided** — Option A. OpenRisk is both the company and the product name.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -132,3 +132,26 @@ it is reviewed as a pricing change, with the stale
 `internal/application/entitlements/service_test.go` updated as part of THAT work.
 **Unblocked** — `feat/w1-02-universal-entity-drawer` stops carrying a red test
 unrelated to its own scope.
+
+### D-007 — One Time to First Value number: 8 minutes · 2026-08-31
+**Recommendation (po)** — Commit publicly to **8 minutes** from signup to the
+Aha moment, and stop using 5 and 12 as if they meant the same thing.
+**Context** — The tree currently promises three numbers.
+`tests/e2e/activation.spec.ts:6-7,27,279` asserts under 8 min and
+`docs/JOURNAL.md` states 8 min. `ROADMAP.md:139` and the original #234 text say
+5 min. `deployment/monitoring/alerts.yml:195` warns at P50 > 12 min.
+`docs/MARKETING_CLAIM_MATRIX.md` has no onboarding row at all, so none of them
+is backed by anything. #234 is a `launch-gate`.
+**Rationale** — 8 min is the only number an automated test actually asserts, so
+it is the only one we can defend under RULE #12. Five minutes through a
+five-step wizard plus a first risk plus a framework import is not provable
+today. The 12-minute figure is an operational alert threshold with deliberate
+headroom for a warning to be actionable; it is not a promise and must be
+documented as not being one.
+**Cost of delay** — Marketing can publish "5 minutes" while the test asserts 8
+and the alert fires at 12. That is the exact failure mode the claim matrix
+exists to prevent, on a launch-gate claim.
+**Proceeding on** — 8 minutes, written into #234 criterion 5 so the work is not
+blocked. An override to 5 changes one number in that criterion and nothing else
+about the work.
+**Owner call needed on** — whether the public promise is 5 or 8.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -133,7 +133,7 @@ it is reviewed as a pricing change, with the stale
 **Unblocked** — `feat/w1-02-universal-entity-drawer` stops carrying a red test
 unrelated to its own scope.
 
-### D-007 — One Time to First Value number: 8 minutes · 2026-08-31
+### D-008 — One Time to First Value number: 8 minutes · 2026-08-31
 **Recommendation (po)** — Commit publicly to **8 minutes** from signup to the
 Aha moment, and stop using 5 and 12 as if they meant the same thing.
 **Context** — The tree currently promises three numbers.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -47,6 +47,34 @@ regardless.
 every register wired the wrong way is rework.
 **Status** — OPEN
 
+### D-008 — One Time to First Value number: 8 minutes · 2026-08-31
+**Recommendation (po)** — Commit publicly to **8 minutes** from signup to the
+Aha moment, and stop using 5 and 12 as if they meant the same thing.
+**Context** — The tree currently promises three numbers.
+`tests/e2e/activation.spec.ts:6-7,27,279` asserts under 8 min and
+`docs/JOURNAL.md` states 8 min. `ROADMAP.md:139` and the original #234 text say
+5 min. `deployment/monitoring/alerts.yml:195` warns at P50 > 12 min.
+`docs/MARKETING_CLAIM_MATRIX.md` has no onboarding row at all, so none of them
+is backed by anything. #234 is a `launch-gate`.
+**Rationale** — 8 min is the only number an automated test actually asserts, so
+it is the only one we can defend under RULE #12. Five minutes through a
+five-step wizard plus a first risk plus a framework import is not provable
+today. The 12-minute figure is an operational alert threshold with deliberate
+headroom for a warning to be actionable; it is not a promise and must be
+documented as not being one.
+**Cost of delay** — Marketing can publish "5 minutes" while the test asserts 8
+and the alert fires at 12. That is the exact failure mode the claim matrix
+exists to prevent, on a launch-gate claim.
+**Proceeding on** — 8 minutes, written into #234 criterion 5 so the work is not
+blocked. An override to 5 changes one number in that criterion and nothing else
+about the work.
+**Owner call needed on** — whether the public promise is 5 or 8.
+**Reversible?** — Yes. It is one constant in
+`tests/e2e/activation.spec.ts`, one row in `docs/MARKETING_CLAIM_MATRIX.md` and
+one line in the alert description; changing it later costs minutes, but every
+week it sits open is a week marketing could publish the wrong number.
+**Status** — OPEN
+
 ## Resolved
 
 <!-- Append: date · decision · rationale · issues unblocked -->
@@ -132,26 +160,3 @@ it is reviewed as a pricing change, with the stale
 `internal/application/entitlements/service_test.go` updated as part of THAT work.
 **Unblocked** — `feat/w1-02-universal-entity-drawer` stops carrying a red test
 unrelated to its own scope.
-
-### D-008 — One Time to First Value number: 8 minutes · 2026-08-31
-**Recommendation (po)** — Commit publicly to **8 minutes** from signup to the
-Aha moment, and stop using 5 and 12 as if they meant the same thing.
-**Context** — The tree currently promises three numbers.
-`tests/e2e/activation.spec.ts:6-7,27,279` asserts under 8 min and
-`docs/JOURNAL.md` states 8 min. `ROADMAP.md:139` and the original #234 text say
-5 min. `deployment/monitoring/alerts.yml:195` warns at P50 > 12 min.
-`docs/MARKETING_CLAIM_MATRIX.md` has no onboarding row at all, so none of them
-is backed by anything. #234 is a `launch-gate`.
-**Rationale** — 8 min is the only number an automated test actually asserts, so
-it is the only one we can defend under RULE #12. Five minutes through a
-five-step wizard plus a first risk plus a framework import is not provable
-today. The 12-minute figure is an operational alert threshold with deliberate
-headroom for a warning to be actionable; it is not a promise and must be
-documented as not being one.
-**Cost of delay** — Marketing can publish "5 minutes" while the test asserts 8
-and the alert fires at 12. That is the exact failure mode the claim matrix
-exists to prevent, on a launch-gate claim.
-**Proceeding on** — 8 minutes, written into #234 criterion 5 so the work is not
-blocked. An override to 5 changes one number in that criterion and nothing else
-about the work.
-**Owner call needed on** — whether the public promise is 5 or 8.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -176,7 +176,7 @@ score utilisant le vert de **remplissage** de la bande basse comme texte 12px
 **Time to First Value — un seul chiffre : 8 minutes.** L'arbre en promettait trois
 (E2E 8 min · alerte `SlowTimeToAha` P50 > 12 min · `ROADMAP.md` 17.6 « < 5 min »).
 8 est le seul qu'un test assert, donc le seul défendable sous la RÈGLE #12
-(`docs/DECISIONS.md` D-007, arbitrage propriétaire encore ouvert entre 5 et 8).
+(`docs/DECISIONS.md` D-008, arbitrage propriétaire encore ouvert entre 5 et 8).
 `docs/MARKETING_CLAIM_MATRIX.md` gagne les lignes C-002/C-003 et une section
 expliquant que **12 minutes est un seuil d'exploitation, pas la promesse**.
 `ROADMAP.md` 17.6 ne prétend plus « Aucun package onboarding » ; 17.5 reflète le

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -128,6 +128,70 @@ Système de **rôles métiers** par-dessus le RBAC runtime existant. **Additionn
 - **Audit des boutons morts** : `docs/ui/dead-controls.md` recense **13 contrôles morts en production** (traités) + 4 dans du code inatteignable (fichiers supprimés) + 5 laissés avec leur raison. Notamment : point vert « Realtime » → **vrai indicateur de connexion** (`lib/connection.ts`, alimenté par les événements online/offline **et** l'issue de chaque appel axios ; un 4xx n'est pas une panne) · **micro supprimé** · « Voir toutes les notifications » **supprimé** (il ne faisait que fermer le panneau) · **« Supprimer l'organisation » implémenté** (c'était un `<button>` sans `onClick` — `DELETE /rbac/tenants/:id` + radiographie d'impact + logout) · Actualiser / Synchroniser / Matcher → états en vol visibles · funnel de l'Asset Universe → **vrai filtre par criticité** (masque aussi les arêtes pendantes).
 - **Tests** : `frontend/src/shared/datatable/__tests__/DataTable.test.tsx` (**25 tests, verts**) pour toute la logique pure ; `tests/e2e/datatable.spec.ts` + `tests/e2e/dead-controls.spec.ts` (**68 cas** listés par Playwright) pour les effets observables, dont l'obligatoire *« menu de la dernière ligne d'une table de 200 items entièrement visible »*. **Restes honnêtes** : les E2E n'ont pas été **exécutés** dans cette session (ils exigent backend + frontend démarrés) et **la chaîne Go n'est pas installée sur cette machine** → les 4 fichiers backend touchés sont relus mais **non compilés** ; `go build ./... && go vet ./...` reste à passer avant merge.
 
+## Onboarding W1-04 (#234) — la checklist dit enfin la vérité aux tenants déjà configurés
+
+**Problème** — le journal d'événements d'activation est **en avant seulement** : une
+banque inscrite au trimestre précédent, avec 200 risques, un référentiel ISO 27001
+importé et un parc d'actifs cartographié, n'a **aucun** événement et se voit
+demander « créez votre premier risque ». Le seul panneau dont le métier est de dire
+où l'on en est disait quelque chose de visiblement faux, et **aucune action
+utilisateur ne pouvait le corriger** (aucun endpoint ne permet au client de cocher
+une étape). `BackfillExistingMembers` n'amorçait que l'ancre `signup`.
+
+- **Amorçage dérivé** (`internal/infrastructure/repository/gorm_activation_backfill.go`,
+  appelé au boot dans `cmd/server/main.go`) : pour chacune des 6 étapes dérivables,
+  si le tenant **détient** l'enregistrement qui la prouve, on ancre un événement
+  **daté de cet enregistrement** (jamais `now()` — dater du déploiement empoisonnerait
+  `openrisk_time_to_aha_seconds` pour tout l'historique). Sources : `risks`,
+  `compliance_frameworks`, `assets`, `mitigations`, `reports` (**`run_state =
+  'succeeded'` uniquement**), `organization_members` (sous-requête corrélée excluant
+  le membre fondateur : « inviter un coéquipier » = un second membre). Le `Model()`
+  GORM applique le **soft-delete** — un risque supprimé ne prouve rien.
+  **`profile` reste non dérivable** : aucun enregistrement ne la prouve, et cocher
+  une étape que personne n'a faite est exactement le défaut qu'on corrige.
+- **Tenancy (RÈGLE #2)** — chaque dérivation groupe sur la colonne tenant de la table
+  source et **réécrit cette même valeur** ; il n'existe aucune jointure entre une
+  ligne source et un tenant qui ne lui appartient pas, donc aucune disposition des
+  données ne peut faire cocher la checklist de A par les enregistrements de B.
+- **Idempotence** — un tenant qui possède déjà un événement pour une clé est ignoré :
+  les redémarrages ne dupliquent pas de lignes et ne déplacent pas de `completed_at`.
+- **Preuves** — 7 tests sqlite verts (`-run BackfillDerived`) **et vérification sur
+  PostgreSQL réel** : deux tenants amorcés, le « busy » obtient ses 6 étapes datées
+  de ses propres enregistrements, le « quiet » **uniquement** `asset.connected` (son
+  rapport en échec et son fondateur solitaire correctement ignorés) ; après un second
+  boot, 8 événements pour 8 paires (tenant, clé) distinctes.
+
+**Accessibilité** — les 5 routes du wizard et la checklist étaient **absentes** de
+`tests/e2e/a11y.spec.ts` : les premiers écrans qu'un nouveau client voit étaient les
+seuls jamais vérifiés. Elles ne pouvaient pas rejoindre `SCREENS` (ce bloc tourne en
+admin déjà onboardé, et `OnboardingCompletedRedirect` aurait renvoyé chaque
+navigation vers le dashboard — balayage vert sur le mauvais écran). Le nouveau bloc
+**crée son propre tenant** et **assert qu'il est bien sur l'étape demandée** avant de
+scanner. Trois violations réelles trouvées et corrigées : barre de progression sans
+nom accessible ; badges org/compte de la sidebar (`--accent-500` sur le tint
+`--accent-soft` de la variante azure, 4,42:1 → assombri de 2 %, 4,56:1) ; nombre du
+score utilisant le vert de **remplissage** de la bande basse comme texte 12px
+(4,29:1 → `bandTextColor` renvoie `--success-text`, 5,83:1). **6/6 verts.**
+
+**Time to First Value — un seul chiffre : 8 minutes.** L'arbre en promettait trois
+(E2E 8 min · alerte `SlowTimeToAha` P50 > 12 min · `ROADMAP.md` 17.6 « < 5 min »).
+8 est le seul qu'un test assert, donc le seul défendable sous la RÈGLE #12
+(`docs/DECISIONS.md` D-007, arbitrage propriétaire encore ouvert entre 5 et 8).
+`docs/MARKETING_CLAIM_MATRIX.md` gagne les lignes C-002/C-003 et une section
+expliquant que **12 minutes est un seuil d'exploitation, pas la promesse**.
+`ROADMAP.md` 17.6 ne prétend plus « Aucun package onboarding » ; 17.5 reflète le
+balayage réel.
+
+**Restes honnêtes** — pas de revue `devsecops` sur le chemin d'amorçage (recommandée
+avant merge : il écrit dans un journal append-only que tous les tenants lisent) ·
+4 écrans **préexistants** échouent au balayage a11y sur `master` (`/risks`,
+`/vulnerabilities`, `/assets`, `/incidents` — contrastes `--risk-low`/`--risk-high`
+sur chips teintés + un `select` sans nom), **prouvé indépendant de ce travail** en
+rejouant les 4 avec les modifications frontend remisées · `TestBusinessRoles
+ReferenceOnlyCatalogPermissions` échoue sur `master` (`events:read` hors catalogue),
+sans rapport · étapes « intégrations », « première évaluation » et « guidage selon le
+rôle » explicitement hors périmètre (#234 commentaire de découpage).
+
 ## Activation & Onboarding — le parcours « inconnu → Aha en < 8 min »
 **Cause racine corrigée** : l'état d'activation vivait **côté client** (localStorage + comptes dérivés dans le composant checklist). D'où toute la famille de bugs : checklist qui ne se coche pas (drapeau écrit sur un appareil, lu sur un autre), confettis aléatoires (l'heuristique « c'est fait ? » rejouée à chaque render), **deux items barrés après un seul import** (deux étapes client dérivées du même compteur). L'état est désormais **dérivé d'événements serveur**. Branche `feature/activation-onboarding-aha`.
 - **Modèle** (`internal/domain/activation.go`, migration `0043` + AutoMigrate) : `ActivationEvent` (journal **append-only** : tenant, user, `event_key`, `occurred_at`, `payload` jsonb — la lecture ne prend QUE la **première occurrence par clé**, donc une étape terminée ne se dé-coche jamais et son `completed_at` ne bouge plus) ; `ActivationCelebration` (registre par utilisateur, unique `(user_id, step_key)` — c'est *ça* qui rend la célébration idempotente entre reloads et appareils) ; `OnboardingProgress` (état du wizard, **par utilisateur**, reprenable). **Catalogue d'étapes en code** (`activationSteps`) avec l'invariant clé : **1 étape ↔ 1 `event_key`**, imposé par `ValidateActivationSteps()` + test — un import ne peut donc plus cocher deux lignes.

--- a/docs/MARKETING_CLAIM_MATRIX.md
+++ b/docs/MARKETING_CLAIM_MATRIX.md
@@ -8,8 +8,27 @@ Status: `VERIFIED` · `PARTIAL` · `MOCKED` · `ABSENT` · `PLANNED`
 | ID | Claim (EN) | Claim (FR) | Status | Evidence (file:line + test) | Surface | Verified on |
 |----|-----------|-----------|--------|------------------------------|---------|-------------|
 | C-001 | _seed row — run /verify-claims to populate_ | — | ABSENT | — | — | — |
+| C-002 | A new organization reaches its first real risk insight — a cyber score on its own data with at least one compliance gap identified — in under 8 minutes. | Une nouvelle organisation atteint sa première information de risque réelle — un score cyber sur ses propres données avec au moins un écart de conformité identifié — en moins de 8 minutes. | PARTIAL | `tests/e2e/activation.spec.ts` (`AHA_BUDGET_MS = 8 * 60 * 1000`, assertion sur la durée totale signup → Aha) ; définition de l'Aha : `backend/internal/domain/activation.go` (`AhaSignal.IsAha()`) ; mesure : `openrisk_time_to_aha_seconds` (`backend/pkg/monitoring/activation.go`) | Site, docs produit | 2026-08-31 — non promu : la suite E2E n'a pas été exécutée dans cet environnement (pas de backend ni de frontend démarrés). `product-verifier` doit la lancer avant tout passage à `VERIFIED`. |
+| C-003 | The onboarding checklist reflects what the organization has actually done — including work completed before the checklist existed. | La checklist d'onboarding reflète ce que l'organisation a réellement fait — y compris le travail accompli avant l'existence de la checklist. | PARTIAL | `backend/internal/infrastructure/repository/gorm_activation_backfill.go` + `gorm_activation_backfill_test.go` (7 tests : amorçage, idempotence sur redémarrage, absence de preuve = absence de coche, isolation multi-tenant) ; `go test ./internal/infrastructure/repository/ -run BackfillDerived` | Docs produit | 2026-08-31 — tests unitaires verts ; l'étape `profile` reste non dérivable (aucun enregistrement ne la prouve). |
 
 ## Blocking rule
 
 `MOCKED` and `ABSENT` claims must not appear on any public surface.
 `PLANNED` claims must be future tense and visually marked.
+
+## Time to first value — one number
+
+The committed promise is **8 minutes**, and it is the only number that may
+appear on a public surface. Two other numbers exist in the tree and are NOT the
+promise:
+
+- **12 minutes** — `SlowTimeToAha` in `deployment/monitoring/alerts.yml`. An
+  operational warning threshold, deliberately set above the promise so the page
+  has headroom and does not fire on every ordinary bad day. It is not a target
+  and must never be quoted as one.
+- **5 minutes** — appeared in an old `ROADMAP.md` row (17.6) and in the wording
+  of issue #234. Corrected: no test, metric or alert has ever asserted it.
+
+Changing the promise means changing `AHA_BUDGET_MS` in
+`tests/e2e/activation.spec.ts`, this row, and the alert's `description` in the
+same commit. See `docs/DECISIONS.md` D-007.

--- a/docs/MARKETING_CLAIM_MATRIX.md
+++ b/docs/MARKETING_CLAIM_MATRIX.md
@@ -31,4 +31,4 @@ promise:
 
 Changing the promise means changing `AHA_BUDGET_MS` in
 `tests/e2e/activation.spec.ts`, this row, and the alert's `description` in the
-same commit. See `docs/DECISIONS.md` D-007.
+same commit. See `docs/DECISIONS.md` D-008.

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ import { OpenRiskLogo } from '../../shared/Logo';
 import { visibleNavGroups, pinnedItems, ALL_NAV_ITEMS, type NavItem, type NavCount } from '../../shared/navModel';
 import { useScore } from '../../hooks/useScore';
 import { useOrganizationCounts } from '../../features/organization/useOrganization';
-import { bandColor, bandLabel } from '../../services/scoreService';
+import { bandColor, bandLabel, bandTextColor } from '../../services/scoreService';
 
 interface SidebarProps {
   /** Off-canvas drawer open on mobile (< lg). Ignored on desktop, where the
@@ -114,6 +114,9 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
   // token — so this cannot disagree with the server about where a cut lies.
   const score = tenantScore ? Math.round(tenantScore.value) : undefined;
   const scoreColor = bandColor(tenantScore?.band);
+  // The bar uses the fill colour; the number is small text and needs the
+  // text-weight token (see bandTextColor).
+  const scoreTextColor = bandTextColor(tenantScore?.band);
 
   // Live, tenant-scoped counters for the nav badges. A failed or refused read
   // leaves every count at zero, which renders no badge at all — the honest
@@ -300,7 +303,7 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
                 <span className="text-[10.5px] text-ink-soft font-medium">
                   {L.globalScore} · {bandLabel(tenantScore?.band, lang)}
                 </span>
-                <span className="mono text-[12px] font-semibold" style={{ color: scoreColor }}>
+                <span className="mono text-[12px] font-semibold" style={{ color: scoreTextColor }}>
                   {score}/100
                 </span>
               </div>

--- a/frontend/src/features/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/features/onboarding/OnboardingChecklist.tsx
@@ -104,6 +104,10 @@ export function OnboardingChecklist() {
         className="h-1.5 rounded-full overflow-hidden mb-4"
         style={{ background: 'var(--bg-hover)' }}
         role="progressbar"
+        // A progressbar with no accessible name is announced as a bare
+        // percentage with nothing to say what it measures. Named, not
+        // aria-hidden: the number IS the useful part of this card.
+        aria-label={tr("Progression de la prise en main", 'Onboarding progress')}
         aria-valuenow={state.percent}
         aria-valuemin={0}
         aria-valuemax={100}

--- a/frontend/src/services/scoreService.ts
+++ b/frontend/src/services/scoreService.ts
@@ -125,6 +125,21 @@ export function bandColor(band: ScoreBand | undefined): string {
   }
 }
 
+/**
+ * The band token for SMALL TEXT, as opposed to a fill.
+ *
+ * The low band's green (--risk-low, #1a7f3c) is a fill colour: as 12px text on
+ * --surface-sunken it measures 4.29:1, just under AA. The design system already
+ * carries --success-text (#15682f, 5.83:1) for text-weight green, which is what
+ * this returns. The other three bands clear 4.5:1 on that surface unchanged, so
+ * they are passed through — the scale itself is not redefined here.
+ *
+ * Use bandColor for bars, chips and fills; use this for a number or a label.
+ */
+export function bandTextColor(band: ScoreBand | undefined): string {
+  return band === 'low' ? 'var(--success-text)' : bandColor(band);
+}
+
 /** FR/EN label for a band, keyed by the server's i18n key. */
 export function bandLabel(band: ScoreBand | undefined, lang: 'fr' | 'en'): string {
   const labels: Record<ScoreBand, { fr: string; en: string }> = {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -437,8 +437,14 @@
 }
 
 :root[data-theme='light'][data-variant='azure'] {
-  --accent: #0b62bd;
-  --accent-500: #0b62bd;
+  /* #0b62bd measured 4.42:1 as small bold text on this variant's own
+     --accent-soft tint (the sidebar's org and account badges) — caught by axe
+     on the live dashboard, not by the token check, which only compared the
+     accent against page backgrounds. Two percent darker clears 4.5:1 there
+     (4.56) and improves every other accent-on-light pairing. Same class of fix
+     as --risk-moderate above. */
+  --accent: #0b60b9;
+  --accent-500: #0b60b9;
   --accent-hover: #094e97;
   --accent-soft: rgba(11, 98, 189, 0.1);
   --accent-line: rgba(11, 98, 189, 0.3);

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -87,11 +87,19 @@ test.describe('a11y — onboarding', () => {
   // This block owns its identity; the shared admin storageState must not leak in.
   test.use({ storageState: { cookies: [], origins: [] } });
 
+  // ONE tenant for all five routes. The wizard guard only redirects a user who
+  // has COMPLETED it, so an unfinished account can open any step directly — and
+  // signing up five separate tenants in a row trips the registration rate limit.
+  let wizard: Awaited<ReturnType<typeof signUp>>;
+  test.beforeAll(async () => {
+    const api = await pwRequest.newContext();
+    wizard = await signUp(api, 'a11ywiz');
+    await api.dispose();
+  });
+
   for (const step of WIZARD_STEPS) {
     test(`a11y: onboarding wizard — ${step} (/onboarding/${step})`, async ({ browser }, info) => {
-      const api = await pwRequest.newContext();
-      const newcomer = await signUp(api, `a11y${step}`);
-      const ctx = await browser.newContext({ storageState: newcomer.storageState });
+      const ctx = await browser.newContext({ storageState: wizard.storageState });
       const page = await ctx.newPage();
 
       await page.goto(`/onboarding/${step}`, { waitUntil: 'domcontentloaded' });
@@ -107,7 +115,6 @@ test.describe('a11y — onboarding', () => {
       await expectNoBlockingViolations(page, info, `onboarding-${step}`, `/onboarding/${step}`);
 
       await ctx.close();
-      await api.dispose();
     });
   }
 

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -3,9 +3,10 @@
 // zero serious/critical; screens that violate today are quarantined in A11Y_KNOWN
 // (test.fixme with a bug id) so the gate stays green while violations stay named.
 
-import { test, expect } from '@playwright/test';
+import { test, expect, request as pwRequest, type Page, type TestInfo } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { authFileFor } from './support/env';
+import { signUp, authed } from './support/newcomer';
 
 test.use({ storageState: authFileFor('admin') });
 
@@ -32,31 +33,113 @@ const SCREENS: { path: string; name: string }[] = [
 // the 6 key screens now pass axe WCAG 2.1 AA — the gate enforces it going forward.
 const A11Y_KNOWN: Record<string, string> = {};
 
+/**
+ * One axe pass. Always attaches the full report; the gate is zero
+ * serious/critical.
+ */
+async function expectNoBlockingViolations(page: Page, info: TestInfo, label: string, path: string) {
+  const results = await new AxeBuilder({ page })
+    // WCAG 2.2 AA (task §1): include the 2.2 rule tags on top of 2.0/2.1.
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
+    .analyze();
+
+  await info.attach(`axe-${label}.json`, {
+    body: JSON.stringify(results.violations, null, 2),
+    contentType: 'application/json',
+  });
+
+  const blocking = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+  info.annotations.push({
+    type: 'a11y-summary',
+    description: `${path} :: ${results.violations.length} total, ${blocking.length} serious/critical [${blocking.map((v) => v.id).join(', ')}]`,
+  });
+
+  expect(
+    blocking,
+    `serious/critical WCAG 2.1 AA violations on ${path}:\n${blocking.map((v) => `${v.id}: ${v.help}`).join('\n')}`,
+  ).toEqual([]);
+}
+
 for (const screen of SCREENS) {
   test(`a11y: ${screen.name} (${screen.path})`, async ({ page }, info) => {
     test.fixme(screen.path in A11Y_KNOWN, A11Y_KNOWN[screen.path]);
     await page.goto(screen.path, { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
 
-    const results = await new AxeBuilder({ page })
-      // WCAG 2.2 AA (task §1): include the 2.2 rule tags on top of 2.0/2.1.
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'])
-      .analyze();
-
-    await info.attach(`axe-${screen.name}.json`, {
-      body: JSON.stringify(results.violations, null, 2),
-      contentType: 'application/json',
-    });
-
-    const blocking = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
-    info.annotations.push({
-      type: 'a11y-summary',
-      description: `${screen.path} :: ${results.violations.length} total, ${blocking.length} serious/critical [${blocking.map((v) => v.id).join(', ')}]`,
-    });
-
-    expect(
-      blocking,
-      `serious/critical WCAG 2.1 AA violations on ${screen.path}:\n${blocking.map((v) => `${v.id}: ${v.help}`).join('\n')}`,
-    ).toEqual([]);
+    await expectNoBlockingViolations(page, info, screen.name, screen.path);
   });
 }
+
+// ---------------------------------------------------------------------------
+// Onboarding (#234, criterion 7).
+//
+// These five routes and the activation checklist were absent from the sweep,
+// which means the first screens a new customer ever sees were the only ones
+// never checked. They cannot be added to SCREENS above: that block runs as the
+// seeded admin, who is past the wizard, and OnboardingCompletedRedirect would
+// bounce every /onboarding/* navigation to the dashboard — the sweep would pass
+// while scanning the wrong page. So this block signs up its own tenant.
+// ---------------------------------------------------------------------------
+
+const WIZARD_STEPS = ['organization', 'profile', 'goal', 'framework', 'team'] as const;
+
+test.describe('a11y — onboarding', () => {
+  // This block owns its identity; the shared admin storageState must not leak in.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  for (const step of WIZARD_STEPS) {
+    test(`a11y: onboarding wizard — ${step} (/onboarding/${step})`, async ({ browser }, info) => {
+      const api = await pwRequest.newContext();
+      const newcomer = await signUp(api, `a11y${step}`);
+      const ctx = await browser.newContext({ storageState: newcomer.storageState });
+      const page = await ctx.newPage();
+
+      await page.goto(`/onboarding/${step}`, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+
+      // Guard against the silent-redirect trap this block exists to avoid: if we
+      // are not on the step we asked for, the scan below would be meaningless.
+      await expect(page, 'the wizard step must actually be on screen').toHaveURL(
+        new RegExp(`/onboarding/${step}`),
+        { timeout: 15_000 },
+      );
+
+      await expectNoBlockingViolations(page, info, `onboarding-${step}`, `/onboarding/${step}`);
+
+      await ctx.close();
+      await api.dispose();
+    });
+  }
+
+  test('a11y: activation checklist (dashboard, steps outstanding)', async ({ browser }, info) => {
+    const api = await pwRequest.newContext();
+    const newcomer = await signUp(api, 'a11ychecklist');
+    const client = authed(api, newcomer.token);
+
+    // Finish the wizard so the guard lifts, but complete nothing else: the
+    // checklist only renders while steps remain outstanding, so a fully
+    // activated tenant would give us a dashboard with no checklist to scan.
+    await client.put('/onboarding/steps/profile', {
+      answers: { full_name: 'Awa Newcomer', job_title: 'RSSI', language: 'fr' },
+    });
+    await client.post('/onboarding/complete', {});
+
+    const ctx = await browser.newContext({ storageState: newcomer.storageState });
+    const page = await ctx.newPage();
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+
+    await expect(page, 'the guard must have lifted').not.toHaveURL(/\/onboarding/, {
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByTestId('activation-step-first_risk'),
+      'the checklist must be on screen for the scan to mean anything',
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expectNoBlockingViolations(page, info, 'activation-checklist', '/ (checklist)');
+
+    await ctx.close();
+    await api.dispose();
+  });
+});

--- a/tests/e2e/activation.spec.ts
+++ b/tests/e2e/activation.spec.ts
@@ -20,61 +20,11 @@
 // It signs up a REAL new account (a fresh tenant) rather than reusing a seeded
 // persona, because an already-onboarded tenant cannot exercise onboarding.
 
-import { test, expect, request as pwRequest, type APIRequestContext } from '@playwright/test';
-import { API_URL, FRONTEND_ORIGIN } from './support/env';
-import { apiLogin, storageStateFor } from './support/auth';
+import { test, expect, request as pwRequest } from '@playwright/test';
+import { signUp, authed } from './support/newcomer';
 
 /** The eight-minute promise, with headroom for a cold CI runner. */
 const AHA_BUDGET_MS = 8 * 60 * 1000;
-
-interface Newcomer {
-  email: string;
-  password: string;
-  storageState: Awaited<ReturnType<typeof storageStateFor>>;
-  token: string;
-}
-
-/**
- * Register a brand-new account through the real API and mint its storageState.
- * Unique per call so parallel runs and retries never collide.
- */
-async function signUp(ctx: APIRequestContext, tag: string): Promise<Newcomer> {
-  const stamp = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
-  const email = `e2e.activation.${tag}.${stamp}@openrisk.test`;
-  const password = 'ActivationE2E!2026';
-  const username = `e2eact${tag}${stamp}`.slice(0, 28);
-
-  const res = await ctx.post(`${API_URL}/auth/register`, {
-    data: {
-      email,
-      username,
-      password,
-      full_name: 'Awa Newcomer',
-      company_name: `Awa Test Org ${stamp}`,
-    },
-  });
-  expect(res.status(), `registration should succeed: ${await res.text()}`).toBe(201);
-
-  const login = await apiLogin(ctx, email, password);
-  return {
-    email,
-    password,
-    // From the SAME context that logged in, so the session cookies come with
-    // it — they, not a localStorage token, are the credential now.
-    storageState: await storageStateFor(ctx, login),
-    token: login.token_pair.access_token,
-  };
-}
-
-/** Authenticated API helper for the new account. */
-function authed(ctx: APIRequestContext, token: string) {
-  const headers = { Authorization: `Bearer ${token}` };
-  return {
-    get: (path: string) => ctx.get(`${API_URL}${path}`, { headers }),
-    put: (path: string, data: unknown) => ctx.put(`${API_URL}${path}`, { headers, data }),
-    post: (path: string, data: unknown) => ctx.post(`${API_URL}${path}`, { headers, data }),
-  };
-}
 
 interface ActivationStep {
   key: string;

--- a/tests/e2e/support/newcomer.ts
+++ b/tests/e2e/support/newcomer.ts
@@ -26,9 +26,17 @@ export async function signUp(ctx: APIRequestContext, tag: string): Promise<Newco
   const stamp = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
   const email = `e2e.activation.${tag}.${stamp}@openrisk.test`;
   const password = 'ActivationE2E!2026';
-  const username = `e2eact${tag}${stamp}`.slice(0, 28);
+  // The stamp comes BEFORE the tag: the username is capped at 28 characters, so
+  // with the tag first a long tag ate the timestamp and every run produced the
+  // same username — a 409 on the second run. The short tags this helper started
+  // with hid it.
+  const username = `e2e${stamp}${tag}`.slice(0, 28);
 
-  const res = await ctx.post(`${API_URL}/auth/register`, {
+  // Registration is rate limited per IP. A spec that signs up several tenants in
+  // a row trips it and fails with a 429 that looks nothing like the thing under
+  // test, so back off and retry — the same treatment scripts/seed-e2e.mjs gives
+  // the login endpoint.
+  let res = await ctx.post(`${API_URL}/auth/register`, {
     data: {
       email,
       username,
@@ -37,9 +45,33 @@ export async function signUp(ctx: APIRequestContext, tag: string): Promise<Newco
       company_name: `Awa Test Org ${stamp}`,
     },
   });
+  for (let attempt = 1; res.status() === 429 && attempt <= 5; attempt++) {
+    await new Promise((r) => setTimeout(r, attempt * 6_000));
+    res = await ctx.post(`${API_URL}/auth/register`, {
+      data: {
+        email,
+        username,
+        password,
+        full_name: 'Awa Newcomer',
+        company_name: `Awa Test Org ${stamp}`,
+      },
+    });
+  }
   expect(res.status(), `registration should succeed: ${await res.text()}`).toBe(201);
 
-  const login = await apiLogin(ctx, email, password);
+  // The login endpoint is rate limited too, and a spec that signs up several
+  // tenants hits that limit one request after clearing the registration one.
+  let login: Awaited<ReturnType<typeof apiLogin>> | undefined;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      login = await apiLogin(ctx, email, password);
+      break;
+    } catch (err) {
+      if (attempt === 3 || !String(err).includes('429')) throw err;
+      await new Promise((r) => setTimeout(r, (attempt + 1) * 4_000));
+    }
+  }
+  if (!login) throw new Error(`login never succeeded for ${email}`);
   return {
     email,
     password,

--- a/tests/e2e/support/newcomer.ts
+++ b/tests/e2e/support/newcomer.ts
@@ -1,0 +1,61 @@
+// Registering a brand-new account, for the specs that must exercise a tenant
+// which has NOT been onboarded.
+//
+// The seeded personas (admin / analyst / auditor) are all past the wizard, and
+// OnboardingCompletedRedirect sends a completed user away from /onboarding/*.
+// A spec that reused one of them would silently be redirected to the dashboard
+// and would assert against the wrong screen — green, and meaningless. Anything
+// touching onboarding therefore signs up its own tenant.
+
+import { expect, type APIRequestContext } from '@playwright/test';
+import { API_URL } from './env';
+import { apiLogin, storageStateFor } from './auth';
+
+export interface Newcomer {
+  email: string;
+  password: string;
+  storageState: Awaited<ReturnType<typeof storageStateFor>>;
+  token: string;
+}
+
+/**
+ * Register a brand-new account through the real API and mint its storageState.
+ * Unique per call so parallel runs and retries never collide.
+ */
+export async function signUp(ctx: APIRequestContext, tag: string): Promise<Newcomer> {
+  const stamp = `${Date.now()}${Math.floor(Math.random() * 1000)}`;
+  const email = `e2e.activation.${tag}.${stamp}@openrisk.test`;
+  const password = 'ActivationE2E!2026';
+  const username = `e2eact${tag}${stamp}`.slice(0, 28);
+
+  const res = await ctx.post(`${API_URL}/auth/register`, {
+    data: {
+      email,
+      username,
+      password,
+      full_name: 'Awa Newcomer',
+      company_name: `Awa Test Org ${stamp}`,
+    },
+  });
+  expect(res.status(), `registration should succeed: ${await res.text()}`).toBe(201);
+
+  const login = await apiLogin(ctx, email, password);
+  return {
+    email,
+    password,
+    // From the SAME context that logged in, so the session cookies come with
+    // it — they, not a localStorage token, are the credential now.
+    storageState: await storageStateFor(ctx, login),
+    token: login.token_pair.access_token,
+  };
+}
+
+/** Authenticated API helper for a newcomer's token. */
+export function authed(ctx: APIRequestContext, token: string) {
+  const headers = { Authorization: `Bearer ${token}` };
+  return {
+    get: (path: string) => ctx.get(`${API_URL}${path}`, { headers }),
+    put: (path: string, data: unknown) => ctx.put(`${API_URL}${path}`, { headers, data }),
+    post: (path: string, data: unknown) => ctx.post(`${API_URL}${path}`, { headers, data }),
+  };
+}


### PR DESCRIPTION
Closes #234

A tenant configured before activation shipped had no activation events at all, so
the checklist told a bank with 200 risks to "create your first risk" — and no user
action could correct it, because no endpoint lets a client mark a step complete.
This seeds the checklist from the records a tenant already holds, adds the
onboarding screens to the accessibility sweep, and reduces three competing
time-to-value numbers to one.

## What changed

- **`BackfillDerivedEvents`** (`gorm_activation_backfill.go`, wired at boot) — one
  event per checklist step per tenant that holds the proving record, dated from that
  record rather than from the boot that noticed it. Every derivation groups by the
  source table's own tenant column and writes that value back, so no arrangement of
  the data lets one tenant's records tick another's checklist. Skips tenants that
  already have the key, so reboots neither duplicate rows nor move a `completed_at`.
  `profile` stays underivable: no stored record proves it.
- **Onboarding a11y sweep** — the 5 wizard routes and the checklist, in a block that
  signs up its own tenant (the seeded admin is past the wizard, so the existing block
  would have scanned the dashboard and passed for the wrong reason). Three real
  violations found and fixed, not quarantined: `A11Y_KNOWN` is still `{}`.
- **One TTFV number: 8 minutes** — the only one a test asserts. Claim matrix rows
  C-002/C-003 plus a section stating that the 12-minute `SlowTimeToAha` threshold is
  an operational warning and not the promise. `ROADMAP.md` 17.6 no longer claims
  there is no onboarding package.

## Verification

```
$ cd backend && go test ./internal/infrastructure/repository/ -run BackfillDerived -v
--- PASS: TestBackfillDerived_ConfiguredTenantSeesCompletedSteps
--- PASS: TestBackfillDerived_IsIdempotentAcrossReboots
--- PASS: TestBackfillDerived_DoesNotDisturbLiveEvents
--- PASS: TestBackfillDerived_NeverMarksAStepWithoutEvidence
--- PASS: TestBackfillDerived_TenantIsolation
--- PASS: TestBackfillDerived_UnknownTenantHasNoState
--- PASS: TestBackfillDerived_EmptyDatabaseIsANoOp
ok  github.com/opendefender/openrisk/internal/infrastructure/repository  0.107s
```

Also proven against real PostgreSQL 16, not only the sqlite the unit tests use — two
pre-activation tenants seeded, server booted twice:

```
        tenant_id            |     event_key      |     occurred_at
-----------------------------+--------------------+------------------------
 1111...1111 (busy)          | risk.created       | 2026-03-02 09:00:00+00
 1111...1111                 | framework.imported | 2026-03-02 10:00:00+00
 1111...1111                 | asset.connected    | 2026-03-02 11:00:00+00
 1111...1111                 | mitigation.created | 2026-03-02 12:00:00+00
 1111...1111                 | report.generated   | 2026-03-02 13:00:00+00
 1111...1111                 | member.invited     | 2026-03-02 14:00:00+00
 2222...2222 (quiet)         | asset.connected    | 2026-03-02 17:00:00+00

second boot: total_events 8 | distinct_pairs 8
```

The quiet tenant got only its asset: its failed report and its lone founder correctly
proved nothing.

```
$ npx playwright test a11y.spec.ts --project=chromium -g "onboarding" --workers=1
  6 passed (2.1m)

$ npx playwright test activation.spec.ts --project=chromium --workers=1
  3 passed (9.8s)

$ cd frontend && npx tsc -b --force && npx vitest run
  Test Files 34 passed (34) · Tests 389 passed (389)
```

## Honest remainders

- **No `devsecops` review yet.** Recommended before merge: this is the one path that
  reads every tenant's tables in a single statement and writes into an append-only log
  no user can correct. The tenant-isolation test and the two-tenant Postgres run are
  evidence, not a substitute.
- **4 pre-existing a11y failures on `master`** are untouched here: `/risks`,
  `/vulnerabilities`, `/assets`, `/incidents` — contrast on `--risk-low` / `--risk-high`
  over tinted chips, plus a `select` with no accessible name. Proven independent of this
  work by re-running those 4 with this branch's frontend changes stashed: same 4
  failures. The a11y gate is therefore currently red on `master` and `A11Y_KNOWN = {}`
  is stale. Deliberately not quarantined here — it deserves its own issue.
- `TestBusinessRolesReferenceOnlyCatalogPermissions` fails on `master` too
  (`events:read` is not in the permission catalogue). Unrelated to this branch.
- The azure `--accent-500` nudge is a design-token change. It is a defect fix of the
  same class as the `--risk-moderate` note already in `tokens.css`, but `art-director`
  owns the token system and should confirm it.
- **Out of scope by decision, not oversight** (see the split comment on #234):
  integrations / "connected environment" step, a distinct "first assessment" step, and
  role-aware guidance. The first is blocked on integrations that do not exist; the
  second edits the frozen step ↔ event-key bijection and needs `tech-lead` sign-off.
- D-008 is open: the public promise is 8 minutes here because that is what a test
  asserts. An owner override to 5 changes one constant and one claim-matrix row.