### PR TITLE
fix(ci): check-design-system reads @theme, the 36 theme.css tokens are back under contract (#451)

### DIFF
--- a/frontend/scripts/check-design-system.mjs
+++ b/frontend/scripts/check-design-system.mjs
@@ -34,7 +34,13 @@ import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const CANONICAL = resolve(here, '../design-system/openrisk.tokens.css');
+// Order is cascade order, because scopesOf() merges with "later wins".
+// theme.css comes FIRST even though index.css imports it LAST: its @theme
+// blocks land in Tailwind's `@layer theme`, while the other three are imported
+// with `layer(base)`. Base outranks theme, so a token declared in both resolves
+// to the base value in the browser — and has to resolve to it here too.
 const PRODUCT = [
+  resolve(here, '../src/styles/theme.css'),
   resolve(here, '../src/styles/primitives.css'),
   resolve(here, '../src/styles/tokens.css'),
   resolve(here, '../src/styles/components.css'),
@@ -90,6 +96,23 @@ const RENAMED = {
   '--text-muted': { to: '--fg-muted', why: 'See --text-primary.' },
   '--text-inverse': { to: '--fg-inverse', why: 'See --text-primary.' },
   '--text-on-solid': { to: '--fg-on-solid', why: 'See --text-primary.' },
+
+  // The other half of the same v4 namespace rule, in the opposite direction.
+  // A font size only generates its utility if it IS called --text-*, so the
+  // canonical --display-1 has to be declared as --text-display-1 for
+  // `text-display-1` to exist. Values are compared unchanged.
+  '--display-1': {
+    to: '--text-display-1',
+    why:
+      'Tailwind v4 (#441) derives font-size utilities from the --text-* ' +
+      'namespace. Declared as --display-1 the token is inert: no ' +
+      '`text-display-1` class is generated and the marketing headline falls ' +
+      'back to the base size.',
+  },
+  '--display-2': { to: '--text-display-2', why: 'See --display-1.' },
+  '--display-3': { to: '--text-display-3', why: 'See --display-1.' },
+  '--display-4': { to: '--text-display-4', why: 'See --display-1.' },
+  '--lead': { to: '--text-lead', why: 'See --display-1.' },
 };
 
 /**
@@ -102,6 +125,35 @@ function normalise(value) {
   return value.replace(/\d+\.\d+/g, (n) => String(parseFloat(n)));
 }
 
+/** Pulls `--x: y;` declarations out of a rule body, ignoring nested blocks. */
+function declarationsIn(body) {
+  const vars = {};
+  let depth = 0;
+  for (const line of body.split('\n')) {
+    if (depth === 0) {
+      const m = line.match(/^\s*(--[\w-]+)\s*:\s*([^;]+);/);
+      if (m) vars[m[1]] = m[2].trim().replace(/\s+/g, ' ');
+    }
+    for (const ch of line) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+    }
+  }
+  return vars;
+}
+
+/** Index of the `}` closing the block opened at `open`. -1 if unbalanced. */
+function closingBrace(css, open) {
+  let depth = 1;
+  let j = open + 1;
+  while (j < css.length) {
+    if (css[j] === '{') depth++;
+    else if (css[j] === '}' && --depth === 0) return j;
+    j++;
+  }
+  return -1;
+}
+
 /** Strips comments, then walks top-level rules into [selector, declarations]. */
 function parseRules(css) {
   const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -110,29 +162,39 @@ function parseRules(css) {
   while (i < clean.length) {
     const open = clean.indexOf('{', i);
     if (open === -1) break;
-    const selector = clean.slice(i, open).trim().replace(/\s+/g, ' ');
+    // Everything after the last `;` is this block's own prelude. Without the
+    // split, a statement at-rule ahead of it (`@source ...;`,
+    // `@custom-variant ...;`) is swallowed into the selector and `@theme` is
+    // read as `@source` — which is how theme.css stayed unparsed.
+    const selector = clean
+      .slice(i, open)
+      .split(';')
+      .pop()
+      .trim()
+      .replace(/\s+/g, ' ');
 
-    // Skip at-rules (@media, @import) wholesale: they nest, and nothing in the
-    // token contract declares a value inside one that is not also declared out.
     if (selector.startsWith('@')) {
-      let depth = 1;
-      let j = open + 1;
-      while (j < clean.length && depth > 0) {
-        if (clean[j] === '{') depth++;
-        else if (clean[j] === '}') depth--;
-        j++;
+      const end = closingBrace(clean, open);
+      if (end === -1) break;
+
+      // `@theme` and `@theme inline` are read as `:root`, because that is what
+      // Tailwind v4 compiles them to. Since #441 they are the ONLY declaration
+      // site for 36 contract tokens — the type scale, radii, easings, leading,
+      // tracking and font families — so skipping them means shipping those 36
+      // unchecked. Every other at-rule (@media, @import, @source, @layer,
+      // @utility, @custom-variant) is still skipped: none of them declares a
+      // contract token that is not also declared at the top level.
+      if (/^@theme\b/.test(selector)) {
+        const vars = declarationsIn(clean.slice(open + 1, end));
+        if (Object.keys(vars).length) rules.push([':root', vars]);
       }
-      i = j;
+      i = end + 1;
       continue;
     }
 
     const close = clean.indexOf('}', open);
     if (close === -1) break;
-    const vars = {};
-    for (const line of clean.slice(open + 1, close).split('\n')) {
-      const m = line.match(/^\s*(--[\w-]+)\s*:\s*([^;]+);/);
-      if (m) vars[m[1]] = m[2].trim().replace(/\s+/g, ' ');
-    }
+    const vars = declarationsIn(clean.slice(open + 1, close));
     if (Object.keys(vars).length) rules.push([selector, vars]);
     i = close + 1;
   }


### PR DESCRIPTION
Closes #451

`check-design-system.mjs` read only `primitives.css`, `tokens.css` and `components.css`, and
`parseRules` skipped every at-rule wholesale. Since #441 moved the Layer 1 primitives into the
`@theme` block of `theme.css`, 36 contract tokens — the type scale, radii, easings, leading,
tracking and font families — were outside the comparison, and the blocking
`frontend-design-system` job has failed on `master` ever since, on tokens it was never actually
checking.

## What changed

One file, `frontend/scripts/check-design-system.mjs` (+77/-15).

- **`theme.css` added to `PRODUCT`, first in the list.** Order there is cascade order, because
  `scopesOf()` merges later-wins. `theme.css`'s `@theme` blocks compile into Tailwind's
  `@layer theme`; the other three are imported with `layer(base)` in `src/index.css` and
  outrank it. First in the array makes the script resolve a doubly-declared token to the same
  value the browser resolves it to.
- **`@theme` and `@theme inline` are read as `:root`**, which is what v4 compiles them to.
  `@media`, `@import`, `@source`, `@layer`, `@utility` and `@custom-variant` keep being skipped.
- **The selector is now the text after the last `;` of the prelude.** This is why simply adding
  the file to `PRODUCT` does not work: `@source '../../e2e';` and `@custom-variant ...;` sit
  above `@theme` with no braces of their own, so the old slice produced
  `"@source '../../e2e'; @custom-variant dark (...); @theme"` — a selector starting with
  `@source`. `@theme` was never matched, and the first attempt still reported all 36 MISSING.
- **`declarationsIn()` and `closingBrace()` extracted.** `declarationsIn` tracks depth and
  ignores nested blocks, so an at-rule body can never leak a nested rule's variables into `:root`.
- **The stale comment is corrected** rather than left to mislead (criterion 5).

`--display-1..4` and `--lead` are recorded in `RENAMED` → `--text-display-1..4` / `--text-lead`.
Values are byte-identical to canonical and are still compared; only the names differ. In v4 a
font size emits its utility only if it is named `--text-*`, so `--display-1` under the canonical
name is inert — no `text-display-1` class is generated at all. Same namespace rule as the
existing `--text-primary` → `--fg-primary` entries, pointing the other way. This is a rename,
not an exclusion.

## Verification

All run in `frontend/`.

```
$ npm run check:design-system
274 canonical tokens checked, 15 renamed, 6 deliberate divergence(s), 0 drifting.
Product tokens are in sync with the canonical design system.
$ echo $?
0

$ npm run check:tokens          # both steps of the frontend-design-system job
274 canonical tokens checked, 15 renamed, 6 deliberate divergence(s), 0 drifting.
164 pairs checked, 0 failing.
All token pairs meet their WCAG target in both themes.
exit 0

$ grep -c '^\s*--[a-z0-9-]*\s*:' design-system/openrisk.tokens.css
274                              # == `checked`. No token quietly skipped.

$ npx eslint scripts/check-design-system.mjs; echo $?
0
```

### Criterion 4 — the negative test

Three of the 36, one per category, each edit reverted with `git checkout` afterwards.

```
# --radius-md: 10px -> 12px in src/styles/theme.css
DRIFT    --radius-md  in  :root
  canonical: --radius-md: 10px
  product:   12px
274 canonical tokens checked, 15 renamed, 6 deliberate divergence(s), 1 drifting.
Design-system check FAILED.
exit 1

# --ease-out -> linear
DRIFT    --ease-out  in  :root
  canonical: --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1)
  product:   linear

# --font-mono -> Comic Sans MS
DRIFT    --font-mono  in  :root
  canonical: --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', monospace
  product:   Comic Sans MS
```

Working tree is clean after the reverts; the diff in this PR is the script only.

### Criterion 3 — at-rule scoping

No `@media` exists in any of the four product stylesheets
(`grep -c '@media' src/styles/*.css` → `0,0,0,0`), so this is proven on a synthetic sheet:

```
input:  @import; @source; @custom-variant; @theme{--a}; @theme inline{--b};
        @media{:root{--should-not-appear}}; @layer utilities{.x{--also-not}};
        @utility z-base{...}; :root{--c}; :root[data-theme='light']{--d}

output: [[":root",{"--a":"1px"}], [":root",{"--b":"2px"}],
         [":root",{"--c":"3px"}], [":root[data-theme='light']",{"--d":"4px"}]]
```

Both `@theme` forms map to `:root`; `--should-not-appear` and `--also-not` never enter it.

## Honest remainders

- **No test file guards the parser.** The synthetic fixture above was run ad hoc, not committed.
  `frontend/scripts/` has no test harness today, so adding one is a larger change than this
  P1 fix should carry. Worth its own issue if you want the gate's own parser gated.
- **Criterion 3's `@media` case is synthetic, not real.** Nothing in the four product
  stylesheets exercises it. It is proven, but on a fixture rather than on shipped CSS.
- **`npx prettier --check` warns on this file — it also warns on `master`'s version.** Prettier
  is not a devDependency and no workflow runs it, so this is pre-existing and not a gate.
- **The `RENAMED` addition is the one judgement call.** If you would rather
  opendefender-website adopt the `--text-*` names upstream in the canonical file, these five
  entries get deleted and the check keeps passing. That is a separate issue, not this one.
- **CI itself is unverified from here** — the job is asserted green by running both of its steps
  locally on Node, not by a run on GitHub. Confirm on the PR checks.
