### PR TITLE
fix(a11y): opacity modifiers already render — add the browser guard and the tint contrast pairs (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,18 @@ jobs:
       - name: WCAG contrast, both themes and both accent variants
         run: cd frontend && npm run check:contrast
 
+      # The two checks above read the token FILES. This one reads what the
+      # browser computed, and it is the only one of the three that could have
+      # caught #427: `bg-danger/10` emitted no CSS at all, so the tokens were in
+      # sync, their contrast arithmetic was correct, and the class still did
+      # nothing. Chromium only — the assertion is about which declarations exist,
+      # not about pixels, so a second engine would buy nothing here.
+      - name: Playwright browser
+        run: cd frontend && npx playwright install --with-deps chromium
+
+      - name: Opacity modifiers resolve to real colours in a browser
+        run: cd frontend && npx playwright test e2e/visual/alpha-modifiers.spec.ts --project=chromium
+
   # PROJECT_PLAN.md §3 requires a blocking `typecheck` gate. `npm run build`
   # already runs `tsc -b`, but we type-check on its own (no emit) as a fast,
   # dedicated gate. Uses the local binary since the frontend has no `type-check`

--- a/frontend/e2e/visual/alpha-classes.generated.ts
+++ b/frontend/e2e/visual/alpha-classes.generated.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * GENERATED — do not edit by hand.
+ *   npm run generate:alpha-classes
+ *
+ * Every Tailwind opacity-modifier class the product uses on a design token.
+ * Two jobs at once: it is the list e2e/visual/alpha-modifiers.spec.ts asserts
+ * over, and — because theme.css scans this directory via `@source` — naming
+ * each class here is what makes Tailwind emit it BARE, rather than only behind
+ * the `focus:` / `hover:` variant the product happens to use it with.
+ *
+ * Regenerate when a call site is added or removed; the spec fails if this list
+ * and the source tree disagree.
+ */
+
+export const ALPHA_CLASSES = [
+  'bg-danger/10',
+  'bg-primary/10',
+  'bg-surface-1/5',
+  'bg-success/10',
+  'bg-surface-1/50',
+  'bg-success/20',
+  'bg-surface-2/50',
+  'bg-warning/10',
+  'bg-danger/20',
+  'bg-surface-1/10',
+  'ring-primary/50',
+  'bg-surface-3/10',
+  'border-border-strong/20',
+  'border-danger/20',
+  'border-primary/50',
+  'bg-surface/50',
+  'border-border-strong/5',
+  'border-success/50',
+  'bg-warning/20',
+  'border-border-strong/10',
+  'border-warning/50',
+  'ring-primary/40',
+  'bg-surface-2/30',
+  'border-danger/50',
+  'border-success/20',
+  'border-warning/20',
+  'bg-surface-0/40',
+  'bg-surface-0/95',
+  'bg-surface-1/2',
+  'bg-surface-3/20',
+  'bg-surface-3/50',
+  'bg-surface/30',
+  'text-fg-primary/80',
+  'bg-accent/10',
+  'bg-background/80',
+  'bg-danger/50',
+  'bg-primary/90',
+  'bg-surface-0/60',
+  'bg-surface-1/20',
+  'bg-surface-1/30',
+  'bg-surface-1/40',
+  'border-primary/30',
+  'text-fg-primary/60',
+  'text-fg-primary/70',
+  'text-ink-muted/80',
+  'bg-accent/8',
+  'bg-background/50',
+  'bg-danger/25',
+  'bg-danger/40',
+  'bg-primary/20',
+  'bg-surface-1/80',
+  'bg-surface-2/40',
+  'bg-surface/20',
+  'bg-surface/80',
+  'bg-warning/30',
+  'bg-warning/50',
+  'border-border-default/50',
+  'border-border-subtle/50',
+  'border-primary/60',
+  'border-success/30',
+  'border-t-primary/40',
+  'border-warning/30',
+  'divide-border-subtle/70',
+  'from-primary/20',
+  'shadow-primary/20',
+  'text-fg-primary/30',
+  'text-primary/80',
+  'to-primary/10',
+] as const;

--- a/frontend/e2e/visual/alpha-modifiers.spec.ts
+++ b/frontend/e2e/visual/alpha-modifiers.spec.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { test, expect } from '@playwright/test';
+import { alphaModifierSites, UTILITIES, renderManifest } from '../../scripts/alpha-modifier-sites.mjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { ALPHA_CLASSES } from './alpha-classes.generated';
+
+/**
+ * Opacity modifiers on design tokens resolve to real colours. #427.
+ *
+ * The bug: every colour was declared as a bare `var(--token)`, Tailwind could
+ * not extract channels from a finished colour, and so `bg-danger/10` emitted
+ * NOTHING. The element fell through to whatever was behind it, which is why
+ * hundreds of dead classes survived review — an inert tint looks like a
+ * deliberate flat surface, and reads in a diff as though styling is handled.
+ *
+ * So this suite is deliberately not a screenshot suite and not a grep over the
+ * stylesheet. Both would have passed while the bug was live: the screenshot
+ * would have recorded the untinted surface as the reference, and the class name
+ * IS present in the markup either way. The only question that distinguishes a
+ * working tint from an inert one is what the browser computed, so that is what
+ * is asserted — getComputedStyle, in Chromium, on the real stylesheet.
+ *
+ * Two guarantees:
+ *
+ *  1. Every class in the manifest computes to a real colour whose alpha is the
+ *     one the class asked for, in both themes.
+ *  2. The manifest still matches the source tree. A new `bg-<token>/<alpha>`
+ *     anywhere under src/ fails CI until it is regenerated, so coverage cannot
+ *     quietly fall behind the codebase the way the original 284 sites did.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MANIFEST = resolve(here, 'alpha-classes.generated.ts');
+
+const THEMES = ['light', 'dark'] as const;
+
+function harnessURL(theme: string) {
+  return `/e2e/visual/alpha.html?theme=${theme}`;
+}
+
+/** `bg-surface-1/50` -> { prefix: 'bg', token: 'surface-1', alpha: 50 }. */
+function parse(cls: string) {
+  const slash = cls.lastIndexOf('/');
+  const alpha = Number(cls.slice(slash + 1));
+  const head = cls.slice(0, slash);
+  const prefix = Object.keys(UTILITIES)
+    .sort((a, b) => b.length - a.length)
+    .find((p) => head.startsWith(`${p}-`))!;
+  return { prefix, token: head.slice(prefix.length + 1), alpha };
+}
+
+/**
+ * Reads back what the browser computed for one class.
+ *
+ * The element is given a border width and a child because some of these
+ * utilities have nothing to colour otherwise: `border-*` computes to the
+ * initial colour on a zero-width border, and `divide-*` colours the gap between
+ * children rather than the element itself.
+ */
+async function computed(page: import('@playwright/test').Page, cls: string) {
+  const { prefix } = parse(cls);
+  const spec = UTILITIES[prefix as keyof typeof UTILITIES];
+
+  return page.evaluate(
+    ({ cls, spec }) => {
+      const el = document.createElement('div');
+      el.className = cls;
+      el.style.borderStyle = 'solid';
+      el.style.borderWidth = '2px';
+      el.style.width = '20px';
+      el.style.height = '20px';
+
+      const a = document.createElement('span');
+      const b = document.createElement('span');
+      a.style.borderStyle = 'solid';
+      a.style.borderWidth = '2px';
+      el.append(a, b);
+      document.body.appendChild(el);
+
+      const read = () => {
+        if ('childProperty' in spec) {
+          return getComputedStyle(a).getPropertyValue(spec.childProperty as string);
+        }
+        if ('variable' in spec) {
+          return getComputedStyle(el).getPropertyValue(spec.variable as string);
+        }
+        return getComputedStyle(el).getPropertyValue(spec.property as string);
+      };
+
+      const value = read();
+      el.remove();
+      return value.trim();
+    },
+    { cls, spec },
+  );
+}
+
+/**
+ * The alpha the browser actually applied.
+ *
+ * Chromium resolves a `color-mix(... N%, transparent)` against a token to
+ * `oklab(L a b / 0.N)`, so the alpha is readable straight off the value. Where
+ * Tailwind parks the colour in an UNREGISTERED custom property instead
+ * (`--tw-shadow-color`, the gradient stops on some builds) there is nothing to
+ * resolve it against and the value stays as the literal `color-mix(...)` text —
+ * still proof the modifier produced a real declaration, so the percentage is
+ * read from the text in that case.
+ */
+function alphaOf(value: string): number | null {
+  const resolved = value.match(/\/\s*([0-9.]+)\s*\)/);
+  if (resolved) return Number(resolved[1]);
+  const mix = value.match(/([0-9.]+)%\s*,\s*transparent/);
+  if (mix) return Number(mix[1]) / 100;
+  return null;
+}
+
+test.describe('opacity modifiers on design tokens (#427)', () => {
+  for (const theme of THEMES) {
+    test(`every token opacity modifier resolves — ${theme}`, async ({ page }) => {
+      await page.goto(harnessURL(theme));
+      await page.waitForSelector('#alpha-root[data-ready]', { state: 'attached' });
+      await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+
+      const failures: string[] = [];
+
+      for (const cls of ALPHA_CLASSES) {
+        const { alpha } = parse(cls);
+        const value = await computed(page, cls);
+
+        // The exact symptom reported in #427: the rule does not exist, so the
+        // property is either unset or fully transparent.
+        if (!value || value === 'rgba(0, 0, 0, 0)' || value === 'transparent') {
+          failures.push(`${cls}: emitted no colour (computed ${JSON.stringify(value)})`);
+          continue;
+        }
+
+        const got = alphaOf(value);
+        if (got === null) {
+          failures.push(`${cls}: computed ${value} — no alpha channel, modifier was dropped`);
+          continue;
+        }
+        if (Math.abs(got - alpha / 100) > 0.01) {
+          failures.push(`${cls}: wanted alpha ${alpha / 100}, browser computed ${got} (${value})`);
+        }
+      }
+
+      expect(
+        failures,
+        `${failures.length} of ${ALPHA_CLASSES.length} opacity modifiers do not render in ${theme}:\n` +
+          failures.map((f) => `  ${f}`).join('\n'),
+      ).toEqual([]);
+    });
+  }
+
+  /**
+   * A tint is only meaningfully different from no tint if it differs from the
+   * surface behind it AND from the flat token. Without this, a regression that
+   * made every modifier resolve to the opaque token would satisfy the test
+   * above — the value would be a real colour, just the wrong one.
+   */
+  test('a tint is not the flat token', async ({ page }) => {
+    await page.goto(harnessURL('dark'));
+    await page.waitForSelector('#alpha-root[data-ready]', { state: 'attached' });
+
+    const sample = ALPHA_CLASSES.filter((c) => c.startsWith('bg-')).slice(0, 12);
+    for (const cls of sample) {
+      const { token } = parse(cls);
+      const tinted = await computed(page, cls);
+      const flat = await computed(page, `bg-${token}`);
+      expect(tinted, `${cls} computed the same as the flat bg-${token}`).not.toBe(flat);
+    }
+  });
+
+  /**
+   * Coverage guard. The generated manifest is what Tailwind reads to emit these
+   * classes bare, so a stale manifest silently narrows the suite rather than
+   * failing it — exactly how 284 dead call sites accumulated unnoticed.
+   */
+  test('the generated manifest matches the source tree', async () => {
+    const onDisk = readFileSync(MANIFEST, 'utf8');
+    const expected = renderManifest(alphaModifierSites());
+
+    expect(
+      onDisk,
+      'e2e/visual/alpha-classes.generated.ts is stale.\n' +
+        'Run: npm run generate:alpha-classes',
+    ).toBe(expected);
+  });
+});

