### PR TITLE
fix(test): wait for the seeded value, not just the spinbutton (#501)

### DIFF
--- a/frontend/src/features/settings/__tests__/mfaPolicyPanel.test.tsx
+++ b/frontend/src/features/settings/__tests__/mfaPolicyPanel.test.tsx
@@ -65,7 +65,10 @@ describe('MFAPolicyPanel', () => {
   it('shows the shipped default and says nobody chose it', async () => {
     renderPanel();
     const input = (await screen.findByRole('spinbutton')) as HTMLInputElement;
-    expect(input.value).toBe('7');
+    // The panel seeds this field from the server in an effect, not at render, so
+    // there is exactly one frame where the spinbutton exists holding ''.
+    // findByRole resolves on that frame — wait for the VALUE, not the element.
+    await waitFor(() => expect(input.value).toBe('7'));
     expect(document.body.textContent).toMatch(/default value|valeur par défaut/i);
   });
 


### PR DESCRIPTION
Closes #501

One-line fix to a race in a test, plus the comment explaining why it was a race.

## Root cause

`MFAPolicyPanel` seeds the field from the server in an effect, not at render:

```tsx
const [days, setDays] = useState<string>('');                    // line 33
useEffect(() => {
  if (policy && !touched) setDays(String(policy.grace_days));    // line 40
}, [policy, touched]);
```

While loading, the panel renders a skeleton and there is no spinbutton. The
instant the query resolves the spinbutton renders with `value={days}` — and
`days` is still `''`, because the effect runs after paint.

`findByRole('spinbutton')` resolves as soon as the **element** exists, so the
test read `.value` on precisely the frame where it is empty. The assertion now
waits for the value instead. **The component is unchanged** — a single frame of
empty value is invisible to a user, and the panel's "don't clobber the admin's
typing on a background refetch" behaviour is deliberate and correct.

The other seven tests in the file were each checked; none reads the seeded
value, so none shares this race, and none is touched.

## Verification

```
=== single suite, as CI runs it ===
 Test Files  41 passed (41)
      Tests  481 passed (481)

=== mfaPolicyPanel.test.tsx, 5 consecutive runs ===
      Tests  8 passed (8)   x5
```

Honest note on reproduction: **the unfixed test passes locally in isolation** —
this machine flushes the effect before `findByRole` resolves, which is exactly
why it survived review. It reproduces under load. One unfixed full-suite run on
a loaded machine gave `11 failed | 470 passed`; with the fix, two deliberately
concurrent suites gave `2 failed` and `3 failed` and **`mfaPolicyPanel` was in
neither**. The authoritative reproduction is CI itself:
`expected '' to be '7'` on run 33639356696.

## Why it appeared now

`Frontend Unit Tests` has never executed on any branch — `@vitest/coverage-v8`
was missing, so `vitest --coverage` died with `MISSING DEPENDENCY` before running
anything. #341 (PR #500) fixes that, and the job's first run in its life failed
here. **This PR unblocks #500**, which cannot go green until it lands.

## Honest remainders

- Two *other* files are timing-fragile under artificial 2× contention:
  `action-center/__tests__/actionCenterPage.test.tsx` (pager + axe) and
  `auth/__tests__/signup.test.tsx` (MFA hand-off). They did **not** fail in any
  single-suite run, so they may well be fine under CI's one-suite load — but
  they are the next thing likely to make the new gate flap. Not fixed here; they
  are unrelated to this issue and deserve their own investigation.
- `Frontend Design Tokens` remains red on master for an unrelated reason (the
  D-021 licence-boundary break). Not touched by this PR.
