### PR TITLE
perf(frontend): close the 66 KB gap — 245.8 KB to 179.7 KB initial (#462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,8 +313,9 @@ jobs:
           ls -lah dist/
 
       # Performance budget (task §2) — BLOCKING. Fails the build if the initial
-      # (preloaded) JS exceeds 248 KB gzipped. Route/on-demand chunks excluded.
-      - name: Enforce bundle-size budget (< 248 KB gzip initial)
+      # (preloaded) JS exceeds 180 KB gzipped — the design guide's target, met by
+      # #462. Route/on-demand chunks excluded.
+      - name: Enforce bundle-size budget (< 180 KB gzip initial)
         run: cd frontend && npm run budget
 
       - name: Upload artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,17 @@ jobs:
       - name: Three-licence boundary is intact
         run: cd frontend && npm run check:license-boundary
 
+      # The bundle budget runs HERE as well as in build-frontend, and that is
+      # deliberate rather than duplication. build-frontend `needs:
+      # [frontend-lint, frontend-unit-tests]`, both of which are currently red,
+      # so the budget step has been SKIPPED on every run — the ratchets in #446
+      # (250 -> 248) and #462 (-> 180) were being enforced by nobody. A gate that
+      # does not run is the exact failure mode both issues exist to prevent.
+      # This job depends on nothing that is failing, so the budget is checked for
+      # real. Drop this step once the lint and unit-test jobs are green again.
+      - name: Bundle budget (< 180 KB gzip initial)
+        run: cd frontend && npm run build && npm run budget
+
   # PROJECT_PLAN.md §3 requires a blocking `typecheck` gate. `npm run build`
   # already runs `tsc -b`, but we type-check on its own (no emit) as a fast,
   # dedicated gate. Uses the local binary since the frontend has no `type-check`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,6 @@
         "react-dom": "^19.2.0",
         "react-grid-layout": "^1.5.2",
         "react-hook-form": "^7.66.1",
-        "react-hot-toast": "^2.6.0",
         "react-leaflet": "^5.0.0",
         "react-router": "^8.3.0",
         "react-use": "^17.6.0",
@@ -2086,6 +2085,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -4320,15 +4385,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/goober": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
-      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5701,23 +5757,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-hot-toast": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
-      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.1.3",
-        "goober": "^2.1.16"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,6 @@
     "react-dom": "^19.2.0",
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.66.1",
-    "react-hot-toast": "^2.6.0",
     "react-leaflet": "^5.0.0",
     "react-router": "^8.3.0",
     "react-use": "^17.6.0",

--- a/frontend/scripts/check-bundle-budget.mjs
+++ b/frontend/scripts/check-bundle-budget.mjs
@@ -13,12 +13,20 @@ import { gzipSync } from 'node:zlib';
 import { join } from 'node:path';
 
 const DIST = 'dist';
-// Ratcheted down from 250 by #446. Measured 245.8 KB on 2026-09-01, so 248 locks
-// in today's number with ~2 KB for chunk-hash noise and stops a silent drift up
-// to 249.9. It is NOT the guide's target: that is 180 KB, which is 66 KB below
-// where the console actually is and is a code-splitting project, not a lint
-// rule — escalated as D-018. This budget may only ever be lowered.
-const BUDGET_KB = Number(process.env.BUNDLE_BUDGET_KB ?? 248);
+// The design guide's target, met by #462: 250 -> 248 (#446) -> 180. Measured
+// 179.7 KB on 2026-09-01, so there is ~0.3 KB of headroom and the next
+// regression fails the build rather than eroding the number.
+//
+// It got here by moving what was never needed on first paint OUT of the preload
+// rather than by deleting features: recharts' and @hello-pangea/dnd's Redux
+// engines, framer-motion's engine, and a second toast library were all falling
+// through to the `vendor` chunk, which is preloaded because it also holds axios
+// and zustand. See #462 and D-018.
+//
+// THIS BUDGET MAY ONLY EVER BE LOWERED. Raising it to accommodate a new
+// dependency is the decision that makes it meaningless; the dependency goes in
+// a lazy chunk instead, or it does not go in.
+const BUDGET_KB = Number(process.env.BUNDLE_BUDGET_KB ?? 180);
 
 const indexHtml = join(DIST, 'index.html');
 if (!existsSync(indexHtml)) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@
 
 import { useEffect, useState, lazy, Suspense, type ReactNode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, useNavigate, useParams } from 'react-router';
-import { motion, AnimatePresence } from 'framer-motion';
 
 // --- Imports des Stores & Hooks ---
 import { useAuthStore } from './hooks/useAuthStore';
@@ -122,22 +121,30 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 /**
  * Fades/slides the route content on every navigation, keyed by pathname, so
  * switching pages never feels like an abrupt jump-cut.
+ *
+ * CSS rather than framer-motion, since #462. This was the ONLY framer-motion
+ * usage in the entry graph, and it alone kept the whole 37 KB motion chunk in
+ * the preload for every cold load — for a 180ms fade. The other 55 files that
+ * use framer-motion sit behind lazy routes and still get it, on demand.
+ *
+ * `key` on the element is what replays the animation: React remounts the
+ * subtree when the pathname changes, and `both` fill-mode holds the start frame
+ * until it does.
+ *
+ * WHAT IS LOST, deliberately: AnimatePresence's exit fade. CSS cannot animate an
+ * element that is being unmounted, so the outgoing page is removed at once
+ * instead of fading over 180ms. The entering animation is identical to what it
+ * replaces. See the note in #462 — this is the one visible change in that issue.
  */
 const AnimatedOutlet = () => {
   const location = useLocation();
   return (
-    <AnimatePresence mode="wait">
-      <motion.div
-        key={location.pathname}
-        initial={{ opacity: 0, y: 6 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.18, ease: 'easeOut' }}
-        className="flex-1 flex flex-col min-h-0 h-full"
-      >
-        <Outlet />
-      </motion.div>
-    </AnimatePresence>
+    <div
+      key={location.pathname}
+      className="motion-safe:animate-route flex flex-1 flex-col min-h-0 h-full"
+    >
+      <Outlet />
+    </div>
   );
 };
 

--- a/frontend/src/features/infrastructure/AgentDeployModal.tsx
+++ b/frontend/src/features/infrastructure/AgentDeployModal.tsx
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from 'react';
 import { X, Copy, Check, Download, Apple, Container, Terminal, Monitor } from 'lucide-react';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import { Btn } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
 import { scannerService, type ScanConfig, type RegistrationTokenResponse } from './scannerService';

--- a/frontend/src/features/infrastructure/InfrastructurePage.tsx
+++ b/frontend/src/features/infrastructure/InfrastructurePage.tsx
@@ -12,7 +12,7 @@ import {
   Plus, Play, Trash2, Radar, ChevronRight, Server, DownloadCloud,
   ShieldOff, Boxes, Bug, Loader2, Clock,
 } from 'lucide-react';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import { PageFrame, PageHeader, Btn, Card, Skeleton, EmptyState, ErrorState } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
 import { useUIStrings } from '../../shared/uiStrings';

--- a/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
+++ b/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
@@ -8,7 +8,7 @@
 
 import { useState } from 'react';
 import { X, ShieldCheck, Info } from 'lucide-react';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import { Btn } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
 import { PROVIDERS, CLOUD_CRED_FIELDS, SCOPE_HINTS } from './scannerMeta';

--- a/frontend/src/features/infrastructure/ScanPreviewPage.tsx
+++ b/frontend/src/features/infrastructure/ScanPreviewPage.tsx
@@ -12,7 +12,7 @@ import { useParams, useNavigate } from 'react-router';
 import {
   ArrowLeft, Boxes, Bug, Wrench, Check, Server, Cloud, Download, Trash2, ShieldCheck,
 } from 'lucide-react';
-import toast from 'react-hot-toast';
+import { toast } from 'sonner';
 import { PageFrame, PageHeader, Btn, Card, Skeleton, EmptyState, ErrorState } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
 import { useAuthStore } from '../../hooks/useAuthStore';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,6 +115,22 @@ layer(base);
       transform: scale(1.35);
     }
   }
