### PR TITLE
fix(auth): one-time-code fields accept a pasted code; two of three move to OtpField (#474)

### DIFF
--- a/frontend/src/features/auth/AuthScreen.tsx
+++ b/frontend/src/features/auth/AuthScreen.tsx
@@ -18,6 +18,7 @@ import { landingForBusinessRole } from '../../shared/navModel';
 import { useUIStore } from '../../store/uiStore';
 import { authCopy, providerLabel, type OAuthErrorCode } from './authStrings';
 import { challengeMFA, setupMFA, verifyMFA } from './authService';
+import { OtpField, sanitiseCode } from '../../shared/ds';
 import { AuthLayout } from './AuthLayout';
 import { cascade, usePrefersReducedMotion } from './motion';
 import { PasswordStrength } from './PasswordStrength';
@@ -310,14 +311,27 @@ function MFAChallenge({ token, onCancel }: { token: string; onCancel: () => void
       <div className="mb-[18px]" style={cascade(1, reduced)}>
         <Label htmlFor="mfa-code">{copy.mfaCode}</Label>
         <Shake errorKey={nonce}>
+          {/* NOT an OtpField, deliberately. This field accepts a 6-digit TOTP
+              code OR a 12-character recovery code (backend:
+              `MFAVerifyInput.Code` — "TOTP code OR backup code", and
+              pkg/otp/totp.go mints 12-char base32 recovery codes). OtpField
+              draws a fixed number of segments, so using it here would cap entry
+              at six characters and lock out every user whose authenticator is
+              gone — which is the exact situation recovery codes exist for.
+              What it DOES take from the primitive is the sanitising: a code
+              pasted with spaces, or with the words around it, used to be
+              rejected while the user could plainly read the digits. */}
           <input
             id="mfa-code"
             data-testid="mfa-code"
             inputMode="numeric"
             autoComplete="one-time-code"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
             autoFocus
             value={code}
-            onChange={(e) => setCode(e.target.value)}
+            onChange={(e) => setCode(sanitiseCode(e.target.value, 'alphanumeric'))}
             className={`${inputCls} mono tracking-[0.3em] text-center`}
             style={inputStyle(Boolean(error))}
           />
@@ -465,15 +479,13 @@ function MFAEnrollment({ token }: { token: string }) {
       <div className="mb-[18px]" style={cascade(2, reduced)}>
         <Label htmlFor="enrol-code">{copy.mfaCode}</Label>
         <Shake errorKey={nonce}>
-          <input
+          <OtpField
             id="enrol-code"
-            data-testid="mfa-enrol-code"
-            inputMode="numeric"
-            autoComplete="one-time-code"
+            testId="mfa-enrol-code"
             value={code}
-            onChange={(e) => setCode(e.target.value)}
-            className={`${inputCls} mono tracking-[0.3em] text-center`}
-            style={inputStyle(Boolean(error))}
+            onValueChange={setCode}
+            length={6}
+            invalid={Boolean(error)}
           />
         </Shake>
       </div>

--- a/frontend/src/features/auth/MFAEnrollmentDialog.tsx
+++ b/frontend/src/features/auth/MFAEnrollmentDialog.tsx
@@ -10,6 +10,7 @@
 // from Settings → Security.
 
 import { useEffect, useRef, useState } from 'react';
+import { OtpField } from '../../shared/ds';
 import { createPortal } from 'react-dom';
 import { ShieldCheck, X, Loader2, Copy, Check } from 'lucide-react';
 import { toast } from 'sonner';
@@ -205,19 +206,15 @@ export function MFAEnrollmentDialog({ onClose, onEnrolled }: { onClose: () => vo
                 <span className="text-[11px] font-semibold uppercase tracking-[.04em] text-ink-muted">
                   {tr('Code à 6 chiffres', '6-digit code')}
                 </span>
-                <input
+                <OtpField
                   value={code}
-                  onChange={(e) => {
-                    setCode(e.target.value);
+                  onValueChange={(next) => {
+                    setCode(next);
                     setError('');
                   }}
-                  inputMode="numeric"
-                  autoComplete="one-time-code"
-                  maxLength={8}
-                  aria-invalid={!!error}
-                  aria-describedby={error ? 'mfa-enrol-error' : undefined}
-                  className="w-full h-10 px-3 rounded-[10px] text-[15px] tracking-[.3em] text-ink outline-none focus:border-accent transition-colors"
-                  style={{ border: '1px solid var(--border-strong)', background: 'var(--bg-elevated)' }}
+                  length={6}
+                  invalid={!!error}
+                  describedBy={error ? 'mfa-enrol-error' : undefined}
                 />
               </label>
 

--- a/frontend/src/features/auth/__tests__/otpMigration.test.tsx
+++ b/frontend/src/features/auth/__tests__/otpMigration.test.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// #474 — the one-time-code fields, after moving onto shared/ds.
+//
+// Two different controls, and the difference is the whole point of this suite:
+//
+//   ENROLMENT   only ever takes the 6-digit TOTP code the authenticator shows.
+//               Fixed length, so it is an OtpField and is drawn as segments.
+//   LOGIN       takes a 6-digit TOTP code OR a 12-character recovery code
+//               (backend MFAVerifyInput.Code is documented "TOTP code OR backup
+//               code", and pkg/otp/totp.go mints 12-char base32 recovery codes).
+//               NOT fixed length, so NOT an OtpField — segmenting it would cap
+//               entry at six characters and lock out exactly the users whose
+//               authenticator is gone.
+//
+// Both share the defect this issue exists to fix: a code pasted with spaces, or
+// with the words around it, was silently rejected while the user could plainly
+// read the digits on screen.
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+
+const navigate = vi.fn();
+const login = vi.fn();
+const adoptSession = vi.fn();
+const post = vi.fn();
+const setupMFA = vi.fn();
+const verifyMFA = vi.fn();
+const challengeMFA = vi.fn();
+
+vi.mock("react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router")>("react-router");
+  return { ...actual, useNavigate: () => navigate };
+});
+vi.mock("../../../lib/api", () => ({
+  api: { post: (...a: unknown[]) => post(...a), defaults: { baseURL: "" } },
+}));
+vi.mock("../authService", () => ({
+  setupMFA: (...a: unknown[]) => setupMFA(...a),
+  verifyMFA: (...a: unknown[]) => verifyMFA(...a),
+  challengeMFA: (...a: unknown[]) => challengeMFA(...a),
+  listSessions: vi.fn(),
+  revokeSession: vi.fn(),
+  revokeOtherSessions: vi.fn(),
+}));
+vi.mock("../../../hooks/useAuthStore", () => {
+  const state = {
+    user: undefined,
+    login: (...a: unknown[]) => login(...a),
+    adoptSession: (...a: unknown[]) => adoptSession(...a),
+  };
+  const useAuthStore = (sel?: (s: typeof state) => unknown) =>
+    sel ? sel(state) : state;
+  useAuthStore.getState = () => state;
+  return { useAuthStore };
+});
+
+import { AuthScreen } from "../AuthScreen";
+
+function renderAt(initialView: "login" | "register") {
+  return render(
+    <MemoryRouter>
+      <AuthScreen initialView={initialView} />
+    </MemoryRouter>,
+  );
+}
+
+/** Drives a login all the way to the MFA challenge field. */
+async function reachLoginChallenge() {
+  const user = userEvent.setup();
+  login.mockResolvedValue({
+    status: "mfa_required",
+    mfa_token: "challenge-token",
+  });
+  renderAt("login");
+  await user.type(screen.getByTestId("login-email"), "alix@example.com");
+  await user.type(screen.getByTestId("login-password"), "MotDePasse2026!");
+  await user.click(screen.getByTestId("login-submit"));
+  return { user, input: await screen.findByTestId("mfa-code") };
+}
+
+/** Drives a registration all the way to the MFA enrolment field. */
+async function reachEnrolment() {
+  const user = userEvent.setup();
+  login.mockResolvedValue({
+    status: "mfa_enrollment_required",
+    mfa_token: "enrol-token",
+  });
+  renderAt("register");
+  await user.type(screen.getByTestId("register-name"), "Alix Mensah");
+  await user.type(screen.getByTestId("register-email"), "alix@example.com");
+  await user.type(screen.getByTestId("register-password"), "MotDePasse2026!");
+  await user.click(screen.getByTestId("register-submit"));
+  await waitFor(() => expect(setupMFA).toHaveBeenCalled());
+  return { user, input: await screen.findByTestId("mfa-enrol-code") };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  post.mockResolvedValue({ data: {} });
+  setupMFA.mockResolvedValue({
+    secret: "ABCDEF",
+    qr_code: "/9j/rawbase64",
+    backup_codes: ["ABCDEFGH2345"],
+  });
+});
+
+/* ------------------------------------------------------------------ login -- */
+
+describe("the MFA login field", () => {
+  it("accepts a code pasted with spaces", async () => {
+    const { user, input } = await reachLoginChallenge();
+
+    await user.click(input);
+    await user.paste("123 456");
+
+    // THE DEFECT. This used to arrive as "123 456", which the backend rejects.
+    expect(input).toHaveValue("123456");
+  });
+
+  it("still accepts a 12-character recovery code — it is NOT capped at six", async () => {
+    const { user, input } = await reachLoginChallenge();
+
+    await user.click(input);
+    await user.paste("ABCDEFGH2345");
+
+    // THE REGRESSION GUARD for this issue's own scope. Making this an OtpField
+    // would have truncated to 6 and locked out every user who has lost their
+    // authenticator — the one situation recovery codes exist for.
+    expect(input).toHaveValue("ABCDEFGH2345");
+  });
+
+  it("upper-cases a recovery code typed in lower case", async () => {
+    const { user, input } = await reachLoginChallenge();
+
+    // The codes are displayed upper-case and the alphabet is upper-case base32;
+    // typing them as read should work.
+    await user.type(input, "abcdefgh2345");
+
+    expect(input).toHaveValue("ABCDEFGH2345");
+  });
+
+  it("is still a single field carrying the OS autofill hints", async () => {
+    const { input } = await reachLoginChallenge();
+
+    expect(input).toHaveAttribute("autocomplete", "one-time-code");
+    expect(input).toHaveAttribute("inputmode", "numeric");
+  });
+});
+
+/* -------------------------------------------------------------- enrolment -- */
+
+describe("the MFA enrolment field", () => {
+  it("is an OtpField of exactly six segments", async () => {
+    const { input } = await reachEnrolment();
+
+    // It used to be a bare input with maxLength={8} — wrong for a 6-digit code
+    // in one direction and for a 12-char recovery code in the other, and
+    // recovery codes are never entered here in the first place.
+    expect(input).toHaveAttribute("maxlength", "6");
+    expect(screen.getAllByTestId("otp-segment")).toHaveLength(6);
+  });
+
+  it("accepts a code pasted with spaces", async () => {
+    const { user, input } = await reachEnrolment();
+
+    await user.click(input);
+    await user.paste("123 456");
+
+    expect(input).toHaveValue("123456");
+  });
+
+  it("drops non-digits rather than refusing the code", async () => {
+    const { user, input } = await reachEnrolment();
+
+    await user.click(input);
+    await user.paste("Your code is 654321");
+
+    expect(input).toHaveValue("654321");
+  });
+});

--- a/frontend/src/shared/ds/OtpField.tsx
+++ b/frontend/src/shared/ds/OtpField.tsx
@@ -37,8 +37,10 @@ import {
 } from "react";
 import { cn } from "./cn";
 import { useControlWiring } from "./fieldContext";
+import { sanitiseCode as sanitise } from "./otpCode";
 
-export type OtpAlphabet = "numeric" | "alphanumeric";
+export type { OtpAlphabet } from "./otpCode";
+import type { OtpAlphabet } from "./otpCode";
 
 export interface OtpFieldProps {
   /** How many characters the code has. Drawn as this many segments. */
@@ -66,26 +68,18 @@ export interface OtpFieldProps {
   id?: string;
   className?: string;
   autoFocus?: boolean;
+  /**
+   * Error state for a control used OUTSIDE a `Field`. Inside one the status is
+   * inherited and this is unnecessary; the MFA dialogs label the code
+   * themselves and carry their own error line, so they need to say it here.
+   */
+  invalid?: boolean;
+  /** Id of an external error/description element to associate. */
+  describedBy?: string;
+  /** Placed on the real input, for existing E2E hooks. */
+  testId?: string;
 }
 
-const PATTERN: Record<OtpAlphabet, RegExp> = {
-  numeric: /[^0-9]/g,
-  alphanumeric: /[^a-zA-Z0-9]/g,
-};
-
-/**
- * Keeps only the characters the alphabet allows and truncates to length.
- *
- * Deliberately tolerant of what a real paste contains: spaces and hyphens from
- * a formatted code, and the surrounding words when someone selects a whole line
- * out of an email. Anything that is not a code character is simply not a code
- * character.
- */
-function sanitise(raw: string, alphabet: OtpAlphabet, length: number): string {
-  const cleaned = raw.replace(PATTERN[alphabet], "");
-  const cased = alphabet === "alphanumeric" ? cleaned.toUpperCase() : cleaned;
-  return cased.slice(0, length);
-}
 
 export const OtpField = forwardRef<HTMLInputElement, OtpFieldProps>(
   function OtpField(
@@ -100,10 +94,18 @@ export const OtpField = forwardRef<HTMLInputElement, OtpFieldProps>(
       id,
       className,
       autoFocus,
+      invalid = false,
+      describedBy,
+      testId,
     },
     ref,
   ) {
-    const { id: wiredId, status, aria } = useControlWiring(id);
+    const { id: wiredId, status: fieldStatus, aria } = useControlWiring(id);
+    /* A Field, when there is one, is the authority — it already knows whether
+       the group is invalid. `invalid` only speaks for a control standing on its
+       own, which is how both MFA dialogs use it. */
+    const status =
+      fieldStatus !== "default" ? fieldStatus : invalid ? "invalid" : "default";
     const describedById = useId();
     const segments = useMemo(
       () => Array.from({ length }, (_, i) => i),
@@ -179,8 +181,10 @@ export const OtpField = forwardRef<HTMLInputElement, OtpFieldProps>(
             maxLength={length}
             aria-label={label}
             aria-describedby={
-              cn(aria["aria-describedby"], describedById) || undefined
+              cn(aria["aria-describedby"], describedBy, describedById) || undefined
             }
+            aria-invalid={status === "invalid" || undefined}
+            data-testid={testId}
             className="absolute inset-0 z-10 h-full w-full cursor-text bg-transparent text-transparent caret-transparent outline-none disabled:cursor-not-allowed"
             {...aria}
           />

--- a/frontend/src/shared/ds/index.ts
+++ b/frontend/src/shared/ds/index.ts
@@ -48,7 +48,8 @@ export { Tooltip, type TooltipProps, type TooltipPlacement } from './Tooltip';
 export { Popover, type PopoverProps, type PopoverPlacement } from './Popover';
 export { Menu, type MenuProps, type MenuItem } from './Menu';
 export { Command, type CommandProps, type CommandItem } from './Command';
-export { OtpField, type OtpFieldProps, type OtpAlphabet } from './OtpField';
+export { OtpField, type OtpFieldProps } from './OtpField';
+export { sanitiseCode, type OtpAlphabet } from './otpCode';
 export {
   ErrorState,
   PermissionDenied,

--- a/frontend/src/shared/ds/otpCode.ts
+++ b/frontend/src/shared/ds/otpCode.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Code sanitising, in its own module.
+ *
+ * Split out of OtpField.tsx for the same mechanical reason fieldContext.ts is
+ * split out of Field.tsx: a module that exports both a component and a plain
+ * function cannot be hot-replaced reliably, and `react-refresh/only-export-components`
+ * is at error level here.
+ *
+ * It has a second consumer, which is why it is exported at all. The MFA LOGIN
+ * field is not an OtpField — it accepts a 6-digit TOTP code OR a 12-character
+ * recovery code, so it has no fixed length to draw segments for — but it needs
+ * exactly this cleaning, because the defect being fixed (a pasted code with
+ * spaces or surrounding words silently rejected) is worst on the login path.
+ */
+
+export type OtpAlphabet = "numeric" | "alphanumeric";
+
+const PATTERN: Record<OtpAlphabet, RegExp> = {
+  numeric: /[^0-9]/g,
+  alphanumeric: /[^a-zA-Z0-9]/g,
+};
+
+/**
+ * Keeps only the characters the alphabet allows, and truncates to `length` when
+ * one is given. Omit `length` for a code whose length is not fixed.
+ *
+ * Deliberately tolerant of what a real paste contains: spaces and hyphens from a
+ * formatted code, and the surrounding words when someone selects a whole line
+ * out of an email. Anything that is not a code character is simply not a code
+ * character.
+ */
+export function sanitiseCode(
+  raw: string,
+  alphabet: OtpAlphabet,
+  length?: number,
+): string {
+  const cleaned = raw.replace(PATTERN[alphabet], "");
+  const cased = alphabet === "alphanumeric" ? cleaned.toUpperCase() : cleaned;
+  return length === undefined ? cased : cased.slice(0, length);
+}


### PR DESCRIPTION
Closes #474.

> Branched off #473 while it was open; #473 merged mid-work, so this now targets `master` directly
> and the diff is the three commits below.

## The issue said migrate three fields. Two of them. Migrating the third would have been a serious regression.

That is the substance of this PR, so it goes first.

The **login** MFA field and the **enrolment** MFA fields look identical and are not the same control:

| | Accepts | Fixed length? | Verdict |
|---|---|---|---|
| Enrolment (`AuthScreen` enrol-code, `MFAEnrollmentDialog`) | the 6-digit TOTP code only | yes | **OtpField** |
| Login (`AuthScreen` mfa-code) | a 6-digit TOTP code **OR a 12-character recovery code** | **no** | **stays a plain input** |

The backend is explicit: `MFAVerifyInput.Code` is documented *"TOTP code OR backup code"*,
`mfa_usecase.go` verifies TOTP and then falls back to *"Try backup code"*, and `pkg/otp/totp.go`
mints **12-character** base32 recovery codes (`lnCodeLength = 12`, alphabet without `0/1/8/9`). The
login screen's own hint says *"Use a recovery code"*.

`OtpField` draws a fixed number of segments. Making the login field one would have capped entry at
six characters and **locked out every user whose authenticator is gone** — the single situation
recovery codes exist for. That would have been a far worse defect than the one being fixed, on the
most important path in the product.

So the login field keeps its shape and takes the part of the primitive it actually needs: the
sanitising. `sanitiseCode` is exported for it.

**Criterion 3 of the issue is therefore not met as written**, and should not be — it asked that no
local `one-time-code` input remain. Exactly one remains, deliberately, with the reasoning in a
comment at the call site so the next person does not "finish the job".

## The defect being fixed

A code copied out of an email as `123 456`, or as `Your code is 123456`, was rejected without ever
reaching the server — while the user could plainly read the digits on screen. Nothing sanitised the
pasted value at any of the three sites. It is now fixed at all three, including login.

Also fixed: `MFAEnrollmentDialog` had `maxLength={8}` for a six-digit code. Worth noting the issue's
framing of that was wrong too — I described 8 as "too long for a 6-digit code", but it is also *too
short* for the 12-character recovery code, and recovery codes are never entered on that screen
anyway. It is now 6.

## What the migration proved was missing from `OtpField`

Three props, each driven by a real call site rather than invented:

- `invalid` — a control outside a `Field` had no way to show error state. Both MFA dialogs label the
  code themselves and carry their own error line. A `Field`, when present, still wins.
- `describedBy` — to associate the dialog's existing `#mfa-enrol-error` element.
- `testId` — to keep the `data-testid` hooks on the two auth fields.

`sanitiseCode` also moves into `otpCode.ts`, for the same mechanical reason `fieldContext.ts` exists:
a module exporting both a component and a plain function cannot be hot-replaced, and
`react-refresh/only-export-components` is at `error` here. It caught this immediately.

## Verification

```
$ npx vitest run                          -> 39 files, 461 tests passed  (was 454; +7)
$ npx playwright test e2e/visual/         -> 67 passed, 3 failed - the 3 failures are a
                                             PRE-EXISTING master regression, see below
$ npx tsc -b                              -> clean
$ npx eslint src/features/auth src/shared/ds
                                          -> 5 errors, ALL pre-existing in MFAPostAhaPrompt.tsx;
                                             identical count before and after (verified by stashing)
$ npm run lint          (the whole tree)  -> 337 problems (321 errors) - IDENTICAL to master
$ npm run build && node scripts/check-bundle-budget.mjs
                                          -> within budget 172.1 KB <= 180 KB
$ node scripts/check-license-boundary.mjs -> 444 files, all on the correct side
$ npm run check:tokens                    -> 240 pairs 0 failing
$ rg -n "one-time-code" src/features | grep -v __tests__
                                          -> AuthScreen.tsx:328 only (the login field, deliberate)
```

**The paste tests were verified to fail without the fix** — reverting the login field's `onChange`
turned 2 of the 7 red, then green again on restore. A test that has never failed proves nothing.

## Honest remainders

- **Criterion 4 (axe on the real auth screens) is NOT verified.** `e2e/auth.spec.ts` skips itself
  when the API is unreachable, and there is no backend in this environment. What IS verified is axe
  on `OtpField` itself in both themes, via the `specialised-input` gallery on #473, and the markup
  around the migrated fields (`Label`, `Shake`) is unchanged. Someone with the stack up should run
  the auth suite before this is called done on that criterion.
- **The login field is still visually a plain box**, not segmented. That is correct for a
  variable-length code, but it does mean the two MFA screens now look different from each other.
  A designer should decide whether the login field wants its own treatment; I have not opened an
  issue for it.
- **CI will be red**, as on `master` and every open PR: 321 pre-existing lint errors and a missing
  `@vitest/coverage-v8`. Decided as **D-022**, tracked by **#341**.
- **`master`'s visual suite is red before this PR, and not because of it.** Merging #472 and #473
  dropped the `table` gallery from `e2e/visual/gallery.tsx` (the `TableDensity` component and both
  registry entries) while keeping the three `table rows follow --den-row` tests that drive it, so
  those three fail on `master` today. The density FEATURE is intact - `useDensityRowHeight.ts` and
  the `DataTable` wiring both survived - it is only the test harness that was lost in the conflict
  resolution. Raised and fixed separately; nothing in this PR touches it.
