### PR TITLE
docs(decisions): ratify D-016 and resolve D-017 (#452)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,44 +5,57 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-### O-001 — `react-leaflet` ships under Hippocratic-2.1, which is not OSI-approved · raised 2026-09-01
-**Found while** executing #452's task "check whether any repo-wide licence tooling
-asserts everything under `frontend/src/**` is AGPL". The answer is that no such
-tooling exists, and the job that looks like it does is not doing it.
-
-**The facts, verified —**
-- `frontend/package.json:43` depends on `react-leaflet ^5.0.0`.
-  `node -e "require('react-leaflet/package.json').license"` → `"Hippocratic-2.1"`.
-  (`leaflet` itself is `BSD-2-Clause` and is fine.)
-- Hippocratic-2.1 imposes ethical-use restrictions on the licensee. It is **not
-  OSI-approved and not a free-software licence**, so it is not compatible with
-  redistributing a combined work under `AGPL-3.0-only`, and it sits badly with an
-  EE build distributed under a commercial agreement.
-- `.github/workflows/security.yml` `license-check` writes `backend/modules.json`,
-  never reads it, and `echo`s `"✅ License check completed"`. It covers Go
-  modules only and asserts nothing. **The frontend dependency tree is ungated.**
-
-**Why it is the owner's call** — dropping or replacing a shipped map dependency,
-accepting the risk, or paying for an alternative are all owner decisions under
-CLAUDE.md's escalation triggers (dependencies, licensing, anything costing money).
-
-**Options** — (A) replace `react-leaflet` with a permissively-licensed map binding
-and add a real frontend licence gate; (B) keep it and record an accepted-risk
-entry with counsel's opinion; (C) keep it, gate the map behind EE only — which
-does not help, since EE is the harder case, not the easier one.
-
-**Recommendation** — A. The gate is the durable half: without it the next
-incompatible dependency arrives unannounced, exactly as this one did.
-
-**Cost of delay** — It is already published. Every release compounds it.
-
-**Not touched by #452.** That PR relicenses the design system and changes no
-dependency. This entry exists so the finding is not lost with the PR thread; it
-needs its own issue.
+None. Every entry in this register is resolved as of 2026-09-01.
 
 ## Resolved
 
 <!-- Append: date · decision · rationale · issues unblocked -->
+
+### D-017 — `react-leaflet` is removed and a real licence gate replaces the fake one · 2026-09-01
+**Decided** — Option A, both halves. `react-leaflet` is removed from
+`frontend/package.json`, along with `leaflet` and the orphan
+`import 'leaflet/dist/leaflet.css'` in `src/main.tsx`. Separately,
+`.github/workflows/security.yml`'s `license-check` job is replaced with a gate
+that actually fails the build on a non-allowlisted licence, in **both** the Go
+and npm trees.
+**Rationale (owner)** — Matches the recommendation. The removal turned out to be
+free, and the gate is the half with lasting value: this dependency entered
+unnoticed, and without a gate the next one will too.
+**How it was found** — While executing #452's task "check whether any repo-wide
+licence tooling asserts everything under `frontend/src/**` is AGPL". The answer
+was that no such tooling exists, and the job that looks like it does is not doing
+it.
+**The facts, verified 2026-09-01 —**
+- `frontend/package.json:43` declared `react-leaflet ^5.0.0`.
+  `require('react-leaflet/package.json').license` → `"Hippocratic-2.1"`, as does
+  its own `@react-leaflet/core`. Hippocratic-2.1 imposes ethical-use restrictions
+  on the licensee; it is **not OSI-approved and not a free-software licence**, so
+  it is not compatible with redistributing a combined work under `AGPL-3.0-only`,
+  and it sits worse with an EE build under a commercial agreement.
+- **Nothing imports it.** Zero hits for `react-leaflet`, `MapContainer`,
+  `TileLayer` or `useMap` in `frontend/src/`. The only leaflet trace is
+  `src/main.tsx:11`, a CSS import belonging to `leaflet` itself
+  (`BSD-2-Clause`, unproblematic but equally unused). No map feature appears in
+  `ROADMAP.md` or in any open issue. It is declared, not bundled — the exposure
+  is the dependency manifest and every SBOM built from it, not shipped code.
+  **This corrects the entry as first raised**, which framed the choice as
+  replacing a shipped map binding; there was nothing to replace.
+- Full frontend licence census, same date: 356 MIT · 27 ISC · 21 Apache-2.0 ·
+  9 BSD-2-Clause · 6 BSD-3-Clause · 4 MPL-2.0 · 4 Unlicense · 2 MIT-0 ·
+  2 Hippocratic-2.1 (both the react-leaflet family) · 1 Python-2.0 · 1 CC-BY-4.0.
+  The two packages reporting `UNKNOWN` (`fast-shallow-equal`,
+  `react-universal-interface`, both transitive via `react-use`) carry the
+  Unlicense public-domain text and are merely missing the SPDX field. **Nothing
+  else in the tree is non-permissive.**
+- `.github/workflows/security.yml` `license-check` writes `backend/modules.json`,
+  never reads it, and `echo`s `"✅ License check completed"`. It covers Go modules
+  only and asserts nothing; the frontend tree was never gated at all.
+**Consequence** — Reversible. Re-adding a map binding is trivial if a map feature
+ever lands, and an allowlist can be loosened. The gate must fail the build rather
+than warn, or it reproduces the defect it replaces.
+**Not touched by #452 / PR #456**, which relicenses the design system and changes
+no dependency.
+**Unblocked** — #457 opened to execute both halves.
 
 ### D-016 — the Apache-2.0 boundary is both design-system directories · 2026-08-31
 **Decided** — Option A. "The design system" in D-014 means **`frontend/design-system/`
@@ -75,7 +88,9 @@ its blocking table only.
 executing #452, from the issue body and `po-openrisk`'s timestamped comment of
 2026-08-31. The decision is the owner's and dates from 2026-08-31; only the
 register entry is late. `LICENSING.md` and `frontend/design-system/README.md`
-cite it. Owner to confirm the transcription is faithful.
+cite it. **Transcription confirmed faithful by the owner on 2026-09-01** — the
+entry is ratified, not assumed, and is not to be relitigated on the grounds that
+it was written down late.
 
 ### D-015 — CLA acceptance is enforced by a DCO check · 2026-08-31
 **Decided** — Option A. A GitHub Action asserts the `Signed-off-by` trailer on


### PR DESCRIPTION
Follow-up to #452 / PR #456. **Docs only — one file, `docs/DECISIONS.md`.**

This commit was pushed to the #456 branch a few minutes after you merged it, so it missed the
merge. Nothing is wrong with what landed on master; this is the register catching up.

## What it records

**D-016 is ratified.** While executing #452 I found that D-016 did not exist in the register —
it ran D-001…D-015, and D-014's own text scopes itself to `design-system/` alone, so nothing on
record authorised relicensing `frontend/src/shared/ds/`, which was the substance of #456. Two
shipped files (`LICENSING.md`, `frontend/design-system/README.md`) cited the missing entry. I
transcribed it from the issue body and po-openrisk's comment and flagged it for confirmation;
**you confirmed it faithful on 2026-09-01**, and the record note now says so. A future agent
reads a ratified entry rather than a late transcription of unclear standing.

**O-001 is resolved as D-017** (option A: remove `react-leaflet`, and replace the no-op
`license-check` job with one that actually fails). The entry is **corrected on the fact that
changed the decision**: as first raised it read as "a shipped map dependency under a non-OSI
licence", which priced the options as replacing a map binding. Checking the import sites first
showed `react-leaflet` has **zero** — no `MapContainer`, no `TileLayer`, no `useMap`, no map in
the roadmap or any open issue — and the only leaflet trace is an orphan CSS import belonging to
BSD-2-Clause `leaflet`. It is declared, not bundled, so the removal is nearly free and the CI
gate is the half with lasting value.

The entry also carries the **full frontend licence census** (356 MIT · 27 ISC · 21 Apache-2.0 ·
9 BSD-2 · 6 BSD-3 · 4 MPL-2.0 · 4 Unlicense · 2 MIT-0 · 2 Hippocratic-2.1 · 1 Python-2.0 ·
1 CC-BY-4.0) so #457 can write its allowlist from evidence rather than guesswork. The
react-leaflet family is the only non-permissive licence in the tree, which is what makes a
blocking gate affordable now.

**#457** is open and `status:ready` to execute D-017. The register's **Open** section is empty
again.

## Verification

```
$ git diff --stat origin/master...HEAD
 docs/DECISIONS.md | 85 ++++++++++++++++++++-----------------------
 1 file changed, 50 insertions(+), 35 deletions(-)
```

One file, documentation only. No code, no dependency, no licence header touched.

## Honest remainders

- My comment on #452 saying "PR #456 is clear to merge" was posted a few minutes after you had
  already merged it. The content stands; the timing line was wrong.
- Two follow-ups from #452 still have no issue: the `opendefender-website` divergence (that repo
  has no `LICENSE` file at all and its copy of the tokens still carries the AGPL header, so one
  file now exists under two licences), and the `LICENSING.md` paragraph on why EE files importing
  AGPL files is not a conflict — eight such imports remain via `shared/ui`.
