### PR TITLE
feat(ci): make the design doctrine executable — anti-cliché rule, deny-list, licence boundary (#446)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,15 @@ jobs:
       - name: Opacity modifiers resolve to real colours in a browser
         run: cd frontend && npx playwright test e2e/visual/alpha-modifiers.spec.ts --project=chromium
 
+      # The three-licence boundary (#446). D-014 and D-016 put
+      # frontend/design-system/ and frontend/src/shared/ds/ under Apache-2.0
+      # while the core stays AGPL-3.0-only and the EE is commercial. #443 is
+      # about to vendor ~50 third-party components into shared/ds, and
+      # Apache-2.0 is irreversible once published, so the guarantee worth
+      # automating is that a file cannot land there carrying the core's header.
+      - name: Three-licence boundary is intact
+        run: cd frontend && npm run check:license-boundary
+
   # PROJECT_PLAN.md §3 requires a blocking `typecheck` gate. `npm run build`
   # already runs `tsc -b`, but we type-check on its own (no emit) as a fast,
   # dedicated gate. Uses the local binary since the frontend has no `type-check`
@@ -304,8 +313,8 @@ jobs:
           ls -lah dist/
 
       # Performance budget (task §2) — BLOCKING. Fails the build if the initial
-      # (preloaded) JS exceeds 250 KB gzipped. Route/on-demand chunks excluded.
-      - name: Enforce bundle-size budget (< 250 KB gzip initial)
+      # (preloaded) JS exceeds 248 KB gzipped. Route/on-demand chunks excluded.
+      - name: Enforce bundle-size budget (< 248 KB gzip initial)
         run: cd frontend && npm run budget
 
       - name: Upload artifact

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,7 +5,51 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-None. Every entry in this register is resolved as of 2026-09-01.
+### D-018 — the guide's 180 KB initial-bundle target is 66 KB below reality · 2026-09-01
+**Raised by** — #446, while making the design guide executable.
+**The fact, measured 2026-09-01** — the console's initial (preloaded, gzipped) JS
+is **245.8 KB**, against a guide target of **180 KB**:
+
+```
+  79.8 KB  vendor      59.1 KB  react       38.8 KB  index
+  24.6 KB  motion      17.5 KB  query       13.1 KB  icons     12.8 KB  router
+ 245.8 KB  TOTAL
+```
+
+**Why this is not an agent's call** — closing a 66 KB gap is not a lint rule. It
+means splitting or dropping runtime dependencies: `motion` (framer-motion) at
+24.6 KB is the obvious candidate and is used by real product animation, and
+`vendor` at 79.8 KB needs auditing package by package. That is a performance
+project with visible product consequences, and #446 is a CI-doctrine issue.
+Setting the number to 180 without doing the work would turn the build red on
+every PR, which is how a budget gets deleted rather than met.
+
+**What #446 did instead** — ratcheted the existing gate from 250 KB to **248 KB**,
+locking in today's measurement with ~2 KB for chunk-hash noise so the console
+cannot silently drift up to 249.9. The gate is `frontend/scripts/check-bundle-budget.mjs`,
+already blocking in CI. The budget may only ever be lowered.
+
+**Options**
+- **A** — Accept 248 KB as the standing budget; open a separate performance issue
+  to pursue 180 KB, scheduled on its own merits. *(Recommended.)* Keeps the gate
+  honest and green, and puts the 66 KB where the work actually is.
+- **B** — Keep 180 KB as the declared target and make the gate non-blocking until
+  it is met. Costs the gate: a warning nobody acts on is what #446 exists to end.
+- **C** — Do the splitting work inside #446. Mixes a doctrine change with a
+  performance refactor in one PR, and neither gets reviewed properly.
+
+**Cost of delay** — low, and bounded: the 248 KB ratchet holds the line either
+way. What is lost is only the 66 KB, and only for as long as nobody schedules it.
+
+**Reversible?** — Yes. The budget is one constant.
+
+**Also unresolved in the same issue, and cheaper** — #446's last task asks for
+Playwright snapshots across **two themes × two languages**. The visual suite
+(`frontend/e2e/visual/`) does themes today but has no language axis: the harness
+never mounts i18n, so adding FR/EN is new harness work rather than a parameter.
+It is not blocked on a decision, only on scope — recommend a separate issue,
+since French running ~20% longer than English is a real layout risk worth its own
+review rather than a footnote in a lint PR.
 
 ## Resolved
 

--- a/frontend/eslint-rules/no-design-cliches.js
+++ b/frontend/eslint-rules/no-design-cliches.js
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * openrisk/no-design-cliches
+ *
+ * Enforces the design guide's anti-cliché list as a lint rule rather than a
+ * review preference — contribution rule 1 of the guide, in its own words.
+ *
+ * The list is not about taste. Each ban is a decision the console already took
+ * once, which a component can silently retake in a way nothing else can see:
+ *
+ *   - **Blur beyond 4px.** `backdrop-blur-xl` on an overlay is the single most
+ *     expensive thing a GRC console can paint, and it is repainted on every
+ *     scroll frame behind a modal. The cap is `sm`, which is what
+ *     --overlay-blur is set to; anything above it is a per-component decision
+ *     to spend frames the product does not have on a link from Douala.
+ *   - **Gradients.** A gradient is two colours the token layer never agreed to.
+ *     `bg-gradient-*` and `bg-linear-*` cannot follow the theme the way a
+ *     surface token does, and `text-transparent bg-clip-text` additionally
+ *     deletes the text colour, so the label is invisible wherever the gradient
+ *     fails to paint.
+ *   - **`animate-pulse` outside the skeleton.** A pulsing element means
+ *     "loading" in this product. Using it for emphasis teaches the user that
+ *     the meaning is unreliable, which costs more than the emphasis gained.
+ *   - **Accent-tinted shadows.** A coloured glow is the cliché that dates an
+ *     interface hardest, and it puts the signature hue somewhere it carries no
+ *     meaning — the accent identifies interactive things, not decorative ones.
+ *
+ * Applied at `error` on frontend/src/**, with an exemption list that may only
+ * shrink. Not `warn`: dropping a rule to warn to accommodate the existing
+ * backlog is exactly how 1559 arbitrary values accumulated before W1-01.
+ * `frontend/src/shared/ds/**` is never exempted — it is clean today, and it is
+ * where #443 vendors ~50 third-party components.
+ *
+ * Escape hatch: none in the rule. A genuine one-off carries an
+ * eslint-disable-next-line with a reason, which is visible in review.
+ */
+
+/** Blur steps above the 4px cap. `backdrop-blur-sm` and below are fine. */
+const BLUR = /(?:^|\s|:)backdrop-blur-(md|lg|xl|2xl|3xl)\b/;
+
+/** Tailwind v3 (`bg-gradient-to-r`) and v4 (`bg-linear-to-r`) spellings. */
+const GRADIENT = /(?:^|\s|:)bg-(?:gradient|linear|radial|conic)-/;
+
+/** The gradient-text cliché. `bg-clip-text` is the load-bearing half. */
+const CLIP_TEXT = /(?:^|\s|:)bg-clip-text\b/;
+
+const PULSE = /(?:^|\s|:)animate-pulse\b/;
+
+/**
+ * A shadow whose colour is the accent. Catches the arbitrary form
+ * (`shadow-[0_0_20px_var(--accent)]`) and the utility form (`shadow-accent`,
+ * `shadow-primary/20`) alike, since both put the signature hue in a glow.
+ */
+const ACCENT_SHADOW =
+  /(?:^|\s|:)shadow-(?:\[[^\]]*(?:--accent|--color-accent|--primary)[^\]]*\]|(?:accent|primary)\b)/;
+
+/** The one file allowed to pulse: it is what `Skeleton` is made of. */
+const PULSE_EXEMPT = /src[\\/]shared[\\/]ds[\\/]States\.tsx$/;
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Enforce the design guide's anti-cliché list: no heavy blur, no gradients, no pulse outside the skeleton, no accent-tinted shadows.",
+    },
+    schema: [],
+    messages: {
+      blur: 'backdrop-blur-{{ step }} exceeds the 4px cap. Use backdrop-blur-sm — the value --overlay-blur already carries.',
+      gradient:
+        'Gradient "{{ match }}" is two colours the token layer never agreed to, and it cannot follow the theme. Use a surface token.',
+      clipText:
+        '`bg-clip-text` with a transparent foreground deletes the text colour: the label disappears wherever the gradient does not paint. Use text-fg-primary.',
+      pulse:
+        '`animate-pulse` means "loading" in this product. Use the Skeleton primitive from src/shared/ds/States.tsx instead of pulsing this element.',
+      accentShadow:
+        'Accent-tinted shadow "{{ match }}": the accent identifies interactive things, not decorative glow. Use an elevation token (shadow-e1 / shadow-e2).',
+    },
+  },
+
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    const pulseAllowed = PULSE_EXEMPT.test(filename);
+
+    function check(node, value) {
+      if (typeof value !== 'string' || value.length === 0) return;
+
+      const blur = value.match(BLUR);
+      if (blur) {
+        context.report({ node, messageId: 'blur', data: { step: blur[1] } });
+      }
+
+      const gradient = value.match(GRADIENT);
+      if (gradient) {
+        context.report({
+          node,
+          messageId: 'gradient',
+          data: { match: gradient[0].trim() },
+        });
+      }
+
+      if (CLIP_TEXT.test(value)) {
+        context.report({ node, messageId: 'clipText' });
+      }
+
+      if (!pulseAllowed && PULSE.test(value)) {
+        context.report({ node, messageId: 'pulse' });
+      }
+
+      const shadow = value.match(ACCENT_SHADOW);
+      if (shadow) {
+        context.report({
+          node,
+          messageId: 'accentShadow',
+          data: { match: shadow[0].trim() },
+        });
+      }
+    }
+
+    return {
+      Literal(node) {
+        check(node, node.value);
+      },
+      // Covers `className={`... ${x} ...`}`, where these usually hide.
+      TemplateElement(node) {
+        check(node, node.value.raw);
+      },
+    };
+  },
+};

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,6 +7,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 import noRawColors from './eslint-rules/no-raw-colors.js'
 import noMockData from './eslint-rules/no-mock-data.js'
 import noAdHocDesignValues from './eslint-rules/no-ad-hoc-design-values.js'
