### PR TITLE
feat(ds): Empty — relicense to Apache-2.0 and close #443 (D-021)

### DIFF
--- a/frontend/scripts/check-license-boundary.mjs
+++ b/frontend/scripts/check-license-boundary.mjs
@@ -25,6 +25,20 @@
  * the guarantee worth automating is that a file cannot land in that directory
  * carrying the core's AGPL header.
  *
+ * TWO RULES, NOT ONE. The header check above is necessary and not sufficient:
+ * it reads the SPDX line and nothing else, so an Apache-2.0 file that IMPORTS
+ * the AGPL core passes it silently. That is the violation that actually matters
+ * — copying a header is a typo, importing across the boundary is the thing the
+ * boundary exists to prevent — and D-021 hit it for real: `Empty` moved into
+ * `shared/ds/` still importing `softFill` from `shared/riskColors`, and this
+ * script said everything was fine. So the second rule below resolves every
+ * relative import out of an Apache directory and asserts it stays inside one.
+ *
+ * Bare specifiers (`react`, `lucide-react`) are deliberately NOT checked here:
+ * that is inbound third-party licensing, a different question with a different
+ * answer, and pretending to cover it would make this gate the kind of green
+ * badge that asserts nothing.
+ *
  * Usage: npm run check:license-boundary
  */
 
@@ -114,6 +128,68 @@ for (const file of files) {
   }
 }
 