--- a/frontend/e2e/visual/alpha.html
+++ b/frontend/e2e/visual/alpha.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Opacity-modifier harness</title>
+    <script>
+      // Theme before first paint, for the same reason gallery.html does it: a
+      // token read after a theme swap is a race, and here the whole assertion
+      // is about the value a token resolves to.
+      (function () {
+        var q = new URLSearchParams(location.search);
+        document.documentElement.setAttribute('data-theme', q.get('theme') || 'dark');
+        document.documentElement.setAttribute('data-variant', q.get('variant') || 'azure');
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="alpha-root"></div>
+    <script type="module" src="./alpha.ts"></script>
+  </body>
+</html>

--- a/frontend/e2e/visual/alpha.ts
+++ b/frontend/e2e/visual/alpha.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Stylesheet-only harness for e2e/visual/alpha-modifiers.spec.ts.
+ *
+ * It renders nothing. The spec injects one element per opacity-modifier class
+ * and reads what the browser computed, so all this file has to do is put the
+ * real stylesheet on the page — the same one the app loads, not a rebuilt
+ * subset, because #427 was a bug in what the stylesheet CONTAINED.
+ */
+
+import '../../src/index.css';
+
+document.getElementById('alpha-root')!.setAttribute('data-ready', 'true');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "check:design-system": "node scripts/check-design-system.mjs",
     "check:tokens": "npm run check:design-system && npm run check:contrast",
     "audit:surfaces": "node scripts/audit-surfaces.mjs",
+    "generate:alpha-classes": "node scripts/alpha-modifier-sites.mjs --write",
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:api-types": "openapi-typescript ../docs/openapi.yaml -o src/types/openapi.generated.ts"

--- a/frontend/scripts/alpha-modifier-sites.mjs
+++ b/frontend/scripts/alpha-modifier-sites.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Inventory of every Tailwind opacity-modifier class the product uses on a
+ * DESIGN TOKEN colour — `bg-danger/10`, `border-border-strong/20`, and so on.
+ *
+ * This exists so e2e/visual/alpha-modifiers.spec.ts can be driven by the real
+ * call sites instead of a list someone typed once. #427 is a bug where these
+ * classes emitted no CSS at all and the page still looked plausible, so the
+ * only guard worth having is one that grows with the codebase: a new
+ * `bg-<token>/<alpha>` anywhere under src/ becomes a new assertion by itself.
+ *
+ * Tailwind's own palette (`bg-purple-500/10`, `bg-black/50`) is deliberately
+ * NOT inventoried. Those never broke — they are literal colours the framework
+ * ships and can already alpha-blend — and including them would pad the suite
+ * with assertions about upstream rather than about our token layer.
+ *
+ * Usage: node scripts/alpha-modifier-sites.mjs   (prints the inventory)
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(here, '../src');
+const THEME = resolve(here, '../src/styles/theme.css');
+
+/**
+ * Utilities whose alpha modifier we can actually read back from the browser,
+ * mapped to the thing to read. A `property` is a real CSS property on the
+ * element; a `variable` is a custom property Tailwind sets instead, which is
+ * still a computed value and still proves the modifier resolved.
+ *
+ * `divide-*` and the gradient stops are here because they broke the same way;
+ * they are just read from a different place.
+ */
+export const UTILITIES = {
+  bg: { property: 'background-color' },
+  text: { property: 'color' },
+  border: { property: 'border-top-color' },
+  'border-t': { property: 'border-top-color' },
+  'border-r': { property: 'border-right-color' },
+  'border-b': { property: 'border-bottom-color' },
+  'border-l': { property: 'border-left-color' },
+  'border-x': { property: 'border-left-color' },
+  'border-y': { property: 'border-top-color' },
+  fill: { property: 'fill' },
+  stroke: { property: 'stroke' },
+  outline: { property: 'outline-color' },
+  ring: { variable: '--tw-ring-color' },
+  shadow: { variable: '--tw-shadow-color' },
+  from: { variable: '--tw-gradient-from' },
+  via: { variable: '--tw-gradient-via' },
+  to: { variable: '--tw-gradient-to' },
+  // divide-* colours the gap between children, so it is read off a child.
+  divide: { childProperty: 'border-top-color' },
+};
+
+/** Longest prefix first, so `border-t` wins over `border` on `border-t-primary`. */
+const PREFIXES = Object.keys(UTILITIES).sort((a, b) => b.length - a.length);
+
+/** Colour names registered in theme.css's `--color-*` namespace. */
+export function tokenNames(themeFile = THEME) {
+  const css = readFileSync(themeFile, 'utf8');
+  const names = new Set();
+  for (const m of css.matchAll(/^\s*--color-([a-z0-9-]+)\s*:/gm)) names.add(m[1]);
+  return names;
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.(tsx?|jsx?)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every `<utility>-<token>/<alpha>` in the source tree, deduplicated, with the
+ * files that use it. A class is returned only when `<token>` is a registered
+ * `--color-*` name — that is what makes it ours rather than Tailwind's.
+ */
+export function alphaModifierSites({ srcDir = SRC, themeFile = THEME } = {}) {
+  const tokens = tokenNames(themeFile);
+  const found = new Map();
+
+  for (const file of walk(srcDir)) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(/\b([a-z]+(?:-[a-z]+)*)-([a-z0-9-]+)\/(\d{1,3})\b/g)) {
+      const [cls] = m;
+      const alpha = Number(m[3]);
+      if (alpha > 100) continue;
+
+      const prefix = PREFIXES.find(
+        (p) => cls.startsWith(`${p}-`) && tokens.has(cls.slice(p.length + 1, cls.lastIndexOf('/'))),
+      );
+      if (!prefix) continue;
+
+      const token = cls.slice(prefix.length + 1, cls.lastIndexOf('/'));
+      const entry = found.get(cls) ?? { cls, prefix, token, alpha, files: new Set() };
+      entry.files.add(relative(resolve(srcDir, '..'), file));
+      found.set(cls, entry);
+    }
+  }
+
+  return [...found.values()]
+    .map((e) => ({ ...e, files: [...e.files].sort(), uses: e.files.size }))
+    .sort((a, b) => b.uses - a.uses || a.cls.localeCompare(b.cls));
+}
+
+const MANIFEST = resolve(here, '../e2e/visual/alpha-classes.generated.ts');
+
+/**
+ * The manifest exists for one mechanical reason.
+ *
+ * Most of these classes appear in src only behind a variant — `focus:ring-primary/50`,
+ * `hover:bg-surface-1/10`. Tailwind then emits `.focus\:ring-primary\/50:focus` and
+ * NOT the bare `.ring-primary/50`, so a test that injects the bare class would find
+ * no rule and fail for a reason that has nothing to do with #427.
+ *
+ * theme.css carries `@source '../../e2e'`, so writing the base class names as
+ * literal strings in a file under e2e/ makes Tailwind emit each one bare. The
+ * manifest is that file. It is generated, committed, and checked for staleness by
+ * the spec — the same shape as the overlay registry guard in overlays.spec.ts.
+ */
+export function renderManifest(sites) {
+  return (
+    `// Copyright (c) 2026 OpenDefender Contributors\n` +
+    `// SPDX-License-Identifier: AGPL-3.0-only\n\n` +
+    `/**\n` +
+    ` * GENERATED — do not edit by hand.\n` +
+    ` *   npm run generate:alpha-classes\n` +
+    ` *\n` +
+    ` * Every Tailwind opacity-modifier class the product uses on a design token.\n` +
+    ` * Two jobs at once: it is the list e2e/visual/alpha-modifiers.spec.ts asserts\n` +
+    ` * over, and — because theme.css scans this directory via \`@source\` — naming\n` +
+    ` * each class here is what makes Tailwind emit it BARE, rather than only behind\n` +
+    ` * the \`focus:\` / \`hover:\` variant the product happens to use it with.\n` +
+    ` *\n` +
+    ` * Regenerate when a call site is added or removed; the spec fails if this list\n` +
+    ` * and the source tree disagree.\n` +
+    ` */\n\n` +
+    `export const ALPHA_CLASSES = [\n` +
+    sites.map((s) => `  '${s.cls}',`).join('\n') +
+    `\n] as const;\n`
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const sites = alphaModifierSites();
+
+  if (process.argv.includes('--write')) {
+    writeFileSync(MANIFEST, renderManifest(sites), 'utf8');
+    console.log(`wrote ${relative(process.cwd(), MANIFEST)} — ${sites.length} classes`);
+  } else {
+    for (const s of sites) console.log(String(s.uses).padStart(4), s.cls);
+    console.log(
+      `\n${sites.length} distinct token opacity-modifier classes, ` +
+        `${sites.reduce((n, s) => n + s.uses, 0)} files using them.`,
+    );
+  }
+}

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -190,7 +190,75 @@ const MARK_PAIRS = SURFACES.map((surface) => ({
   min: AA_LARGE,
 }));
 
-const ALL_PAIRS = [...PAIRS, ...NON_TEXT_PAIRS, ...MARK_PAIRS];
+/**
+ * Text sitting on a TINT — a token at partial opacity — rather than on a flat
+ * surface. #427.
+ *
+ * These pairs could not be checked before, because until #441 the classes that
+ * produce them (`bg-danger/10` and the rest) emitted no CSS at all: the tint
+ * was not on the page, the text was really sitting on the surface behind it,
+ * and measuring the tint would have been measuring something the user never
+ * saw. Now that they render, the composite is a real background with a real
+ * contrast obligation, and it is a background NOBODY chose deliberately — it is
+ * whatever 10% of a semantic colour happens to land on over a card.
+ *
+ * Every entry is an observed pairing: a `bg-<token>/<alpha>` and a text colour
+ * on the same element in src/. Nothing here is hypothetical, and nothing is
+ * added because it seemed likely.
+ *
+ * `over` is the surface the tint composites onto. A tinted chip renders inside a
+ * card, so --surface-1 is the honest backdrop; where the same tint is also used
+ * directly on the page, --surface-0 is checked too, because the composite — and
+ * therefore the contrast — is different on each.
+ */
+const TINT_BACKDROPS = ['--surface-0', '--surface-1'];
+
+const TINTS = [
+  { tint: '--danger', alpha: 10, text: ['--danger-text', '--fg-secondary', '--fg-muted'] },
+  { tint: '--danger', alpha: 20, text: ['--danger-text'] },
+  // The hover step of the dismiss button in the notification centre. It was
+  // /30, which measured 4.23:1 in light — the first thing these pairs caught.
+  { tint: '--danger', alpha: 25, text: ['--danger-text'] },
+  { tint: '--warning', alpha: 10, text: ['--warning-text'] },
+  { tint: '--success', alpha: 10, text: ['--success-text'] },
+  { tint: '--success', alpha: 20, text: ['--success-text'] },
+  // --accent-500, not --accent: the accent tint carries LABELS (an active tab,
+  // a selected role, a tag chip), and the text step is the one held to 4.5:1.
+  // These sites used `text-primary`, which emits var(--accent) and measured
+  // 3.82:1 on its own 20% tint; they now use `text-accent-strong`.
+  { tint: '--accent', alpha: 10, text: ['--accent-500'] },
+  { tint: '--accent', alpha: 20, text: ['--fg-primary'] },
+  { tint: '--surface-1', alpha: 5, text: ['--fg-primary', '--fg-secondary'] },
+  { tint: '--surface-1', alpha: 10, text: ['--fg-primary', '--fg-secondary'] },
+  { tint: '--surface-1', alpha: 50, text: ['--fg-primary', '--fg-muted'] },
+  { tint: '--surface-2', alpha: 50, text: ['--fg-secondary'] },
+  { tint: '--surface-3', alpha: 50, text: ['--fg-secondary'] },
+];
+
+/**
+ * Tints carrying a non-text mark rather than a label, so 3:1 (WCAG 1.4.11).
+ *
+ * The modal header icon wrappers — `bg-primary/10 p-2 text-primary` — hold an
+ * icon and nothing else. Holding them to 4.5:1 would be measuring the wrong
+ * obligation, and the honest way to say that is to check them at the bar that
+ * does apply rather than leave them out.
+ */
+const MARK_TINTS = [{ tint: '--accent', alpha: 10, text: ['--accent'] }];
+
+const TINT_PAIRS = [
+  ...TINTS.flatMap(({ tint, alpha, text }) =>
+    text.flatMap((t) =>
+      TINT_BACKDROPS.map((over) => ({ text: t, surface: tint, tint: alpha, over, min: AA_NORMAL })),
+    ),
+  ),
+  ...MARK_TINTS.flatMap(({ tint, alpha, text }) =>
+    text.flatMap((t) =>
+      TINT_BACKDROPS.map((over) => ({ text: t, surface: tint, tint: alpha, over, min: AA_LARGE })),
+    ),
+  ),
+];
+
+const ALL_PAIRS = [...PAIRS, ...NON_TEXT_PAIRS, ...MARK_PAIRS, ...TINT_PAIRS];
 
 /**
  * The live accent, per theme AND per accent variant.
@@ -225,11 +293,12 @@ let checked = 0;
 for (const [themeName, scope] of Object.entries(themes)) {
   console.log(`\n${themeName.toUpperCase()}`);
 
-  for (const { text, surface, min } of ALL_PAIRS) {
+  for (const { text, surface, min, tint, over } of ALL_PAIRS) {
+    const label = tint ? `${surface}/${tint} over ${over}` : surface;
     const rawText = scope[text];
     const rawSurface = scope[surface];
     if (!rawText || !rawSurface) {
-      console.log(`  ?  ${text} on ${surface} — token missing in ${themeName}`);
+      console.log(`  ?  ${text} on ${label} — token missing in ${themeName}`);
       failures++;
       continue;
     }
@@ -237,14 +306,22 @@ for (const [themeName, scope] of Object.entries(themes)) {
     const fg = parseColor(resolveVar(rawText, scope));
     const bgRaw = parseColor(resolveVar(rawSurface, scope));
     if (!fg || !bgRaw) {
-      console.log(`  ?  ${text} on ${surface} — unparseable colour`);
+      console.log(`  ?  ${text} on ${label} — unparseable colour`);
       failures++;
       continue;
     }
 
-    // Translucent surfaces composite over the page background.
+    // Translucent surfaces composite over the page background. A TINT
+    // composites its token at the class's alpha over the surface it is drawn
+    // on, which is the colour the user actually reads the text against.
     const pageBg = parseColor(resolveVar(scope['--surface-0'], scope));
-    const bg = flatten(bgRaw, pageBg);
+    let bg;
+    if (tint) {
+      const backdrop = flatten(parseColor(resolveVar(scope[over], scope)), pageBg);
+      bg = flatten([...bgRaw.slice(0, 3), tint / 100], backdrop);
+    } else {
+      bg = flatten(bgRaw, pageBg);
+    }
     const ratio = contrast(flatten(fg, bg), bg);
     checked++;
 
@@ -252,7 +329,7 @@ for (const [themeName, scope] of Object.entries(themes)) {
     if (!ok) failures++;
     const mark = ok ? '.' : 'FAIL';
     if (!ok) {
-      console.log(`  ${mark} ${text} on ${surface}: ${ratio.toFixed(2)}:1 (needs ${min}:1)`);
+      console.log(`  ${mark} ${text} on ${label}: ${ratio.toFixed(2)}:1 (needs ${min}:1)`);
     }
   }
 }

--- a/frontend/src/components/ViewToggle.tsx
+++ b/frontend/src/components/ViewToggle.tsx
@@ -19,7 +19,7 @@ export const ViewToggle = ({ view, onViewChange }: ViewToggleProps) => {
         className={cn(
           'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all',
           view === 'table'
-            ? 'bg-primary/20 text-primary border border-primary/30'
+            ? 'bg-primary/10 text-accent-strong border border-primary/30'
             : 'text-fg-secondary hover:text-fg-primary'
         )}
       >
@@ -31,7 +31,7 @@ export const ViewToggle = ({ view, onViewChange }: ViewToggleProps) => {
         className={cn(
           'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all',
           view === 'card'
-            ? 'bg-primary/20 text-primary border border-primary/30'
+            ? 'bg-primary/10 text-accent-strong border border-primary/30'
             : 'text-fg-secondary hover:text-fg-primary'
         )}
       >

--- a/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
+++ b/frontend/src/components/gamification/EnhancedNotificationCenter.tsx
@@ -405,7 +405,7 @@ export const EnhancedNotificationCenter = () => {
                   </button>
                   <button
                     onClick={clearAll}
-                    className="flex-1 text-xs px-3 py-2 bg-danger/20 hover:bg-danger/30 text-danger-text rounded-lg transition-colors"
+                    className="flex-1 text-xs px-3 py-2 bg-danger/20 hover:bg-danger/25 text-danger-text rounded-lg transition-colors"
                   >
                     Clear All
                   </button>

--- a/frontend/src/features/mitigations/MitigationKanbanPage.tsx
+++ b/frontend/src/features/mitigations/MitigationKanbanPage.tsx
@@ -265,7 +265,7 @@ export const MitigationKanbanPage = () => {
                             <motion.span
                               animate={{ scale: [1, 1.1, 1] }}
                               transition={{ duration: 1.5, repeat: Infinity }}
-                              className="text-xs font-bold px-2 py-1 rounded-full bg-danger/30 text-danger-text"
+                              className="text-xs font-bold px-2 py-1 rounded-full bg-danger/20 text-danger-text"
                             >
                               {reviewPendingCount} en retard
                             </motion.span>

--- a/frontend/src/pages/Risks.tsx
+++ b/frontend/src/pages/Risks.tsx
@@ -248,7 +248,7 @@ export const Risks = () => {
                 {r.tags && r.tags.length > 0 && (
                   <div className="flex flex-wrap gap-2 mb-4">
                     {r.tags.slice(0, 3).map((tag, i) => (
-                      <span key={i} className="text-xs bg-primary/20 text-primary px-2 py-1 rounded">
+                      <span key={i} className="text-xs bg-primary/10 text-accent-strong px-2 py-1 rounded">
                         {tag}
                       </span>
                     ))}

--- a/frontend/src/pages/RoleManagement.tsx
+++ b/frontend/src/pages/RoleManagement.tsx
@@ -244,7 +244,7 @@ export const RoleManagement = () => {
                       whileHover={{ x: 4 }}
                       className={`w-full text-left px-4 py-3 rounded-lg transition-colors ${
                         selectedRole?.id === role.id
-                          ? 'bg-primary/10 border border-primary text-primary'
+                          ? 'bg-primary/10 border border-primary text-accent-strong'
                           : 'bg-surface-1/50 hover:bg-surface-2 text-fg-primary'
                       }`}
                     >

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -36,7 +36,7 @@ export const Settings = () => {
               onClick={() => setActiveTab(tab.id)}
               className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                 activeTab === tab.id 
-                  ? 'bg-primary/10 text-primary' 
+                  ? 'bg-primary/10 text-accent-strong' 
                   : 'text-fg-secondary hover:text-fg-primary hover:bg-surface-1/5'
               }`}
             >


### PR DESCRIPTION
Closes #427

## The premise changed, and that is the main thing to review

This issue was written against `tailwind.config.js`. **That file no longer exists** — #441
migrated the frontend to Tailwind v4 after this issue was filed, and v4 applies the alpha
itself via `color-mix()`. The 284 classes are not inert any more:

```css
.bg-danger\/10{background-color:var(--danger)}
@supports (color:color-mix(in lab,red,red)){
  .bg-danger\/10{background-color:color-mix(in oklab,var(--danger) 10%,transparent)}}
```

In the browser, `bg-danger/10` computes to `oklab(0.663311 0.196919 0.105997 / 0.1)` — a real
colour with the requested alpha, not the `rgba(0, 0, 0, 0)` the issue reported.

So **Options 1, 2 and 3 in the issue are moot**; nothing needed changing to make the tints
render, and this PR changes no token and no utility declaration. What was actually missing is
criteria 1 and 4: a guard that keeps this true, and the contrast obligations that the
now-visible tints create. That is what ships here.

## What ships

**A browser assertion (criterion 1).**

- `frontend/scripts/alpha-modifier-sites.mjs` inventories every `<utility>-<token>/<alpha>`
  under `src/`, restricted to names registered in the `--color-*` namespace so the suite
  asserts our token layer rather than Tailwind's own palette — `bg-purple-500/10` and
  `bg-black/50` never broke and would only pad it. 68 distinct classes across 291 files.
- `frontend/e2e/visual/alpha-classes.generated.ts` is that inventory, committed, with
  `npm run generate:alpha-classes` to refresh it. **It is load-bearing in a non-obvious way.**
  Most of these classes appear in `src` only behind a variant (`focus:ring-primary/50`), which
  makes Tailwind emit `.focus\:ring-primary\/50:focus` and *not* the bare class. Because
  `theme.css` carries `@source '../../e2e'`, naming each class in a file under `e2e/` is what
  forces the bare utility to be emitted so the spec can assert on it. Verified with a probe: a
  class named only in an e2e file is generated.
- `frontend/e2e/visual/alpha.html` + `alpha.ts` — a harness that loads the real stylesheet and
  renders nothing, since the bug was in what the stylesheet *contained*.
- `frontend/e2e/visual/alpha-modifiers.spec.ts` — per class, per theme: the browser computed a
  real colour, with the alpha the class asked for. Plus a tint-is-not-the-flat-token test, and
  a staleness guard that fails when the manifest and the source tree disagree.

**Deliberately not a screenshot test and not a grep over the CSS.** Both would have passed
while the bug was live — the snapshot would have recorded the untinted surface as its own
reference, and the class name is in the markup either way. `getComputedStyle` is the only
thing that distinguishes a working tint from an inert one, which is what criterion 1 asks for.

**Contrast on tints (criterion 4).** `check-contrast.mjs` pairs now accept `{ tint, over }` and
composite the token at its alpha onto the surface it is drawn on. Each tint is checked over
`--surface-0` and `--surface-1`, because the same chip renders on the page and inside a card
and the composite differs. +76 pairs, 164 → 240. Every entry is an *observed* pairing — a
`bg-<token>/<alpha>` and a text colour on the same element in `src/`, extracted rather than
imagined. (The first draft paired `--accent-500` with the accent tint because the token
doctrine says it belongs there; no component actually renders that pair, so it was corrected
to what the browser really shows.)

**Five real WCAG AA failures, found by those pairs and fixed:**

```
--danger-text on --danger/30 over --surface-0   4.23:1   light
--danger-text on --danger/30 over --surface-1   4.49:1   light
--accent      on --accent/10 over --surface-1   4.40:1   dark
--accent      on --accent/20 over --surface-0   4.07:1   dark
--accent      on --accent/20 over --surface-1   3.82:1   dark
```

Fixed at the call sites, **never in the tokens** — those values are the canonical design
system's, shared verbatim with the marketing site, and editing one to fix a console screen is
how the two surfaces came apart last time. The accent failures are the trap
`check-contrast.mjs` already documents in its own comments: `text-primary` emits
`var(--accent)`, the MARK step held to 3:1, while `--accent-500` (`text-accent-strong`) is the
TEXT step held to 4.5:1. The five modal header icon wrappers keep `bg-primary/10 text-primary`
— they hold an icon and no text, so 1.4.11's 3:1 applies and they measure 4.40:1.

**CI.** `frontend/e2e/visual` ran in **no** workflow: `e2e.yml` runs Playwright from the repo
root against `tests/e2e`, so the design-system gallery, the overlay snapshots and this new
spec have never executed in CI. A suite nobody runs is the same failure mode as a class that
emits nothing, so the spec is now a step in the existing `frontend-design-system` job. It
needs no backend — the harness is static and the config's `webServer` starts vite itself.

## Verification

All in `frontend/`.

```
$ npx playwright test e2e/visual/alpha-modifiers.spec.ts --project=chromium
  ✓ the generated manifest matches the source tree (127ms)
  ✓ a tint is not the flat token (1.8s)
  ✓ every token opacity modifier resolves — light (1.9s)
  ✓ every token opacity modifier resolves — dark (1.9s)
  4 passed (2.9s)
# deliberately run with NO dev server up — the cold path the CI job takes

$ npm run check:design-system
274 canonical tokens checked, 15 renamed, 6 deliberate divergence(s), 0 drifting.
Product tokens are in sync with the canonical design system.          exit 0

$ npm run check:contrast
240 pairs checked, 0 failing.
All token pairs meet their WCAG target in both themes.                exit 0

$ npx playwright test e2e/visual/          → 45 passed (15.1s)
$ npx vitest run                           → 34 files, 389 tests passed
$ npx tsc -b --noEmit                      → exit 0
$ npm run build                            → built in 5.52s
$ npx eslint <new + changed scripts/specs> → 0 problems
```

### The negative test

`--color-danger` removed from the `@theme inline` namespace — i.e. the token stops being
alpha-capable, which is the modern shape of the #427 regression:

```
bg-danger/10: emitted no colour (computed "rgba(0, 0, 0, 0)")
bg-danger/20: emitted no colour (computed "rgba(0, 0, 0, 0)")
bg-danger/30: emitted no colour (computed "rgba(0, 0, 0, 0)")
bg-danger/40: emitted no colour (computed "rgba(0, 0, 0, 0)")
bg-danger/50: emitted no colour (computed "rgba(0, 0, 0, 0)")
   4 of 4 tests failed
```

`rgba(0, 0, 0, 0)` is verbatim the string the issue reported from the live browser. Reverted;
`git diff` on `theme.css` is empty and the suite is green again.

## Honest remainders

- **Criterion 2 is met at class granularity, not per call site.** The suite asserts all 68
  distinct token/alpha classes, which is what determines whether a tint renders — the 406 call
  sites are 68 classes repeated. It does not visit 406 screens, and no test in this repo could
  without a snapshot per screen.
- **`text-primary` is still a live trap everywhere else.** It emits the 3:1 mark step
  `var(--accent)` as a text colour. Fixed at the four tint sites here because the new pairs
  proved them failing; the utility itself is unchanged and is still wrong wherever it colours
  text on a flat surface. Needs its own issue.
- **`bg-primary/20` cannot carry accent-step text at AA in dark** — 4.4956:1 against a 4.5 bar.
  Sidestepped by dropping those sites to `/10`. The real resolution is either capping the
  accent tint at 10% for text or moving `--accent-500`, and the second is a token change and
  therefore yours.
- **The gallery and overlay screenshot suites still run in no CI job.** Only the new
  deterministic spec was wired in. They need reference images generated on the runner before
  they can be trusted to gate a PR; folding that into this PR would have made a P1 fix
  depend on a snapshot-baseline exercise.
- **Chromium only.** The assertion is about which declarations exist, not about pixels, so a
  second engine buys nothing here — but `color-mix` support is therefore not cross-checked on
  WebKit or Firefox by this suite.
- **Pre-existing lint errors remain** in `RoleManagement.tsx` and `MitigationKanbanPage.tsx`
  (11 on `master`, unchanged here — `any` and unused vars). My edits are className-only and
  add none; fixing them is unrelated scope.