+import noDesignCliches from './eslint-rules/no-design-cliches.js'
 
 /**
  * Local plugin. Kept in-repo rather than published: the rule encodes this
@@ -17,6 +18,7 @@ const openrisk = {
     'no-raw-colors': noRawColors,
     'no-mock-data': noMockData,
     'no-ad-hoc-design-values': noAdHocDesignValues,
+    'no-design-cliches': noDesignCliches,
   },
 }
 
@@ -86,8 +88,6 @@ export default defineConfig([
       'src/features/compliance/RemediationPage.tsx',
       'src/features/cti/ThreatIntel.tsx',
       'src/features/dashboard/DashboardPage.tsx',
-      'src/features/dashboard/widgets/GlobalScore.tsx',
-      'src/features/dashboard/widgets/RiskHeatmap.tsx',
       'src/features/financial/FinancialDashboard.tsx',
       'src/features/gamification/LeaderboardPage.tsx',
       'src/features/gamification/UserLevelCard.tsx',
@@ -102,7 +102,6 @@ export default defineConfig([
       'src/features/notifications/NotificationCategoryPrefs.tsx',
       'src/features/onboarding/OnboardingChecklist.tsx',
       'src/features/onboarding/PersonalizeCard.tsx',
-      'src/features/risks/RiskDrawer.tsx',
       'src/features/risks/RiskRegisterPage.tsx',
       'src/features/risks/components/RiskCard.tsx',
       'src/features/settings/GeneralTab.tsx',
@@ -110,7 +109,6 @@ export default defineConfig([
       'src/features/settings/SettingsScreen.tsx',
       'src/features/settings/TeamTab.tsx',
       'src/features/simulations/SimulationsPage.tsx',
-      'src/features/universe/AssetUniverse.tsx',
       'src/features/vulnerabilities/IngestModal.tsx',
       'src/features/vulnerabilities/IntegrationsPanel.tsx',
       'src/features/vulnerabilities/VulnerabilitiesPage.tsx',
@@ -123,8 +121,6 @@ export default defineConfig([
       'src/components/shared/ScoreMeter.tsx',
       'src/components/shared/StatusDot.tsx',
       'src/components/shared/UserAvatar.tsx',
-      'src/components/ui/Input.tsx',
-      'src/pages/AIRiskInsights.tsx',
       'src/pages/Analytics.tsx',
       'src/pages/AnalyticsDashboard.tsx',
       'src/pages/AuditLogs.tsx',
@@ -134,12 +130,8 @@ export default defineConfig([
       'src/pages/ImportRisks.tsx',
       'src/pages/Login.tsx',
       'src/pages/Marketplace.tsx',
-      'src/pages/MonitoringDashboard.tsx',
-      'src/pages/PermissionAnalytics.tsx',
-      'src/pages/RealTimeAnalyticsDashboard.tsx',
       'src/pages/Register.tsx',
       'src/pages/Reports.tsx',
-      'src/pages/RiskTimeline.tsx',
       'src/pages/RoleManagement.tsx',
       'src/pages/ThreatMap.tsx',
       'src/pages/TokenManagement.tsx',
@@ -189,6 +181,100 @@ export default defineConfig([
     plugins: { openrisk },
     rules: {
       'openrisk/no-ad-hoc-design-values': 'error',
+    },
+  },
+  {
+    // The anti-cliché guard, at error level. The design guide's own
+    // contribution rule 1: "Lint rule, not a code review preference."
+    //
+    // Scoped to src/** and NOT to src/components/**: the primitive layer is
+    // src/shared/ds/ (src/components/ui/ was deleted on 2026-08-25 by 96a4a57
+    // and #443 is forbidden to recreate it), so a components-only glob would
+    // cover none of the ~50 components #443 vendors — the exact reason #443 is
+    // blocked behind this issue.
+    files: ['src/**/*.{ts,tsx}'],
+    // Screens carrying the cliché today. This list may ONLY shrink; a file
+    // leaves it by being fixed, never by being added.
+    //
+    // src/shared/ds/** is deliberately absent and must stay absent: it is
+    // clean today, and it is where the vendored primitives land. Acceptance
+    // criterion 1 of this issue is exactly that absence.
+    ignores: [
+      '**/__tests__/**',
+      '**/*.test.{ts,tsx}',
+      '**/*.spec.{ts,tsx}',
+      'src/components/gamification/AchievementTrackingUI.tsx',
+      'src/components/gamification/EnhancedNotificationCenter.tsx',
+      'src/components/gamification/GamificationDashboard.tsx',
+      'src/components/layout/NotificationCenter.tsx',
+      'src/components/layout/PageHeader.tsx',
+      'src/components/shared/FloatingBulkBar.tsx',
+      'src/components/shared/ScoreMeter.tsx',
+      'src/components/shared/UserAvatar.tsx',
+      'src/features/assets/AssetHistoryDrawer.tsx',
+      'src/features/assets/AssetsPage.tsx',
+      'src/features/attackSurface/AssetSchemaSettings.tsx',
+      'src/features/billing/BillingPanel.tsx',
+      'src/features/compliance/ComplianceModals.tsx',
+      'src/features/compliance/CompliancePage.tsx',
+      'src/features/compliance/ControlDrawer.tsx',
+      'src/features/compliance/ImportCatalogModal.tsx',
+      'src/features/gamification/UserLevelCard.tsx',
+      'src/features/mitigations/MitigationKanbanPage.tsx',
+      'src/features/reports/BoardReportPage.tsx',
+      'src/features/risks/ComplianceMappingField.tsx',
+      'src/features/risks/LifecycleStepper.tsx',
+      'src/features/settings/GeneralTab.tsx',
+      'src/features/users/CreateUserModal.tsx',
+      'src/pages/ComplianceReportDashboard.tsx',
+      'src/pages/Login.tsx',
+      'src/pages/Marketplace.tsx',
+      'src/pages/Register.tsx',
+      'src/pages/RoleManagement.tsx',
+      'src/pages/ThreatMap.tsx',
+      'src/pages/TokenManagement.tsx',
+      'src/pages/Users.tsx',
+    ],
+    plugins: { openrisk },
+    rules: {
+      'openrisk/no-design-cliches': 'error',
+    },
+  },
+  {
+    // Import deny-list from the design guide. Purely preventive: none of these
+    // is imported anywhere today, so the rule needs no exemption and starts
+    // life at error with a clean tree.
+    //
+    // The chart bans are about honesty rather than looks — a gauge, a ring and
+    // a sunburst all encode a magnitude as an angle, which people read far less
+    // accurately than a length. A GRC console reports numbers a regulator will
+    // ask about; it uses bars.
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@number-flow/react',
+              message:
+                'Animated number tickers make a figure unreadable while it settles. Render the value; if it must change visibly, change it once.',
+            },
+            {
+              name: 'motion',
+              message:
+                "Use 'framer-motion', already a dependency. Two animation runtimes in one bundle is the size budget spent twice.",
+            },
+          ],
+          patterns: [
+            {
+              group: ['**/GaugeChart', '**/RingChart', '**/SunburstChart', '**/LiveLineChart'],
+              message:
+                'Angle-encoded and self-updating charts are banned by the design guide: they read a magnitude less accurately than a bar, and a live line implies data the console does not stream. Use the bar/area primitives in src/shared/ds.',
+            },
+          ],
+        },
+      ],
     },
   },
 ])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "check:tokens": "npm run check:design-system && npm run check:contrast",
     "audit:surfaces": "node scripts/audit-surfaces.mjs",
     "generate:alpha-classes": "node scripts/alpha-modifier-sites.mjs --write",