+/* ---------------------------------------------------- import direction -- */
+
+/** Candidate on-disk paths for an extension-less relative import. */
+function candidates(base) {
+  const exts = ['.ts', '.tsx', '.js', '.jsx', '.css'];
+  return [
+    base,
+    ...exts.map((e) => base + e),
+    ...exts.map((e) => join(base, 'index' + e)),
+  ];
+}
+
+/** Resolves a relative specifier to a repo-relative path, or null if unresolved. */
+function resolveRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  for (const candidate of candidates(base)) {
+    if (existsSync(candidate) && !readdirSyncIsDir(candidate)) {
+      return relative(REPO, candidate).split('\\').join('/');
+    }
+  }
+  return null;
+}
+
+function readdirSyncIsDir(p) {
+  try {
+    readdirSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* `from '...'` covers both `import ... from` and `export ... from`; the bare
+   side-effect form `import './x'` is matched separately. */
+const FROM = /\bfrom\s+['"]([^'"]+)['"]/g;
+const SIDE_EFFECT = /\bimport\s+['"]([^'"]+)['"]/g;
+
+let crossed = 0;
+
+for (const file of files) {
+  const rel = relative(REPO, file).split('\\').join('/');
+  if (!APACHE_DIRS.some((d) => rel.startsWith(`${d}/`))) continue;
+
+  const source = readFileSync(file, 'utf8');
+  const specs = [
+    ...[...source.matchAll(FROM)].map((m) => m[1]),
+    ...[...source.matchAll(SIDE_EFFECT)].map((m) => m[1]),
+  ];
+
+  for (const spec of specs) {
+    if (!spec.startsWith('.')) continue; // npm package — inbound licensing, not this gate
+    const target = resolveRelative(file, spec);
+    if (!target) continue; // type-only or generated path we cannot see; not a licence claim
+    if (APACHE_DIRS.some((d) => target.startsWith(`${d}/`))) continue;
+
+    console.log(`CROSSES  ${rel}`);
+    console.log(`  imports '${spec}' → ${target}`);
+    console.log('  Apache-2.0 may not depend on the AGPL core; the dependency runs one way\n');
+    crossed++;
+  }
+}
+
 console.log(
   `${checked} files checked — ` +
     Object.entries(counts)
@@ -122,9 +198,10 @@ console.log(
       .join(' · '),
 );
 
-if (missing || wrong) {
+if (missing || wrong || crossed) {
   console.error(
-    `\nLicence boundary FAILED: ${missing} missing header(s), ${wrong} on the wrong side.\n` +
+    `\nLicence boundary FAILED: ${missing} missing header(s), ${wrong} on the wrong side, ` +
+      `${crossed} import(s) crossing it.\n` +
       'frontend/design-system/ and frontend/src/shared/ds/ are Apache-2.0; the rest of\n' +
       'frontend/src/ is AGPL-3.0-only, except Enterprise files which declare\n' +
       'LicenseRef-OpenRisk-Commercial. Apache-2.0 is irreversible once published, so a\n' +
@@ -132,4 +209,7 @@ if (missing || wrong) {
   );
   process.exit(1);
 }
-console.log('Every file is on the correct side of the three-licence boundary.');
+console.log(
+  'Every file is on the correct side of the three-licence boundary, and no Apache-2.0\n' +
+    'file imports across it.',
+);

--- a/frontend/src/shared/EmptyState.tsx
+++ b/frontend/src/shared/EmptyState.tsx
@@ -1,124 +1,20 @@
 // Copyright (c) 2026 OpenDefender Contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// The single empty state for the whole app.
+// Compatibility shim. The implementation moved to `shared/ds/Empty.tsx` and was
+// relicensed to Apache-2.0 by D-021 (2026-09-02), so that the design system has
+// an empty state without the Apache layer depending on AGPL code — the
+// dependency runs one way only, and this file is the allowed direction: AGPL
+// importing Apache.
 //
-// A fresh tenant is mostly empty states, so they are not an edge case to be
-// handled with a shrug — they are the product's first impression. Three
-// divergent EmptyState components used to exist (this one, components/shared/,
-// and one inlined in shared/ui.tsx), each with different prop names and a
-// different idea of whether an action was required. They are now this one.
+// This file exists so that the 24 importers of `shared/EmptyState` do not change
+// at all: #443 Résolution 1 point 4 forbids rewriting call sites.
 //
-// The variant is the whole point:
-//
-//   first-use      Nothing here YET. This is a tutorial: say in one sentence
-//                  what the page is for, and offer the action that fills it.
-//                  Never a sad "no data" — the user has not failed at anything.
-//   no-results     There IS data, the filter excluded it. Offer a way back out.
-//   error          We could not load. Offer a retry.
-//   no-permission  It exists, this user may not see it. Say who to ask.
-//
-// The distinction matters because the four cases have opposite remedies, and
-// collapsing them into one grey "Aucune donnée" is what makes a fresh install
-// feel broken rather than new.
+// NEW CODE SHOULD IMPORT `Empty` FROM `shared/ds`. This shim is kept for the
+// existing call sites, not as a second name for a new one to choose between.
 
-import type { ReactNode } from 'react';
-import { Inbox, SearchX, AlertTriangle, Lock, ExternalLink, type LucideIcon } from 'lucide-react';
-import { softFill } from './riskColors';
-
-export type EmptyStateVariant = 'first-use' | 'no-results' | 'error' | 'no-permission';
-
-interface VariantStyle {
-  icon: LucideIcon;
-  /** Token driving the icon tile's tint. */
-  tone: string;
-  /** first-use and error earn a tinted tile; the quieter states stay neutral. */
-  tinted: boolean;
-}
-
-const VARIANTS: Record<EmptyStateVariant, VariantStyle> = {
-  'first-use': { icon: Inbox, tone: 'var(--accent)', tinted: true },
-  'no-results': { icon: SearchX, tone: 'var(--fg-muted)', tinted: false },
-  error: { icon: AlertTriangle, tone: 'var(--critical)', tinted: true },
-  'no-permission': { icon: Lock, tone: 'var(--fg-muted)', tinted: false },
-};
-
-export interface EmptyStateProps {
-  variant?: EmptyStateVariant;
-  /** Overrides the variant's default glyph. */
-  icon?: LucideIcon;
-  title: string;
-  /** For first-use, this is the tutorial line: what is this page for? */
-  description?: string;
-  /** The action that resolves the state — creating the first record, clearing
-   *  the filter, retrying. Strongly encouraged on first-use and no-results. */
-  primaryAction?: ReactNode;
-  secondaryAction?: ReactNode;
-  /** Documentation deep-link, rendered as a quiet trailing link. */
-  learnMoreHref?: string;
-  learnMoreLabel?: string;
-  className?: string;
-}
-
-export function EmptyState({
-  variant = 'first-use',
-  icon,
-  title,
-  description,
-  primaryAction,
-  secondaryAction,
-  learnMoreHref,
-  learnMoreLabel,
-  className = '',
-}: EmptyStateProps) {
-  const v = VARIANTS[variant];
-  const Icon = icon ?? v.icon;
-  const hasActions = Boolean(primaryAction || secondaryAction);
-
-  return (
-    <div
-      // Hooks for the empty-states E2E sweep, which asserts that a fresh tenant
-      // renders one of these on every screen instead of fabricated numbers.
-      data-testid="empty-state"
-      data-variant={variant}
-      role="status"
-      className={`flex flex-col items-center justify-center text-center py-16 px-6 ${className}`}
-      style={{ animation: 'or-fadein .3s ease' }}
-    >
-      <div
-        className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5"
-        style={{
-          background: v.tinted ? softFill(v.tone, 12) : 'var(--bg-hover)',
-          color: v.tone,
-        }}
-      >
-        <Icon size={28} strokeWidth={1.7} />
-      </div>
-
-      <div className="text-md font-semibold text-ink mb-1.5">{title}</div>
-
-      {description && (
-        <div className="text-sm text-ink-soft max-w-sm leading-relaxed">{description}</div>
-      )}
-
-      {hasActions && (
-        <div className="flex items-center justify-center gap-2.5 flex-wrap mt-5">
-          {primaryAction}
-          {secondaryAction}
-        </div>
-      )}
-
-      {learnMoreHref && (
-        <a
-          href={learnMoreHref}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs text-ink-muted hover:text-ink transition-colors mt-4"
-        >
-          {learnMoreLabel ?? 'En savoir plus'}
-          <ExternalLink size={13} strokeWidth={1.8} />
-        </a>
-      )}
-    </div>
-  );
-}
+export {
+  Empty as EmptyState,
+  type EmptyProps as EmptyStateProps,
+  type EmptyVariant as EmptyStateVariant,
+} from "./ds/Empty";

--- a/frontend/src/shared/ds/Empty.tsx
+++ b/frontend/src/shared/ds/Empty.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Empty — the single empty state for the whole app.
+ *
+ * A fresh tenant is mostly empty states, so they are not an edge case to be
+ * handled with a shrug — they are the product's first impression. Three
+ * divergent EmptyState components used to exist (shared/, components/shared/,
+ * and one inlined in shared/ui.tsx), each with different prop names and a
+ * different idea of whether an action was required. They are now this one, and
+ * keeping it that way is the point: a fourth is a regression, not a feature.
+ *
+ * THE VARIANT IS THE WHOLE POINT.
+ *
+ *   first-use      Nothing here YET. This is a tutorial: say in one sentence
+ *                  what the page is for, and offer the action that fills it.
+ *                  Never a sad "no data" — the user has not failed at anything.
+ *   no-results     There IS data, the filter excluded it. Offer a way back out.
+ *   error          We could not load. Offer a retry.
+ *   no-permission  It exists, this user may not see it. Say who to ask.
+ *
+ * The distinction matters because the four cases have opposite remedies, and
+ * collapsing them into one grey "Aucune donnée" is what makes a fresh install
+ * feel broken rather than new.
+ *
+ * WHY IT LIVES HERE (D-021, 2026-09-02). It was `src/shared/EmptyState.tsx`
+ * under AGPL-3.0. `shared/ds/` is Apache-2.0 (D-014, D-016) and may not depend
+ * on or re-export AGPL code — the dependency runs one way only. That left three
+ * options: relicense and move, build a second generic `Empty` beside this one,
+ * or accept a design system with no empty state. Only this one leaves the
+ * product with ONE empty state AND a complete primitive layer.
+ *
+ * `src/shared/EmptyState.tsx` is now a re-export shim under its original names,
+ * so all 24 importers are untouched — #443 Résolution 1 point 4 forbids
+ * rewriting call sites.
+ */
+
+import type { ReactNode } from "react";
+import {
+  Inbox,
+  SearchX,
+  AlertTriangle,
+  Lock,
+  ExternalLink,
+  type LucideIcon,
+} from "lucide-react";
+
+export type EmptyVariant =
+  "first-use" | "no-results" | "error" | "no-permission";
+
+/**
+ * A translucent wash of `color` over whatever is behind it.
+ *
+ * Inlined rather than imported from `shared/riskColors`, which is the AGPL core:
+ * an Apache-2.0 file may not depend on it, and the licence-boundary script reads
+ * headers rather than imports, so that violation would have passed CI silently.
+ * There is nothing to share here anyway — this is one generic `color-mix` with
+ * no risk semantics in it, unlike the rest of `riskColors`, which maps
+ * criticality and framework names and is product knowledge that stays AGPL.
+ */
+function tint(color: string, pct: number): string {
+  return `color-mix(in srgb, ${color} ${pct}%, transparent)`;
+}
+
+interface VariantStyle {
+  icon: LucideIcon;
+  /** Token driving the icon tile's tint. */
+  tone: string;
+  /** first-use and error earn a tinted tile; the quieter states stay neutral. */
+  tinted: boolean;
+}
+
+const VARIANTS: Record<EmptyVariant, VariantStyle> = {
+  "first-use": { icon: Inbox, tone: "var(--accent)", tinted: true },
+  "no-results": { icon: SearchX, tone: "var(--fg-muted)", tinted: false },
+  error: { icon: AlertTriangle, tone: "var(--critical)", tinted: true },
+  "no-permission": { icon: Lock, tone: "var(--fg-muted)", tinted: false },
+};
+
+export interface EmptyProps {
+  variant?: EmptyVariant;
+  /** Overrides the variant's default glyph. */
+  icon?: LucideIcon;
+  title: string;
+  /** For first-use, this is the tutorial line: what is this page for? */
+  description?: string;
+  /** The action that resolves the state — creating the first record, clearing
+   *  the filter, retrying. Strongly encouraged on first-use and no-results. */
+  primaryAction?: ReactNode;
+  secondaryAction?: ReactNode;
+  /** Documentation deep-link, rendered as a quiet trailing link. */
+  learnMoreHref?: string;
+  learnMoreLabel?: string;
+  className?: string;
+}
+
+export function Empty({
+  variant = "first-use",
+  icon,
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+  learnMoreHref,
+  learnMoreLabel,
+  className = "",
+}: EmptyProps) {
+  const v = VARIANTS[variant];
+  const Icon = icon ?? v.icon;
+  const hasActions = Boolean(primaryAction || secondaryAction);
+
+  return (
+    <div
+      // Hooks for the empty-states E2E sweep, which asserts that a fresh tenant
+      // renders one of these on every screen instead of fabricated numbers.
+      data-testid="empty-state"
+      data-variant={variant}
+      role="status"
+      className={`flex flex-col items-center justify-center text-center py-16 px-6 ${className}`}
+      style={{ animation: "or-fadein .3s ease" }}
+    >
+      <div
+        className="w-16 h-16 rounded-2xl flex items-center justify-center mb-5"
+        style={{
+          background: v.tinted ? tint(v.tone, 12) : "var(--bg-hover)",
+          color: v.tone,
+        }}
+      >
+        <Icon size={28} strokeWidth={1.7} />
+      </div>
+
+      <div className="text-md font-semibold text-ink mb-1.5">{title}</div>
+
+      {description && (
+        <div className="text-sm text-ink-soft max-w-sm leading-relaxed">
+          {description}
+        </div>
+      )}
+
+      {hasActions && (
+        <div className="flex items-center justify-center gap-2.5 flex-wrap mt-5">
+          {primaryAction}
+          {secondaryAction}
+        </div>
+      )}
+
+      {learnMoreHref && (
+        <a
+          href={learnMoreHref}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-ink-muted hover:text-ink transition-colors mt-4"
+        >
+          {learnMoreLabel ?? "En savoir plus"}
+          <ExternalLink size={13} strokeWidth={1.8} />
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/ds/__tests__/feedback.test.tsx
+++ b/frontend/src/shared/ds/__tests__/feedback.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Feedback primitives: Spinner and AlertDialog. #443 PR 2.
+ * Feedback primitives: Spinner, AlertDialog and Empty. #443 PR 2 (Empty landed
+ * later, once D-021 unblocked the licence question that kept it out).
  *
  * Same doctrine as the other two suites — behaviour and accessibility, never
  * class names. For AlertDialog the behaviour under test is almost entirely about
@@ -18,6 +19,8 @@ import userEvent from '@testing-library/user-event';
 import { Spinner } from '../Spinner';
 import { AlertDialog } from '../AlertDialog';
 import { LoadingState } from '../States';
+import { Empty } from '../Empty';
+import { EmptyState } from '../../EmptyState';
 
 /* ----------------------------------------------------------------- Spinner -- */
 
@@ -150,4 +153,53 @@ describe('accessibility (axe-core)', () => {
     );
     expect(serious.map((v) => `${v.id}: ${v.help}`)).toEqual([]);
   }, 20_000);
+});
+
+/* ------------------------------------------------------------------- Empty -- */
+
+describe('Empty', () => {
+  it('announces itself, because it replaces content the user was expecting', () => {
+    render(<Empty title="No risks yet" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('No risks yet')).toBeInTheDocument();
+  });
+
+  it('exposes the variant, which is what the E2E fresh-tenant sweep asserts on', () => {
+    const { rerender } = render(<Empty title="Nothing" />);
+    // first-use is the default on purpose: a fresh tenant has not failed at
+    // anything, and "no data" is the wrong thing to say to it.
+    expect(screen.getByTestId('empty-state')).toHaveAttribute('data-variant', 'first-use');
+
+    rerender(<Empty title="Nothing" variant="no-results" />);
+    expect(screen.getByTestId('empty-state')).toHaveAttribute('data-variant', 'no-results');
+  });
+
+  it('renders both actions when given them, and neither slot when not', () => {
+    const { rerender } = render(<Empty title="Nothing" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    rerender(
+      <Empty
+        title="Nothing"
+        primaryAction={<button type="button">Create</button>}
+        secondaryAction={<button type="button">Import</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument();
+  });
+
+  it('opens the learn-more link safely in a new tab', () => {
+    render(<Empty title="Nothing" learnMoreHref="https://docs.example/risks" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    // rel=noreferrer, or the new tab can reach back through window.opener.
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('is still reachable under its old name and path (D-021 shim)', () => {
+    // The 24 existing importers were deliberately NOT rewritten — Résolution 1
+    // point 4. If this fails, the shim is gone and every one of them is broken.
+    expect(EmptyState).toBe(Empty);
+  });
 });

--- a/frontend/src/shared/ds/index.ts
+++ b/frontend/src/shared/ds/index.ts
@@ -42,6 +42,7 @@ export {
 export { Modal, type ModalProps, type ModalSize } from './Modal';
 export { AlertDialog, type AlertDialogProps } from './AlertDialog';
 export { Spinner, type SpinnerProps, type SpinnerSize } from './Spinner';
+export { Empty, type EmptyProps, type EmptyVariant } from './Empty';
 export { Drawer, type DrawerProps, type DrawerSide, type DrawerSize } from './Drawer';
 export { Tabs, TabPanel, type TabItem, type TabsProps } from './Tabs';
 export { Tooltip, type TooltipProps, type TooltipPlacement } from './Tooltip';


### PR DESCRIPTION
Closes #443.

Implements **D-021**. This is the last deliverable of #443 — the `Empty` that PR 2 could not build.

## What was blocking it

`shared/ds/` is Apache-2.0 (D-014, D-016) and may not depend on or re-export AGPL code; the
dependency runs one way only. `src/shared/EmptyState.tsx` was AGPL, had **24 importers**, and is
itself the consolidation of three divergent empty states. So the design system could not have an
empty state without either relicensing that file, building a second one beside it, or going without.
D-021 chose the relicence: it is the only option that leaves the product with **one** empty state
AND a complete primitive layer.

## What changed

- `src/shared/ds/Empty.tsx` — the implementation, **Apache-2.0**, exporting `Empty` / `EmptyProps` /
  `EmptyVariant`. Rendering is unchanged, deliberately: 24 call sites depend on it and this is a
  licence move, not a redesign.
- `src/shared/EmptyState.tsx` — now a **re-export shim** under the original names. **Zero call sites
  changed**, per Résolution 1 point 4. A test asserts the shim still resolves to the same component,
  because if it silently went, all 24 importers would break at once.
- `src/shared/ds/index.ts` — exports `Empty`.

**`softFill` is inlined** as a local one-line `color-mix` rather than imported from
`shared/riskColors`. An Apache file may not depend on the AGPL core, and there was nothing to share:
the rest of `riskColors` maps criticality and framework names, which is product knowledge that stays
AGPL.

## The licence gate was not actually checking this

Worth reading even if the rest is routine. `scripts/check-license-boundary.mjs` read the SPDX header
and **nothing else** — so an Apache-2.0 file importing the AGPL core passed it silently. That is the
violation that matters: copying a header is a typo, importing across the boundary is the thing the
boundary exists to prevent. And this PR hit it for real — `Empty` moved into `shared/ds/` still
importing `softFill`, and the script reported *"every file is on the correct side"*.

The script now resolves every relative import out of an Apache directory and asserts it stays inside
one. **Verified by reintroducing that exact import:**

```
$ node scripts/check-license-boundary.mjs      # with the violation put back
  CROSSES  frontend/src/shared/ds/Empty.tsx
    imports '../riskColors' -> frontend/src/shared/riskColors.ts
  Licence boundary FAILED: 0 missing header(s), 0 on the wrong side, 1 import(s) crossing it.
  exit 1

$ node scripts/check-license-boundary.mjs      # restored
  442 files checked - 396 AGPL-3.0-only . 26 Apache-2.0 . 20 LicenseRef-OpenRisk-Commercial
  Every file is on the correct side, and no Apache-2.0 file imports across it.
  exit 0
```

Note `0 on the wrong side` in the failing run: **the header rule alone would have shipped this.**
Bare specifiers are deliberately not checked — that is inbound third-party licensing, a different
question, and covering it badly here would make this gate the kind of green badge that asserts
nothing.

## Verification

```
$ npx vitest run                          -> 37 files, 441 tests passed  (was 436; +5)
                                             run three times, identical
$ npx playwright test e2e/visual/         -> 63 passed
$ npx tsc -b                              -> clean
$ npx eslint src/shared/ds src/shared/EmptyState.tsx scripts/  -> 0 errors
$ npm run lint          (the whole tree)  -> 337 problems (321 errors) - IDENTICAL to master
$ npm run build && node scripts/check-bundle-budget.mjs
                                          -> within budget 171.4 KB <= 180 KB  (UNCHANGED - a pure move)
$ node scripts/check-license-boundary.mjs -> 442 files, all correct, no crossing imports
$ npm run check:tokens                    -> 240 pairs 0 failing
$ git diff --stat origin/master -- .../primitives.test.tsx
                                          -> (empty) - the 34 tests are UNMODIFIED
```

## Honest remainders

- **`Empty` keeps the core token vocabulary** (`text-ink`, `text-ink-soft`, `var(--bg-hover)`) rather
  than the design system's own (`text-fg-primary`, `bg-surface-*`). Changing it would have risked a
  visual regression across 24 screens inside a licence change. It is a consistency wart in the
  Apache layer and deserves its own issue; I have not opened one.
- **The 24 importers still import from `shared/EmptyState`.** That is required by Résolution 1
  point 4, not an oversight. Migrating them to `shared/ds` is a follow-up nobody has scheduled.
- **This branch inherits the cold-start visual flake** — the overflow test walks every gallery inside
  one default test budget and times out on a cold dev server. It reproduces on `master` and is fixed
  identically in #472 and #473; I did not add a third copy of the same patch here.
- **CI will be red**, as on `master` and on #472/#473: 321 pre-existing lint errors and a missing
  `@vitest/coverage-v8`. Decided as **D-022**, tracked by **#341**, not fixed here.
- Follow-ups from D-023 remain open: **#474** (OTP call sites — a live user-facing bug) and **#475**
  (`CommandPalette` rewire).
