### PR TITLE
fix(perf,ci): master is over budget and the budget gate was dropped (#462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,20 @@ jobs:
       - name: Visual suite — themes, languages, axe and the keyboard contract
         run: cd frontend && npx playwright test e2e/visual/ --project=chromium
 
+      # The bundle budget runs HERE as well as in build-frontend, and that is
+      # deliberate. build-frontend `needs: [frontend-lint, frontend-unit-tests]`,
+      # both currently red, so its budget step is skipped on every run and the
+      # gate is enforced by nobody.
+      #
+      # This step was added by #462 and then LOST: #468 branched before #462
+      # merged, rewrote this same job, and its version won the merge. Master then
+      # sat at 180.4 KB — over its own budget — with nothing to notice. Restored
+      # here, after the build the visual suite already needs.
+      #
+      # Remove it once the lint and unit-test jobs are green again.
+      - name: Bundle budget (< 180 KB gzip initial)
+        run: cd frontend && npm run build && npm run budget
+
       - name: Upload visual diffs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/frontend/src/features/onboarding/useActivation.ts
+++ b/frontend/src/features/onboarding/useActivation.ts
@@ -12,7 +12,6 @@
 
 import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
 
 import {
   activationService,
@@ -83,8 +82,15 @@ export function useCelebrateActivation(state: ActivationState | undefined, lang:
       inFlight.current.add(step.key);
 
       if (reduced) {
-        toast.success(
-          `${lang === 'fr' ? 'Étape terminée' : 'Step complete'} — ${i18n(step.label_i18n, lang)}`,
+        /* Imported at call time, not at module scope. This hook is reachable
+           from main.tsx without a lazy boundary, so a static import put 64 KB of
+           raw sonner source in the ENTRY chunk to service a celebration that
+           fires only after a step completes. Fire-and-forget: the toast is
+           feedback, and nothing downstream waits on it. */
+        void import('sonner').then(({ toast }) =>
+          toast.success(
+            `${lang === 'fr' ? 'Étape terminée' : 'Step complete'} — ${i18n(step.label_i18n, lang)}`,
+          ),
         );
       } else {
         // A slightly bigger burst for the step that IS the product's promise.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,9 +10,7 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import 'leaflet/dist/leaflet.css';
 import './index.css'
-import { Toaster } from 'sonner'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useUIStore } from './store/uiStore'
 import { ErrorBoundary } from './shared/system/ErrorBoundary'
 import { installGlobalErrorReporting } from './lib/observability'
 import { registerQueryClient } from './lib/sessionScope'
@@ -62,11 +60,13 @@ onMFARequired(() => {
 // Report uncaught errors and unhandled rejections (Sentry when present).
 installGlobalErrorReporting()
 
-/** Toasts follow the active theme (dc.html §8). */
-function ThemedToaster() {
-  const theme = useUIStore((s) => s.theme)
-  return <Toaster position="top-right" theme={theme} richColors closeButton />
-}
+/*
+ * Loaded after first paint. Nothing can be toasted until the user has acted, and
+ * the first thing a user does is never in the first frame — so sonner (64 KB of
+ * raw source) does not belong in the entry chunk. #443 PR 2 needed the room; the
+ * reason it is correct is older than that.
+ */
+const ThemedToaster = React.lazy(() => import('./shared/system/ThemedToaster'))
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -74,7 +74,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <ErrorBoundary>
         <App />
       </ErrorBoundary>
-      <ThemedToaster />
+      <React.Suspense fallback={null}>
+        <ThemedToaster />
+      </React.Suspense>
     </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/frontend/src/shared/AccessDenied.tsx
+++ b/frontend/src/shared/AccessDenied.tsx
@@ -12,7 +12,6 @@
 
 import { Link, useNavigate } from 'react-router';
 import { Lock, ArrowLeft, Copy } from 'lucide-react';
-import { toast } from 'sonner';
 import { useUIStore } from '../store/uiStore';
 import { parentHref } from './routeModel';
 import { Btn } from './ui';
@@ -30,7 +29,17 @@ export function AccessDenied({ permission, pathname }: AccessDeniedProps) {
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   const back = parentHref(pathname) ?? '/';
 
+  /*
+   * `toast` is imported inside the handler, not at the top of the file.
+   *
+   * App.tsx imports AccessDenied eagerly, so a static `import { toast } from
+   * 'sonner'` here put 64 KB of raw sonner source into the ENTRY chunk — fetched
+   * before the sign-in screen could paint — to service a clipboard confirmation
+   * that only ever fires on a click. The dynamic import resolves at click time,
+   * by which point sonner is already loaded for any screen that toasts.
+   */
   const copy = async () => {
+    const { toast } = await import('sonner');
     try {
       await navigator.clipboard.writeText(permission);
       toast.success(tr('Permission copiée', 'Permission copied'));

--- a/frontend/src/shared/system/ThemedToaster.tsx
+++ b/frontend/src/shared/system/ThemedToaster.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * The toast surface, in its own module so it can be loaded after first paint.
+ *
+ * Nothing can be toasted until the user has done something, and the first thing
+ * a user does is never in the first frame. Keeping this in the entry meant
+ * sonner — 64 KB of raw source — was fetched and parsed before the sign-in
+ * screen could render, on every cold load. It is lazy in main.tsx instead.
+ *
+ * Callers are unaffected: they import `toast` from 'sonner' directly, and the
+ * import that resolves it is theirs, not this file's.
+ */
+
+import { Toaster } from 'sonner';
+import { useUIStore } from '../../store/uiStore';
+
+/** Toasts follow the active theme (dc.html §8). */
+export default function ThemedToaster() {
+  const theme = useUIStore((s) => s.theme);
+  return <Toaster position="top-right" theme={theme} richColors closeButton />;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -104,6 +104,13 @@ export default defineConfig({
           if (id.includes('node_modules/motion-dom') || id.includes('node_modules/motion-utils'))
             return 'motion'
 
+          /* The toast surface. Nothing can be toasted until the user has acted,
+             so it is never needed for first paint — but left to fall through to
+             `vendor` it was preloaded anyway, because vendor also holds axios and
+             zustand. Same trap as the engines above: no longer *imported*
+             eagerly, yet still glued to a preloaded chunk. */
+          if (id.includes('node_modules/sonner')) return 'toast'
+
           return 'vendor'
         },
       },


### PR DESCRIPTION
Refs #462 · unblocks #443 PR 2

Two regressions on `master`, both mine, found while starting #443 PR 2.

## 1. The budget gate is not running

#462 added the budget check to `frontend-design-system`, because `build-frontend` declares
`needs: [frontend-lint, frontend-unit-tests]` — both red — and is skipped on every run.

**#468 branched before #462 merged**, rewrote that same job to add the visual suite, and its version
won the merge. The budget step went with it. The only `npm run budget` left is the one in the
skipped job, so nothing has been checking the number.

Editing the same job in two concurrent branches is how a gate disappears silently. Restored here.

## 2. master is over its own budget

```
✗ Initial bundle 180.4 KB exceeds the 180 KB budget.
```

#462 measured 179.7 KB on a worktree branched **before** #465 merged, so the +0.8 KB of
form-control primitives landed on a number with no room for them. Undetected because of (1).

## The fix: sonner leaves the critical path

64 KB of raw source, and nothing can be toasted until the user has acted. Two things kept it in the
entry, and both had to go:

1. **Three eager imports for click-only handlers** — AccessDenied's clipboard confirmation,
   useActivation's reduced-motion celebration, and `main.tsx` mounting `<Toaster>`. Now dynamic
   imports at call time, and `React.lazy` for the Toaster.
2. **`manualChunks` still returned `'vendor'` for it**, and vendor is preloaded because it also
   holds axios and zustand — so sonner rode along even with no eager importer left. Same trap #462
   fixed for recharts' Redux engine. It gets its own `toast` chunk.

Worth noting for review: **only (2) moved the number.** The deferrals alone changed nothing
measurable, because chunk assignment rather than the import graph was what put sonner in the
preload. Both are kept — (1) is what makes (2) honest rather than a trick, since splitting a chunk
off a module the entry still imports would just fetch it anyway.

```
180.4 KB  ->  171.4 KB          8.6 KB of headroom
```

The budget stays at **180**, deliberately not re-ratcheted to 172: #443 has three more groups of
primitives to land, and re-tightening now would guarantee the same breach again. 180 is the guide's
target and we are comfortably under it.

## Verification

```
$ node scripts/check-bundle-budget.mjs   → ✓ Within budget (171.4 KB ≤ 180 KB)
$ npx vitest run                         → 35 files, 413 tests passed
$ npx playwright test e2e/visual/        → 55 passed
$ npx tsc -b                             → clean
$ npm run check:tokens                   → 274 tokens 0 drifting · 240 pairs 0 failing
$ npx eslint <the 4 touched files>       → 0 errors
```

## Honest remainders

- **The toast surface now loads after first paint.** A toast fired in the very first frame would
  have nothing mounted to render it. Nothing does that today — every `toast()` call sites behind a
  user action — but it is a real constraint this introduces.
- **`build-frontend` still has its own budget step**, now duplicated. Both are cheap; the comment
  says to drop the one added here once lint and unit tests are green and `build-frontend` stops
  being skipped.
- **This does not fix the two red jobs** (322 pre-existing lint errors). They are the root cause of
  gates being placed in odd jobs at all, and deserve their own issue.