+  /* The route transition. 6px rather than or-fadeup's 14px: this moves the
+     WHOLE page, and a large travel on a full-viewport element reads as the
+     layout settling rather than as content arriving. Matches, exactly, the
+     framer-motion transition it replaces — opacity 0->1, y 6->0, --dur-base
+     (180ms), --ease-out. See #462. */
+  @keyframes or-route {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   @keyframes or-fadeup {
     from {
       opacity: 0;

--- a/frontend/src/pages/BulkOperations.tsx
+++ b/frontend/src/pages/BulkOperations.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useState } from 'react';
 import { CheckCircle, Clock, AlertCircle, Trash2, Play, Pause, RefreshCw, Loader } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast } from 'react-hot-toast';
+import { toast } from 'sonner';
 import { getAccessToken } from '../lib/session';
 
 interface BulkOperation {

--- a/frontend/src/pages/CustomFields.tsx
+++ b/frontend/src/pages/CustomFields.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useState } from 'react';
 import { Plus, Trash2, Edit2, Copy, AlertCircle, CheckCircle, Loader } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast } from 'react-hot-toast';
+import { toast } from 'sonner';
 import { getAccessToken } from '../lib/session';
 
 interface CustomField {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -178,6 +178,8 @@
 
   /* --------------------------------------------------------------- animation */
   /* The OpenRisk motion vocabulary. Keyframes live in index.css. */
+  /* Route transition — replaces framer-motion in App.tsx (#462). */
+  --animate-route: or-route var(--dur-base) var(--ease-out) both;
   --animate-fade-in: or-fadein var(--dur-slow) var(--ease-out) both;
   --animate-or-fadeup: or-fadeup var(--dur-slow) var(--ease-out) both;
   --animate-or-fadein: or-fadein var(--dur-base) var(--ease-out) both;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -59,6 +59,51 @@ export default defineConfig({
           if (id.includes('lucide-react')) return 'icons'
           if (id.includes('/react/') || id.includes('/react-dom/') || id.includes('/scheduler/'))
             return 'react'
+
+          /*
+           * Transitive engines of the LAZY libraries above.
+           *
+           * `vendor` is preloaded, because it also holds axios, zustand and
+           * tailwind-merge, which the entry graph genuinely needs. Anything that
+           * falls through to it is therefore fetched before first paint — and
+           * these were falling through:
+           *
+           *   recharts v3          -> @reduxjs/toolkit, react-redux, redux,
+           *                           reselect, immer, decimal.js-light
+           *   @hello-pangea/dnd    -> react-redux, redux
+           *   framer-motion v11    -> motion-dom, motion-utils
+           *
+           * Rules above catch `recharts` and `@hello-pangea` by name, but a file
+           * inside `node_modules/react-redux` matches none of them, so the Redux
+           * engine of a chart library the first screen never renders was being
+           * downloaded on every cold load. ~240 KB of raw source.
+           *
+           * Verified before moving: NONE of these is imported by app code —
+           * `grep -rl "from '<pkg>'" src` returns nothing for every one, and the
+           * only zustand middleware in use is `zustand/middleware`, not the immer
+           * one. So this chunk is reachable only through a lazy route, which is
+           * what keeps it out of the preload.
+           */
+          if (
+            id.includes('node_modules/@reduxjs/toolkit') ||
+            id.includes('node_modules/react-redux') ||
+            id.includes('node_modules/redux/') ||
+            id.includes('node_modules/redux-thunk') ||
+            id.includes('node_modules/reselect') ||
+            id.includes('node_modules/immer') ||
+            id.includes('node_modules/decimal.js-light') ||
+            id.includes('node_modules/es-toolkit') ||
+            id.includes('node_modules/tabbable') ||
+            id.includes('node_modules/eventemitter3')
+          )
+            return 'lazy-engines'
+
+          /* framer-motion v11 moved its engine into these two packages; the rule
+             above matches the old names only, so they were landing in `vendor`
+             rather than beside the animation code that uses them. */
+          if (id.includes('node_modules/motion-dom') || id.includes('node_modules/motion-utils'))
+            return 'motion'
+
           return 'vendor'
         },
       },


### PR DESCRIPTION
Closes #462

**245.8 KB → 179.7 KB initial gzipped JS.** The design guide's 180 KB target is met, and the budget
gate is lowered to 180. **Nothing was deleted from the product to get there** — and one real defect
was found and fixed on the way.

## The audit, because nothing recorded what was in `vendor`

Measured from the build's own sourcemap, raw source bytes per package in the 79.8 KB `vendor` chunk:

```
 155.1 KB axios · 128.3 motion-dom · 94.9 tailwind-merge · 78.2 @reduxjs/toolkit
  64.3 sonner · 48.4 decimal.js-light · 44.8 es-toolkit · 37.3 immer · 36.6 react-redux
  27.3 tabbable · 21.5 reselect · 16.8 zustand · 16.4 redux · 10.1 react-hot-toast · …
```

**Redux, in a Zustand codebase.** It is not a declared dependency and `grep -rl` finds zero imports
under `src/`. It arrives transitively — **recharts v3 uses Redux internally**, as does
`@hello-pangea/dnd`. The `manualChunks` rules match `recharts` and `@hello-pangea` *by name*, but a
file inside `node_modules/react-redux` matches none of them, so it fell through to `vendor` — which
**is preloaded**, because it also holds axios, zustand and tailwind-merge that the entry genuinely
needs. The Redux engine of a chart library the first screen never renders was being downloaded on
every cold load. Same story for framer-motion v11, whose engine moved into `motion-dom` /
`motion-utils` and stopped matching the `framer-motion` rule.

## The three changes

| # | Change | Effect |
|---|---|---|
| 1 | New `lazy-engines` chunk for the transitive-only engines; `motion-dom`/`motion-utils` into `motion` | **245.8 → 220.2** |
| 2 | `AnimatedOutlet` moves from framer-motion to CSS | **220.2 → 183.0** |
| 3 | `react-hot-toast` removed, 6 call sites migrated to sonner | **183.0 → 179.7** |

**(1)** is pure chunking — it moves bytes and deletes nothing. Before moving anything I verified none
of the ten packages is imported by app code (`grep -rl "from '<pkg>'" src` → 0 for each), and that
the only zustand middleware in use is `zustand/middleware`, not the immer one. They are reachable
only through a lazy route, which is what keeps the new chunk out of the preload.

**(2) is the product call D-018 flagged, and this PR calls it.** `AnimatedOutlet` was the *only*
framer-motion usage in the entry graph, and it alone kept the 37 KB motion chunk in the preload —
for a 180ms fade. The animation is **reproduced exactly**, not dropped: the framer-motion transition
was opacity 0→1, y 6→0, 180ms, easeOut; `--dur-base` **is** 180ms and `--ease-out` **is** that curve,
so the new `or-route` keyframe and `--animate-route` token are the same motion written in the token
vocabulary. It is applied as `motion-safe:`, so it now honours `prefers-reduced-motion` — which the
framer-motion version did not.

> **The one visible change in this PR:** `AnimatePresence`'s exit fade is gone. CSS cannot animate an
> element that is being unmounted, so the outgoing page is removed at once instead of fading over
> 180ms. The entering animation is identical. If you want the exit back, revert this one file and the
> budget goes to ~217 — it is a single, reversible decision.

**(3) is a defect fix that happens to save bytes.** The product carried two toast libraries.
**Only sonner's `<Toaster>` is mounted** (`src/main.tsx`), and react-hot-toast renders nothing
without its own Toaster — so every `toast.success` and `toast.error` in those six files has been a
**silent no-op**. The scan-config save, the agent deploy, the bulk operation and the custom-field
save have been reporting success and failure to nobody. All six call sites use only `toast()`,
`toast.success()` and `toast.error()`, which sonner exposes with the same signature, so the
migration is the import line and nothing else.

## Verification

```
$ node scripts/check-bundle-budget.mjs
     59.1 KB  react       38.7 KB  index      38.4 KB  vendor
     17.5 KB  query       13.1 KB  icons      12.8 KB  router
    179.7 KB  TOTAL
✓ Within budget (179.7 KB ≤ 180 KB).

$ npx vitest run                  → 34 files, 389 tests passed
$ npx tsc -b                      → clean
$ npm run build                   → clean
$ npm run check:tokens            → 274 tokens 0 drifting · 240 contrast pairs 0 failing
$ npx eslint . -f json | (count)  → 322 errors — IDENTICAL to master, none new
$ npx eslint <the 8 touched files>→ 32 problems on this branch, 32 on master — none new
```

The CSS animation is confirmed **compiled**, not merely written:

```
@keyframes or-route{0%{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
.motion-safe\:animate-route{animation:var(--animate-route)}
```

The app was booted on :5174 and rendered the sign-in screen with **zero console errors**.

## Honest remainders

- **The route transition was not exercised on a live authenticated route.** `AnimatedOutlet` sits
  inside the authenticated shell and logging in needs a backend I did not run. What is verified is
  that the keyframe and the utility compile with the right values, that the class is on the element
  in the JSX, and that the app boots clean. Worth one manual navigation before merge.
- **axios is 155 KB of raw source** and is now the largest single package in the initial chunk.
  Replacing it with `fetch` in `src/services/` is the next real win and a contained refactor —
  deliberately not attempted here, since it touches every API call and belongs in its own PR.
- **`tailwind-merge` is 94.9 KB raw** and runs inside every `cn()`. Whether the runtime merge is
  needed everywhere, or only where classes are composed dynamically, is worth its own look.
- **Headroom is ~0.3 KB.** That is deliberate — the next regression fails the build rather than
  eroding the number — but it does mean the next dependency has to go in a lazy chunk. PR 4 of #443
  adds `@tanstack/react-table` (6.3 KB gzipped) and **must** be lazy-chunked; flagging it here
  because that PR is already planned.
- **322 pre-existing lint errors remain**, unchanged from master. `Frontend Lint & Format` was
  already red before this branch and still will be.
- **D-018 can be closed** — its 66 KB gap is gone, and none of it came from deleting a feature.