+    "check:license-boundary": "node scripts/check-license-boundary.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:api-types": "openapi-typescript ../docs/openapi.yaml -o src/types/openapi.generated.ts"

--- a/frontend/scripts/check-bundle-budget.mjs
+++ b/frontend/scripts/check-bundle-budget.mjs
@@ -13,7 +13,12 @@ import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
 const DIST = 'dist';
-const BUDGET_KB = Number(process.env.BUNDLE_BUDGET_KB ?? 250);
+// Ratcheted down from 250 by #446. Measured 245.8 KB on 2026-09-01, so 248 locks
+// in today's number with ~2 KB for chunk-hash noise and stops a silent drift up
+// to 249.9. It is NOT the guide's target: that is 180 KB, which is 66 KB below
+// where the console actually is and is a code-splitting project, not a lint
+// rule — escalated as D-018. This budget may only ever be lowered.
+const BUDGET_KB = Number(process.env.BUNDLE_BUDGET_KB ?? 248);
 
 const indexHtml = join(DIST, 'index.html');
 if (!existsSync(indexHtml)) {

--- a/frontend/scripts/check-license-boundary.mjs
+++ b/frontend/scripts/check-license-boundary.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Asserts the three-licence boundary the repository actually has.
+ *
+ * #446's original "reuse lint" task assumed two licences. Since D-014 and D-016
+ * (executed by #452) there are three, and a check configured on "everything
+ * under frontend/src/** is AGPL" would be red where it should be green — or,
+ * worse, green on the wrong answer:
+ *
+ *   AGPL-3.0-only                  the core
+ *   Apache-2.0                     frontend/design-system/ AND frontend/src/shared/ds/
+ *   LicenseRef-OpenRisk-Commercial the Enterprise Edition
+ *
+ * Written here rather than delegated to `reuse`: that tool is a new external
+ * dependency, which CLAUDE.md makes an owner decision, and #443 is blocked on
+ * exactly that question for two other packages. Adding one unasked while
+ * enforcing a doctrine about restraint would be the wrong shape. The boundary
+ * is four rules and a header grep; it does not need a toolchain.
+ *
+ * Why this matters beyond tidiness: #443 vendors ~50 third-party components into
+ * frontend/src/shared/ds/. Apache-2.0 there is irreversible once published, so
+ * the guarantee worth automating is that a file cannot land in that directory
+ * carrying the core's AGPL header.
+ *
+ * Usage: npm run check:license-boundary
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FRONTEND = resolve(here, '..');
+const REPO = resolve(FRONTEND, '..');
+
+const APACHE = 'Apache-2.0';
+const AGPL = 'AGPL-3.0-only';
+const EE = 'LicenseRef-OpenRisk-Commercial';
+
+/** Directories whose every file is Apache-2.0. Paths are repo-relative. */
+const APACHE_DIRS = ['frontend/design-system', 'frontend/src/shared/ds'];
+
+/**
+ * Files with no header, legitimately.
+ *
+ * Generated output carries whatever its generator emits and is not authored
+ * here; tests ship with no artefact and are covered by the repository licence.
+ * Deliberately narrow — a pattern, not a list of names, so it cannot be used to
+ * quietly excuse a real source file.
+ */
+const EXEMPT = [/\.generated\.ts$/, /[\\/]__tests__[\\/]/, /\.(test|spec)\.[tj]sx?$/];
+
+const SPDX = /SPDX-License-Identifier:\s*([A-Za-z0-9.\-]+)/;
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.(tsx?|jsx?|css)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** The licence a path is REQUIRED to carry, or null when either is acceptable. */
+function expectedFor(rel) {
+  if (APACHE_DIRS.some((d) => rel.startsWith(`${d}/`))) return APACHE;
+  return null; // core or EE — both legitimate under frontend/src
+}
+
+const files = [
+  ...walk(join(FRONTEND, 'src')),
+  ...(existsSync(join(FRONTEND, 'design-system')) ? walk(join(FRONTEND, 'design-system')) : []),
+];
+
+let missing = 0;
+let wrong = 0;
+let checked = 0;
+const counts = {};
+
+for (const file of files) {
+  const rel = relative(REPO, file).split('\\').join('/');
+  if (EXEMPT.some((re) => re.test(rel))) continue;
+
+  const head = readFileSync(file, 'utf8').slice(0, 600);
+  const m = head.match(SPDX);
+  checked++;
+
+  if (!m) {
+    console.log(`MISSING  ${rel}`);
+    console.log('  no SPDX-License-Identifier in the first 600 bytes\n');
+    missing++;
+    continue;
+  }
+
+  const found = m[1];
+  counts[found] = (counts[found] ?? 0) + 1;
+  const expected = expectedFor(rel);
+
+  if (expected && found !== expected) {
+    console.log(`WRONG    ${rel}`);
+    console.log(`  declares ${found}, but this directory is ${expected}`);
+    console.log('  (D-014 + D-016, executed by #452 — see frontend/design-system/NOTICE)\n');
+    wrong++;
+    continue;
+  }
+  if (!expected && found !== AGPL && found !== EE) {
+    console.log(`WRONG    ${rel}`);
+    console.log(`  declares ${found}; outside the design system a file is ${AGPL} or ${EE}\n`);
+    wrong++;
+  }
+}
+
+console.log(
+  `${checked} files checked — ` +
+    Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, v]) => `${v} ${k}`)
+      .join(' · '),
+);
+
+if (missing || wrong) {
+  console.error(
+    `\nLicence boundary FAILED: ${missing} missing header(s), ${wrong} on the wrong side.\n` +
+      'frontend/design-system/ and frontend/src/shared/ds/ are Apache-2.0; the rest of\n' +
+      'frontend/src/ is AGPL-3.0-only, except Enterprise files which declare\n' +
+      'LicenseRef-OpenRisk-Commercial. Apache-2.0 is irreversible once published, so a\n' +
+      'file cannot be moved across this boundary by editing its header alone.',
+  );
+  process.exit(1);
+}
+console.log('Every file is on the correct side of the three-licence boundary.');

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,6 @@
+/* Copyright (c) 2026 OpenDefender Contributors
+   SPDX-License-Identifier: AGPL-3.0-only */
+
 #root {
   width: 100%;
   height: 100%;

