### PR TITLE
chore(license): align every license reference on AGPL-3.0-only and add the CLA

### DIFF
--- a/.claude/agents/direction/tech-lead.md
+++ b/.claude/agents/direction/tech-lead.md
@@ -37,7 +37,7 @@ Map every change onto the layer diagram before judging it.
 
 ## Adding a dependency — answer all five in writing or reject
 
-License compatible with BUSL-1.1 · maintained in the last 6 months · no open
+License compatible with AGPL-3.0-only · maintained in the last 6 months · no open
 CVE · could we write it in under 200 lines · transitive dependency count.
 
 ## ADR — `docs/adr/NNNN-<slug>.md`

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,141 @@
+# OpenRisk Contributor License Agreement
+
+**Version 1.0 — 2026-08-31**
+
+Thank you for your interest in contributing to OpenRisk, a project of OpenDefender
+("the Project").
+
+This Contributor License Agreement ("Agreement") documents the rights granted by
+contributors to the Project. It exists for one reason: OpenRisk is **open-core**. The
+Community Edition is licensed under the GNU Affero General Public License v3.0
+(`AGPL-3.0-only`), and a defined set of Enterprise Edition paths is licensed
+commercially (`LicenseRef-OpenRisk-Commercial`). See [`LICENSING.md`](LICENSING.md)
+for the authoritative boundary. Offering the same work under two licenses requires
+that the Project hold sufficient rights in every contribution. This Agreement grants
+those rights. **You keep the copyright in your work.**
+
+This is a license agreement, not an assignment and not an employment or partnership
+agreement.
+
+---
+
+## 1. Definitions
+
+**"You"** means the individual or legal entity agreeing to this Agreement. For a legal
+entity, "You" includes any entity that controls, is controlled by, or is under common
+control with that entity.
+
+**"Contribution"** means any work of authorship — including source code, documentation,
+configuration, designs, translations and regulatory control content — that You
+intentionally submit to the Project for inclusion in or documentation of any of its
+products. "Submit" means any form of communication sent to the Project or its
+maintainers, including pull requests, patches, issue attachments and discussion posts,
+but **excluding** anything You conspicuously mark in writing as *"Not a Contribution."*
+
+---
+
+## 2. Copyright license
+
+You grant to OpenDefender and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense and distribute Your Contributions and such derivative works.
+
+This license expressly includes the right for OpenDefender to **distribute Your
+Contribution under more than one license**, including the AGPL-3.0-only Community
+Edition license, the OpenRisk Commercial License, and future licenses OpenDefender may
+adopt for the Project.
+
+---
+
+## 3. Patent license
+
+You grant to OpenDefender and to recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to sell, sell,
+import and otherwise transfer the work. This license applies only to those patent
+claims licensable by You that are necessarily infringed by Your Contribution alone or
+by combination of Your Contribution with the work to which it was submitted.
+
+If any entity institutes patent litigation against You or any other entity alleging
+that Your Contribution, or the work it was submitted to, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that entity
+under this Agreement for that Contribution terminate as of the date such litigation is
+filed.
+
+---
+
+## 4. Your representations
+
+You represent that:
+
+1. You are legally entitled to grant the licenses above.
+2. Each Contribution is Your original creation, or You have the necessary rights to
+   submit it under this Agreement.
+3. If Your employer has rights to intellectual property You create, You have either
+   received permission to make the Contribution on behalf of that employer, or Your
+   employer has waived such rights, or Your employer has agreed to this Agreement.
+4. Your Contribution does not, to Your knowledge, violate any third party's copyright,
+   patent, trademark, trade secret or other proprietary right.
+
+**Third-party work.** If You submit work that is not Your original creation, You must
+submit it separately from any original Contribution, identify its source and license,
+and conspicuously mark it — for example `[third-party: MIT, from <project/url>]`. Only
+licenses compatible with `AGPL-3.0-only` may be introduced into the Community Edition.
+
+**Regulatory content.** Contributions of framework control content are subject to the
+Project's citation standard: every control must cite a specific article of a specific
+official text. You represent that any such Contribution does not reproduce copyrighted
+standards text beyond what applicable law permits.
+
+---
+
+## 5. No warranty and no obligation
+
+You provide Your Contributions on an **"AS IS"** basis, without warranties or
+conditions of any kind, express or implied, including any warranty of merchantability,
+fitness for a particular purpose, title or non-infringement — except for the
+representations You make in Section 4.
+
+The Project is under no obligation to accept, merge, use or maintain any Contribution.
+Acceptance is at the maintainers' discretion.
+
+---
+
+## 6. Changed circumstances
+
+You agree to notify the Project if You become aware of any fact or circumstance that
+would make any representation in Section 4 inaccurate.
+
+---
+
+## 7. How You accept this Agreement
+
+You accept this Agreement by adding a `Signed-off-by` trailer to each commit in Your
+pull request, using Your real name and an email address You control:
+
+```
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+`git commit -s` adds it for you. The trailer certifies that You have read this
+Agreement and that Your Contribution is submitted under it.
+
+Corporate contributors whose employer requires a countersigned agreement should contact
+**licensing@opendefender.io** before submitting.
+
+> **Status of automated enforcement.** Acceptance is currently recorded by the
+> `Signed-off-by` trailer in the git history. An automated check that blocks unsigned
+> pull requests is **not yet wired** into the PR workflow — see the escalation in
+> [`docs/DECISIONS.md`](docs/DECISIONS.md). Until it lands, maintainers verify the
+> trailer during review.
+
+---
+
+## 8. Governing terms
+
+This Agreement is governed by the laws applicable to OpenDefender, without regard to
+conflict-of-law principles. If any provision is held unenforceable, the remainder stays
+in effect.
+
+Questions: **licensing@opendefender.io**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -428,18 +428,25 @@ Contributors are recognized in:
 
 ## Contributor License Agreement (CLA)
 
-By contributing to OpenRisk, you agree that your contributions will be licensed under the project's [Business Source License 1.1 (BUSL-1.1)](LICENSE). 
+By contributing to OpenRisk, you agree that your contributions will be licensed under the project's
+[GNU Affero General Public License v3.0](LICENSE) (`AGPL-3.0-only`), the license of the Community
+Edition. OpenRisk is **open-core**: a small set of Enterprise Edition paths carries
+`LicenseRef-OpenRisk-Commercial` instead. [`LICENSING.md`](LICENSING.md) is the authoritative
+boundary between the two — read it before contributing to a file whose SPDX header is not
+`AGPL-3.0-only`.
 
 To ensure the OpenDefender project has the legal rights to distribute and potentially re-license the collective work in the future, we require all contributors to sign a Contributor License Agreement (CLA).
 
-When you submit your first Pull Request, you will be prompted to sign the CLA digitally. By signing, you confirm that:
+The agreement is [`CLA.md`](CLA.md). By agreeing to it, you confirm that:
 1. You grant the OpenDefender project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your contributions.
 2. You are legally entitled to grant the above license.
 3. This is a license agreement only; you retain ownership of your original contributions.
 
 ## License
 
-By contributing to OpenRisk, you agree to the terms of the CLA and acknowledge the Business Source License 1.1 of the project.
+By contributing to OpenRisk, you agree to the terms of the [CLA](CLA.md) and acknowledge the
+GNU Affero General Public License v3.0 of the project core, together with the CE/EE boundary
+defined in [`LICENSING.md`](LICENSING.md).
 
 ## Additional Notes
 

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,33 +1,53 @@
 # Copyright Notice
 
-## OpenRisk - Open Source Risk Management Platform
+## OpenRisk — Open-Source Risk Management Platform
 
-**Copyright © 2024-2026 OpenDefender Contributors**  
-All rights reserved under the Business Source License 1.1 (BUSL-1.1)
+**Copyright © 2024-2026 OpenDefender Contributors**
 
 ---
 
 ## License
 
-This project is licensed under the **Business Source License 1.1** (BUSL-1.1).  
-See the [LICENSE](./LICENSE) file for the full license text.
+OpenRisk is **open-core** and ships as two editions in one repository:
 
-**Key Points:**
-- ✅ You **CAN** use, modify, and distribute this software for non-commercial and internal purposes.
-- ✅ You **MUST** include copyright and license notices.
-- ❌ You **CANNOT** provide the Licensed Work as a managed service (SaaS) or otherwise use it to provide a commercial competitive offering to third parties.
-- 🔄 Reverts to Apache 2.0 license after 4 years from the release date.
+| Edition | License | SPDX header |
+|---|---|---|
+| **Community Edition (CE)** — the core GRC platform | **GNU AGPL v3.0** ([`LICENSE`](./LICENSE)) | `AGPL-3.0-only` |
+| **Enterprise Edition (EE)** — commercial add-ons | **OpenRisk Commercial License** ([`LICENSE.commercial`](./LICENSE.commercial)) | `LicenseRef-OpenRisk-Commercial` |
+
+Every source file declares its edition in its `SPDX-License-Identifier` header.
+[`LICENSING.md`](./LICENSING.md) is the **authoritative boundary** between the two;
+where this file and `LICENSING.md` disagree, `LICENSING.md` wins.
+
+**Key points for the Community Edition (AGPLv3):**
+
+- ✅ You **CAN** use, modify and distribute it — including commercially.
+- ✅ You **CAN** self-host it, for yourself or inside your organisation.
+- ⚠️ You **MUST** preserve the copyright and license notices.
+- ⚠️ You **MUST** release your modified source under the AGPL if you distribute it.
+- ⚠️ You **MUST** also release it if you let others **use your modified version over a
+  network** — this is AGPL §13, and it is the clause that distinguishes the AGPL from
+  the GPL.
+- ❌ You **CANNOT** relicense the Community Edition under different terms.
+
+Enterprise Edition files are **not** covered by the AGPL. They may only be used,
+copied or deployed under a Commercial Agreement — see `LICENSE.commercial`.
 
 ---
 
 ## Copyright Ownership
 
-The copyright for this project is held collectively by all contributors who have submitted code to the repository. By contributing to OpenRisk, you agree that:
+Copyright is held collectively by the contributors who have submitted code to the
+repository. By contributing to OpenRisk, you agree that:
 
-1. Your contributions are submitted under the BUSL-1.1 license
+1. Your contributions to the Community Edition are submitted under `AGPL-3.0-only`
 2. You have the right to submit the contribution
 3. Your contribution becomes part of the collective work
-4. You agree to the Contributor License Agreement (CLA) outlined in CONTRIBUTING.md
+4. You agree to the [Contributor License Agreement](./CLA.md)
+
+The CLA grants OpenDefender the rights it needs to **dual-license** the collective
+work, which is what makes a commercial Enterprise Edition possible alongside an AGPL
+core. You retain ownership of your contributions.
 
 ---
 
@@ -35,18 +55,26 @@ The copyright for this project is held collectively by all contributors who have
 
 **"OpenDefender"** and **"OpenRisk"** are trademarks of the OpenDefender project.
 
-While the code is available under BUSL-1.1, the trademarks are protected. Use of the trademarks requires compliance with our trademark policy:
+The code is free software; the trademarks are not. The AGPL grants no trademark
+rights. Use of the marks requires compliance with our trademark policy:
 
 - ✅ Permitted: Referring to the original project, linking, academic citations
 - ✅ Permitted: Unmodified redistribution with clear attribution
-- ⚠️ Requires Permission: Commercial use, derivative project names, endorsements
+- ⚠️ Requires Permission: Derivative project names, endorsements, implying affiliation
 - ❌ Prohibited: Misleading use, implying official status without authorization
+
+Note that redistributing a **modified** build under the OpenRisk name is a trademark
+question, not a licensing one: the AGPL permits the fork, the trademark policy governs
+what you may call it.
 
 ---
 
 ## Third-Party Components
 
-This project may include third-party libraries and components, each with their own copyright and license terms. All third-party components used are compatible with BUSL-1.1. See individual component documentation for specific copyright notices.
+This project includes third-party libraries and components, each with their own
+copyright and license terms. All third-party components bundled into the Community
+Edition are compatible with `AGPL-3.0-only`. See individual component documentation
+for specific copyright notices.
 
 ---
 
@@ -54,17 +82,20 @@ This project may include third-party libraries and components, each with their o
 
 When using or distributing OpenRisk, you must:
 
-1. **Preserve all copyright notices** in source files
+1. **Preserve all copyright and SPDX notices** in source files
 2. **Include the LICENSE file** in distributions
-3. **Credit the OpenDefender project** prominently
+3. **Credit the OpenDefender project**
 4. **Link to the original repository**: https://github.com/opendefender/OpenRisk
-5. **Indicate modifications** if you've changed the code
+5. **Indicate modifications** if you have changed the code
+6. **Offer the corresponding source** to anyone who interacts with your instance over
+   a network (AGPL §13)
 
 ---
 
 ## DMCA & Copyright Violations
 
 If you believe your copyright has been violated, contact us at:
+
 - **GitHub Issues**: https://github.com/opendefender/OpenRisk/issues
 - **Takedown Requests**: Follow GitHub's DMCA process
 
@@ -72,16 +103,23 @@ If you believe your copyright has been violated, contact us at:
 
 ## Commercial Use
 
-BUSL-1.1 does not permit commercial SaaS deployment to third parties without a commercial license. For alternative licensing arrangements, contact the project maintainers.
+The AGPL permits commercial use, including offering OpenRisk as a hosted service —
+**provided** you release your modifications under the AGPL to the users of that
+service. Organisations that cannot accept the AGPL's source-disclosure obligations,
+or that need the Enterprise Edition, require a commercial license.
+
+For alternative licensing arrangements: **licensing@opendefender.io**
 
 ---
 
 ## Contact
 
 For licensing questions or permissions:
+
+- **Licensing**: licensing@opendefender.io
 - **Repository**: https://github.com/opendefender/OpenRisk
 - **Issues**: https://github.com/opendefender/OpenRisk/issues
 
 ---
 
-*Last Updated: 2026*
+*Last Updated: 2026-08-31*

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 // Command openrisk-agent is the on-prem OpenRisk Scanner Agent.
 //

--- a/agent/scan.go
+++ b/agent/scan.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/agent/service.go
+++ b/agent/service.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/agent/update.go
+++ b/agent/update.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 package main
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,7 +5,56 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-_Nothing open. Last cleared 2026-08-31._
+### D-014 — Relicense `design-system/` to Apache-2.0?
+**Context** — `frontend/src/features/ai/` and
+`frontend/src/features/reports/BoardReportPage.tsx` are
+`LicenseRef-OpenRisk-Commercial` and import the AGPL design system. This is
+resolvable today by copyright ownership — OpenDefender holds the copyright in
+both, so it may combine them — but a third-party auditor doing a procurement
+review sees commercial code importing AGPL code and has to be talked out of the
+obvious reading. Relicensing `design-system/` to Apache-2.0 removes the argument
+instead of answering it.
+**Options** — **A** relicense `design-system/` to `Apache-2.0` and add
+`design-system/NOTICE` · **B** leave it AGPL and document the ownership argument
+in `LICENSING.md` · **C** leave it AGPL and move the two EE consumers off the
+design system.
+**Recommendation** — **A**. The design system is the artifact you *want* copied
+and extended; its value is protected by trademark, not by copyleft. Copyleft on
+it buys nothing and costs an audit conversation on every enterprise deal. C is
+the worst option: it forces the EE surfaces to reinvent primitives, which is the
+exact fragmentation issue #439 exists to end.
+**Cost of delay** — Low but non-zero, and it grows. Every new file added under
+`design-system/` is one more header to change later, and #443/#444 are about to
+add a lot of them. Doing it before the primitive layer lands is materially
+cheaper than after.
+**Reversible?** — **No, not practically.** Apache-2.0 is irrevocable for anything
+already published; the project can relicense future versions but cannot claw back
+what shipped. This is why it is your call and not the agent's.
+**Status** — OPEN
+
+### D-015 — How is CLA acceptance enforced: `cla-assistant` or DCO?
+**Context** — `CLA.md` now exists (this branch) and acceptance is recorded by a
+`Signed-off-by` trailer. Nothing enforces it: there is no CLA check, no DCO
+check, and no PR template in `.github/`. A CLA nobody verifies protects the
+dual-licensing right about as well as no CLA, which is what makes the Enterprise
+Edition defensible.
+**Options** — **A** DCO check — a GitHub Action asserting the `Signed-off-by`
+trailer on every commit; no third party, no data leaves GitHub, no account to
+administer · **B** `cla-assistant` — a hosted bot storing signatures against
+GitHub identities; a real audit trail, but a third-party service holding
+contributor identity data · **C** `cla-assistant` self-hosted — the audit trail
+without the third party, at the cost of running it.
+**Recommendation** — **A now, revisit at the first corporate contribution.** The
+trailer is a real, timestamped, per-commit record in git history and costs one
+workflow file. B is the stronger artifact but is a **new external service** and
+touches contributor personal data, which is exactly the kind of call the
+constitution routes to you rather than to an agent.
+**Cost of delay** — Accrues per merged PR. Every external contribution merged
+without a recorded acceptance is one more contribution whose dual-licensing
+status rests on the CONTRIBUTING.md text alone.
+**Reversible?** — Yes. Switching enforcement later is a workflow change; already
+merged commits keep whatever record they have.
+**Status** — OPEN
 
 ## Resolved
 

--- a/docs/W1-01_DESIGN_SYSTEM_LIVE_PROOF.md
+++ b/docs/W1-01_DESIGN_SYSTEM_LIVE_PROOF.md
@@ -1,5 +1,5 @@
 <!-- Copyright (c) 2026 OpenDefender Contributors
-     SPDX-License-Identifier: BUSL-1.1 -->
+     SPDX-License-Identifier: AGPL-3.0-only -->
 
 # W1-01 — Design System Live Proof
 

--- a/docs/W1-01_OPENRISK_DESIGN_SYSTEM.md
+++ b/docs/W1-01_OPENRISK_DESIGN_SYSTEM.md
@@ -1,5 +1,5 @@
 <!-- Copyright (c) 2026 OpenDefender Contributors
-     SPDX-License-Identifier: BUSL-1.1 -->
+     SPDX-License-Identifier: AGPL-3.0-only -->
 
 # W1-01 — OpenRisk Design System
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,8 +12,8 @@ info:
   contact:
     name: OpenDefender Team
   license:
-    name: Business Source License 1.1 (BUSL-1.1)
-    url: https://mariadb.com/bsl11/
+    name: GNU Affero General Public License v3.0 only (AGPL-3.0-only)
+    url: https://www.gnu.org/licenses/agpl-3.0.html
 servers:
   - url: /api/v1
     description: Production API

--- a/docs/ui/W1-01_VISUAL_DEBT_AUDIT.md
+++ b/docs/ui/W1-01_VISUAL_DEBT_AUDIT.md
@@ -1,5 +1,5 @@
 <!-- Copyright (c) 2026 OpenDefender Contributors
-     SPDX-License-Identifier: BUSL-1.1 -->
+     SPDX-License-Identifier: AGPL-3.0-only -->
 
 # W1-01 — Visual debt audit (pre-change inventory)
 

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Authentication end-to-end suite.

--- a/frontend/e2e/empty-states.spec.ts
+++ b/frontend/e2e/empty-states.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Zero-state truthfulness sweep.

--- a/frontend/e2e/entity-drawer.spec.ts
+++ b/frontend/e2e/entity-drawer.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * The universal entity drawer, end to end (W1-02 §47-§52).

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Reversible navigation.

--- a/frontend/e2e/visual/design-system.spec.ts
+++ b/frontend/e2e/visual/design-system.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';

--- a/frontend/e2e/visual/gallery.tsx
+++ b/frontend/e2e/visual/gallery.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Design-system gallery.

--- a/frontend/e2e/visual/harness.tsx
+++ b/frontend/e2e/visual/harness.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Overlay visual harness.

--- a/frontend/e2e/visual/overlays.spec.ts
+++ b/frontend/e2e/visual/overlays.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';

--- a/frontend/eslint-rules/no-ad-hoc-design-values.js
+++ b/frontend/eslint-rules/no-ad-hoc-design-values.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Flags arbitrary Tailwind values for properties that have a token scale.

--- a/frontend/eslint-rules/no-mock-data.js
+++ b/frontend/eslint-rules/no-mock-data.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * openrisk/no-mock-data

--- a/frontend/eslint-rules/no-raw-colors.js
+++ b/frontend/eslint-rules/no-raw-colors.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * openrisk/no-raw-colors

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { defineConfig, devices } from '@playwright/test';
 

--- a/frontend/scripts/audit-surfaces.mjs
+++ b/frontend/scripts/audit-surfaces.mjs
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Structural guards against deceptive UI (W0-05).

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Verifies WCAG contrast for every text/surface pair in the design tokens, in

--- a/frontend/scripts/check-design-system.mjs
+++ b/frontend/scripts/check-design-system.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Fails when the product's design tokens drift from the canonical contract.

--- a/frontend/scripts/migrate-colors.mjs
+++ b/frontend/scripts/migrate-colors.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Rewrites raw Tailwind palette classes to semantic design tokens.

--- a/frontend/scripts/migrate-primitives.mjs
+++ b/frontend/scripts/migrate-primitives.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * One-shot codemod: move the product off src/components/ui/* onto the design

--- a/frontend/scripts/overlay-inventory.mjs
+++ b/frontend/scripts/overlay-inventory.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Generates docs/ui/overlays.md from the source.

--- a/frontend/scripts/verify-modals.mjs
+++ b/frontend/scripts/verify-modals.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Drives the real application: logs in, opens the reported modals in both

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 /* Design tokens — one source of truth for colour, applied via [data-theme] on
    <html>. Must precede the Tailwind layers so utilities can resolve the vars.

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Session credential access.

--- a/frontend/src/shared/ds/Badge.tsx
+++ b/frontend/src/shared/ds/Badge.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Badge — a read-only status marker.

--- a/frontend/src/shared/ds/Button.tsx
+++ b/frontend/src/shared/ds/Button.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Button — the canonical control.

--- a/frontend/src/shared/ds/Drawer.tsx
+++ b/frontend/src/shared/ds/Drawer.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Drawer — a side panel for the detail of a row you are still looking at.

--- a/frontend/src/shared/ds/Field.tsx
+++ b/frontend/src/shared/ds/Field.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Form system — Field, Input, Textarea, Select.

--- a/frontend/src/shared/ds/Modal.tsx
+++ b/frontend/src/shared/ds/Modal.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Modal — a dialog that takes over until it is answered.

--- a/frontend/src/shared/ds/States.tsx
+++ b/frontend/src/shared/ds/States.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * The states a data surface can be in, as one vocabulary.

--- a/frontend/src/shared/ds/Tabs.tsx
+++ b/frontend/src/shared/ds/Tabs.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Tabs — switching between views of the same subject.

--- a/frontend/src/shared/ds/Tooltip.tsx
+++ b/frontend/src/shared/ds/Tooltip.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Tooltip — a short label for a control whose meaning is not fully carried by

--- a/frontend/src/shared/ds/__tests__/primitives.test.tsx
+++ b/frontend/src/shared/ds/__tests__/primitives.test.tsx
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Design-system primitives: the guarantees a screen is allowed to rely on.

--- a/frontend/src/shared/ds/badgeIntents.ts
+++ b/frontend/src/shared/ds/badgeIntents.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * Business enum -> visual intent.

--- a/frontend/src/shared/ds/chart.ts
+++ b/frontend/src/shared/ds/chart.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * The visualisation contract: one palette and one set of chart furniture for

--- a/frontend/src/shared/ds/cn.ts
+++ b/frontend/src/shared/ds/cn.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';

--- a/frontend/src/shared/ds/index.ts
+++ b/frontend/src/shared/ds/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * The OpenRisk design system.

--- a/frontend/src/shared/ds/useDismissableLayer.ts
+++ b/frontend/src/shared/ds/useDismissableLayer.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 OpenDefender Contributors
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: AGPL-3.0-only
 
 /**
  * The shared behaviour of every layer that covers the page: modal, drawer,

--- a/frontend/src/shared/safeUrl.test.ts
+++ b/frontend/src/shared/safeUrl.test.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 import { describe, it, expect } from 'vitest';
 import { safeExternalUrl } from './safeUrl';

--- a/frontend/src/shared/safeUrl.ts
+++ b/frontend/src/shared/safeUrl.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 /**
  * Allowlist for URLs that reach an `href`.

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 /* ============================================================================
    OpenRisk component tokens

--- a/frontend/src/styles/primitives.css
+++ b/frontend/src/styles/primitives.css
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 /* ============================================================================
    OpenRisk primitive tokens — the non-colour scales

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,5 +1,5 @@
 /* Copyright (c) 2026 OpenDefender Contributors
-   SPDX-License-Identifier: BUSL-1.1 */
+   SPDX-License-Identifier: AGPL-3.0-only */
 
 /* ============================================================================
    OpenRisk semantic tokens — colour and elevation

--- a/helm/openrisk/Chart.yaml
+++ b/helm/openrisk/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
 dependencies: []
 annotations:
   category: Security
-  licenseUrl: https://mariadb.com/bsl11/
+  licenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
   releaseNotes: "Phase 5 - Kubernetes deployment for OpenRisk"


### PR DESCRIPTION
Closes #440

Repository-level licensing was already correct and well structured — `LICENSE` is
AGPL-3.0-only, `LICENSE.commercial` carries `LicenseRef-OpenRisk-Commercial`, and
`LICENSING.md` is an authoritative manifest. This PR closes the gap between that
structure and what the rest of the repository actually said.

## What changed

**1. `CONTRIBUTING.md` no longer contradicts `LICENSE` (the P0).**
Both occurrences told contributors their work would be licensed under BUSL-1.1.
Contributors were agreeing to the terms of a license that is not the project's. Both
now say `AGPL-3.0-only` and point at `LICENSING.md` for the CE/EE boundary.

**2. 48 SPDX headers corrected.** The issue named `CONTRIBUTING.md`; the grep it asked
for found 48 more files still stamped `SPDX-License-Identifier: BUSL-1.1` — the whole
of `frontend/src/shared/ds/`, `frontend/src/styles/`, the e2e suite, the design-system
scripts and eslint rules, `frontend/src/index.css`, and `agent/*.go`. **None of these
files appears in the `LICENSING.md` Enterprise list**, so all 48 are Community Edition
and all became `AGPL-3.0-only`. In `agent/*.go` the MariaDB BSL notice block was
replaced with the AGPL notice used everywhere else in the backend.

**3. Two more license declarations nobody had listed.** `docs/openapi.yaml` published
the API under "Business Source License 1.1" and `helm/openrisk/Chart.yaml` pointed
`licenseUrl` at `mariadb.com/bsl11`. Both are public-facing.

**4. `COPYRIGHT.md` rewritten.** Not a find-and-replace: its "Key Points" described
BUSL terms that are *false* under the AGPL — non-commercial-only use, and a four-year
reversion to Apache 2.0 — while omitting the AGPL §13 network clause, which is the
obligation that actually matters to anyone deploying OpenRisk.

**5. `CLA.md` added.** `LICENSING.md` makes the dual-licensing right — and therefore
the entire Enterprise Edition — depend on a CLA that did not exist. It grants the
copyright and patent licenses needed to distribute a contribution under more than one
license, while the contributor keeps their copyright.

**6. `tech-lead` prompt.** Its dependency checklist gated on "license compatible with
BUSL-1.1", which under the AGPL is wrong in both directions and would have produced
bad accept *and* reject calls on every new dependency.

## Verification

```
$ grep -rn "BUSL\|Business Source\|bsl11" --exclude-dir=.git .
(no output)

$ grep -rl "SPDX-License-Identifier: AGPL-3.0-only" --exclude-dir=.git . | wc -l
1250

$ git diff -U0 <every file with a changed SPDX header> | grep -E '^[+-]' | sort -u
+// SPDX-License-Identifier: AGPL-3.0-only
+     SPDX-License-Identifier: AGPL-3.0-only -->
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+// This program is free software: you can redistribute it and/or modify it under
-// If a copy of the BUSL was not distributed with this file, You can obtain one at https://mariadb.com/bsl11/
-// SPDX-License-Identifier: BUSL-1.1
-     SPDX-License-Identifier: BUSL-1.1 -->
-// This Source Code Form is subject to the terms of the Business Source License, Version 1.1.
```
Every source change is a comment line. Nothing executable was touched.

```
$ cd agent && go build ./...          # OK
$ cd backend && go build ./...        # OK
$ cd frontend && npx tsc -b           # exit 0
```

`npm run lint` fails with 338 problems (`no-unused-vars`, `no-explicit-any`,
`openrisk/no-raw-colors`, `react-hooks/*`). **This is pre-existing** — `gh run list
--branch master` shows CI red on the last three merges to `master`, and this PR's diff
is comment-only, so it cannot have added a lint error. Not fixed here; it is #446's
territory.

## Honest remainders

- **Escalated, not done — `docs/DECISIONS.md` D-014:** relicensing `design-system/` to
  Apache-2.0 (task 4 of the issue). This is **irreversible** for anything already
  published and is a licensing call, which the constitution routes to the owner.
- **Escalated, not done — `docs/DECISIONS.md` D-015:** wiring `cla-assistant` or a DCO
  check into the PR flow (second half of task 3). `cla-assistant` is a **new external
  service** holding contributor identity data. `CLA.md` therefore states plainly that
  acceptance is recorded by a `Signed-off-by` trailer and that automated enforcement is
  **not** wired, rather than implying a bot exists. Recommendation in D-015 is the DCO
  Action.
- **Not in scope, still true — defect 3 of the issue:** Phase 2 `ee/` isolation is not
  done, so a default `go build` still compiles EE code into a Community binary.
  `LICENSING.md` already admits this. It needs its own issue.
- **`.claude/agents/compliance/legal-counsel.md`** also carried four BUSL references and
  they are fixed **in the working tree**, but that file is untracked and belongs to
  another in-flight work stream, so it is deliberately **not** in this PR.
- `docs/DECISIONS.md` on this branch adds only D-014 and D-015. The uncommitted
  D-009–D-013 in the working tree belong to the W1-05 stream and were left out; mine
  were renumbered to 014/015 to avoid colliding with them.