--- a/frontend/src/components/notifications/NotificationBadge.css
+++ b/frontend/src/components/notifications/NotificationBadge.css
@@ -1,3 +1,6 @@
+/* Copyright (c) 2026 OpenDefender Contributors
+   SPDX-License-Identifier: AGPL-3.0-only */
+
 import React from 'react';
 import './NotificationBadge.css';
 

--- a/frontend/src/components/notifications/NotificationCenter.css
+++ b/frontend/src/components/notifications/NotificationCenter.css
@@ -1,3 +1,6 @@
+/* Copyright (c) 2026 OpenDefender Contributors
+   SPDX-License-Identifier: AGPL-3.0-only */
+
 .notification-center-overlay {
   position: fixed;
   top: 0;

--- a/frontend/src/components/notifications/NotificationPreferences.css
+++ b/frontend/src/components/notifications/NotificationPreferences.css
@@ -1,3 +1,6 @@
+/* Copyright (c) 2026 OpenDefender Contributors
+   SPDX-License-Identifier: AGPL-3.0-only */
+
 .notification-preferences {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #446

Makes the design guide's doctrine executable — contribution rule 1, in its own words: *"Lint rule,
not a code review preference."* This is the blocker #443 sits behind.

## Read this first: half the issue was already built

The body assumed nothing was tooled. Measured on the tree, **four of the nine tasks already
existed** and were already at `error`:

| Original task | Reality | Where |
|---|---|---|
| Ban hex literals | ✅ exists | `openrisk/no-raw-colors` |
| Ban Tailwind palette classes | ✅ exists | `openrisk/no-raw-colors` |
| Ban raw px off-scale | ✅ exists | `openrisk/no-ad-hoc-design-values` |
| Contrast contract — "~40 pairs, both themes" | ✅ exists and **exceeds** it: 240 pairs, 2 themes × 2 accent variants | `scripts/check-contrast.mjs` |

Reimplementing those would have produced a second family of rules saying the same thing, which is
the debt #439 exists to end. The issue body has been re-scoped to what was genuinely missing, with
7 numbered acceptance criteria and a DoD it previously had neither of.

## What ships

**1 — `openrisk/no-design-cliches`.** Blur beyond the 4px cap; gradients (`bg-gradient-*`,
`bg-linear-*`, `bg-radial-*`, `bg-conic-*`); `bg-clip-text`; `animate-pulse` outside the skeleton;
accent-tinted shadows, catching both `shadow-[0_0_20px_var(--accent)]` and `shadow-primary/20`.
Each ban carries its reason in the error message, and the reasons are mechanical rather than
aesthetic — blur is repainted every scroll frame behind a modal; a gradient is two colours the token
layer never agreed to and cannot follow the theme; `bg-clip-text` additionally deletes the text
colour, so the label vanishes wherever the gradient fails to paint; pulsing means "loading" in this
product, so reusing it for emphasis makes the meaning unreliable.

**2 — the import deny-list**, via `no-restricted-imports`, each message naming the substitute.
**Zero violations exist today**, so it starts at `error` with no exemption and stays preventive.

**3 — the glob correction, which is what #446 was actually blocked on.** Scope is
`frontend/src/**`, *not* `frontend/src/components/**`. `frontend/src/components/ui/` does not exist
— deleted 2026-08-25 by `96a4a57` as the F5/F6 debt, and #443 is forbidden to recreate it — and the
primitive layer is `frontend/src/shared/ds/`. A components-only glob would have covered **none** of
the ~50 components #443 vendors, so the blocker would have cost the delay and delivered nothing.
`src/shared/ds/**` is exempted by no rule in this PR and is clean today, so **#443's acceptance
criterion 7 is satisfiable with zero debt**.

The 31 screens that carry a cliché are listed explicitly, at `error`, on the shrinking-list doctrine
`no-raw-colors` already established. Not `warn`: dropping a rule to warn to absorb a backlog is how
1559 arbitrary values accumulated before W1-01.

**4 — `scripts/check-license-boundary.mjs`**, the three-licence boundary. Since D-014 and D-016
(executed by #452, merged) the repo has three, not two: `AGPL-3.0-only` core · `Apache-2.0` for
`frontend/design-system/` **and** `frontend/src/shared/ds/` · `LicenseRef-OpenRisk-Commercial` EE.
A check written on "everything under `frontend/src/**` is AGPL" would be red where it should be
green, or green on the wrong answer.

**5 — bundle budget ratcheted 250 → 248 KB**, and the guide's 180 KB target escalated as **D-018**.

**6 — hygiene.** Pruned **10 dead paths** from the `no-raw-colors` ignore list, including
`src/components/ui/Input.tsx`, a file in a directory that no longer exists — a stale exemption list
is the same erosion this issue exists to stop. Added SPDX headers to 4 CSS files that had none.

## Two dependencies deliberately not added

The body asked for `size-limit` and `reuse lint`. Both are new external packages, which CLAUDE.md
makes an owner decision — and **#443 is blocked on precisely that question** for Base UI and
`@tanstack/react-table`. Adding two unasked, in the PR that enforces a doctrine about restraint,
would be incoherent. Both tasks are delivered with existing zero-dependency infrastructure instead:
`scripts/check-bundle-budget.mjs`, already blocking in CI, and the new boundary script. If you would
rather have the real tools, that is a one-line decision and I will swap them in.

## Verification

```
$ npx eslint src/shared/ds
  (no output)                                    ← AC1: 0 errors, no eslint-disable

$ npx eslint . -f json | (count errors)
  errors: 322          master: 322               ← AC6: not one new error

$ node scripts/check-license-boundary.mjs
429 files checked — 395 AGPL-3.0-only · 20 LicenseRef-OpenRisk-Commercial · 14 Apache-2.0
Every file is on the correct side of the three-licence boundary.

$ node scripts/check-bundle-budget.mjs
✓ Within budget (245.8 KB ≤ 248 KB).             ← AC5

$ (stale-path scan of eslint.config.js)
  file paths in config: 83   stale: 0            ← AC7

$ npm run check:tokens    → 274 tokens, 0 drifting · 240 contrast pairs, 0 failing
$ npx vitest run          → 34 files, 389 tests passed
$ python3 -c 'yaml.safe_load(open(".github/workflows/ci.yml"))'  → valid
```

### AC2 — the five bans fire, proven *inside* `src/shared/ds/`

```
1:18 error  backdrop-blur-xl exceeds the 4px cap…                    openrisk/no-design-cliches
2:18 error  Gradient "bg-gradient-" is two colours the token layer…  openrisk/no-design-cliches
3:18 error  `bg-clip-text` … deletes the text colour…                openrisk/no-design-cliches
4:18 error  `animate-pulse` means "loading" in this product…         openrisk/no-design-cliches
5:18 error  Accent-tinted shadow "shadow-[0_0_20px_var(--accent)]"…  openrisk/no-design-cliches
```

### AC3 — the pulse exemption is a path, not a concept

`animate-pulse` appended to `src/shared/ds/States.tsx` → **0 errors**. The same string in any other
`shared/ds` file → error (row 4 above). Reverted.

### AC4 — deny-list, all three forms

```
'@number-flow/react' … Animated number tickers make a figure unreadable while it settles
'motion'             … Use 'framer-motion', already a dependency
'…/GaugeChart'       … Angle-encoded charts read a magnitude less accurately than a bar
```

### Licence boundary — the negative test that matters for #443

Flipping `src/shared/ds/Button.tsx` to the core's header:

```
WRONG    frontend/src/shared/ds/Button.tsx
  declares AGPL-3.0-only, but this directory is Apache-2.0
  (D-014 + D-016, executed by #452 — see frontend/design-system/NOTICE)
```

Apache-2.0 is irreversible once published, so the guarantee worth automating is exactly this: a
vendored file cannot land in `shared/ds` carrying the wrong licence. Reverted; green again.

## Honest remainders

- **The 180 KB budget target is not met, and was not attempted — D-018.** The console measures
  **245.8 KB** initial gzipped, 66 KB above the guide's number. Closing that means splitting or
  dropping runtime dependencies (`motion` at 24.6 KB, `vendor` at 79.8 KB) with visible product
  consequences: a performance project, not a lint rule. Setting the gate to 180 would redden every
  PR, which is how a budget gets deleted rather than met. Ratcheted to 248 KB instead so the console
  cannot silently drift, and escalated with options and a recommendation.
- **FR/EN Playwright snapshots are not delivered.** The visual suite does themes but has no language
  axis — the harness never mounts i18n, so this is new harness work, not a parameter. French running
  ~20% longer than English is a real layout risk that deserves its own review rather than a footnote
  in a lint PR. Recommend a separate issue; noted alongside D-018.
- **31 screens are exempted from the new rule.** They are listed by name at error level and the list
  may only shrink, but they are not fixed here. Fixing them is a design change per screen, not a
  lint change.
- **This PR does not make the repo lint-clean.** 322 errors remain, all pre-existing (`any`,
  unused vars, `no-irregular-whitespace`), identical to `master`. `Frontend Lint & Format` was
  already red before this branch and will still be red after it.
- **I refined the issue myself** rather than routing to `po-openrisk` (this session does not spawn
  subagents). The four corrections were already fully specified in po-openrisk's comment; I decided
  them in the body and added the missing acceptance criteria and DoD. Worth a glance to confirm the
  scope calls match what you'd have chosen.
