### PR TITLE
fix(licence): move the D-021 shim assertion off the Apache side (#503)

### DIFF
--- a/frontend/src/shared/__tests__/emptyStateShim.test.tsx
+++ b/frontend/src/shared/__tests__/emptyStateShim.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * The D-021 compatibility shim.
+ *
+ * D-021 relicensed the empty state to Apache-2.0 and moved the implementation to
+ * `shared/ds/Empty.tsx`, leaving `shared/EmptyState.tsx` re-exporting it so the
+ * existing importers did not have to be rewritten (#443 Résolution 1 point 4).
+ * If the shim stops pointing at the real component, every one of those call
+ * sites breaks at once — so it is asserted, not assumed.
+ *
+ * This suite lives on the AGPL side deliberately. It was previously in
+ * `shared/ds/__tests__/feedback.test.tsx`, which is Apache-2.0, and importing the
+ * AGPL shim from there pointed the dependency the one way it may not go: the
+ * licence-boundary gate failed on it, and took four later CI steps down with it
+ * (see #503). AGPL importing Apache is the allowed direction, so the assertion
+ * belongs here.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from '../EmptyState';
+import { Empty } from '../ds/Empty';
+
+describe('shared/EmptyState (D-021 shim)', () => {
+  it('is still reachable under its old name and path', () => {
+    expect(EmptyState).toBe(Empty);
+  });
+
+  it('re-exports the component itself, not a wrapper around it', () => {
+    // A wrapper would satisfy "is defined" while quietly changing displayName,
+    // defaultProps or ref forwarding for all 24 call sites.
+    expect(EmptyState).toBeTypeOf('function');
+    expect(EmptyState.name).toBe(Empty.name);
+  });
+});

--- a/frontend/src/shared/ds/__tests__/feedback.test.tsx
+++ b/frontend/src/shared/ds/__tests__/feedback.test.tsx
@@ -20,7 +20,6 @@ import { Spinner } from '../Spinner';
 import { AlertDialog } from '../AlertDialog';
 import { LoadingState } from '../States';
 import { Empty } from '../Empty';
-import { EmptyState } from '../../EmptyState';
 
 /* ----------------------------------------------------------------- Spinner -- */
 
@@ -197,9 +196,8 @@ describe('Empty', () => {
     expect(link).toHaveAttribute('rel', 'noreferrer');
   });
 
-  it('is still reachable under its old name and path (D-021 shim)', () => {
-    // The 24 existing importers were deliberately NOT rewritten — Résolution 1
-    // point 4. If this fails, the shim is gone and every one of them is broken.
-    expect(EmptyState).toBe(Empty);
-  });
+  // The D-021 shim assertion ("still reachable as shared/EmptyState") lives in
+  // src/shared/__tests__/emptyStateShim.test.tsx, NOT here. This directory is
+  // Apache-2.0 and the shim is AGPL: importing it from inside shared/ds/ pointed
+  // the dependency the forbidden way and failed the licence-boundary gate.
 });


### PR DESCRIPTION
Closes #503

`Frontend Design Tokens` has been red on master and on every branch. The
licence-boundary step reported one crossing import, and four later steps in the
same job sit behind it and have therefore been **skipped on every run**: the
visual suite, the opacity-modifier browser check, the axe/keyboard contract and
the bundle budget. That skipping is the larger loss.

## Root cause

D-021 relicensed the empty state to Apache-2.0 and moved it to
`shared/ds/Empty.tsx`, leaving `shared/EmptyState.tsx` as an **AGPL** shim so the
24 existing importers did not have to change (#443 Résolution 1 point 4).

`shared/ds/__tests__/feedback.test.tsx` is inside the Apache tree and imported
that AGPL shim, only to assert the shim still resolves to the real component. The
assertion is worth keeping — it is what stops those 24 call sites breaking
silently — but it was in the wrong directory.

## What changed

- The assertion moves to `shared/__tests__/emptyStateShim.test.tsx` (AGPL side,
  where AGPL→Apache is the allowed direction).
- It gains a second case: a wrapper would satisfy `toBeDefined` while quietly
  changing `displayName` and ref forwarding for every call site, so the shim is
  now asserted to be the component *itself*, not merely something truthy.
- `check-license-boundary.mjs` is **not** relaxed. Exempting tests from the
  import-direction rule is arguable — the script already exempts them from the
  *header* rule, on the stated grounds that "tests ship with no artefact" — but
  that is a change to a gate established by D-014/D-016 and belongs to the owner,
  not to a bug fix. Flagged rather than taken.

## Verification

```
=== licence gate ===
450 files checked — 396 AGPL-3.0-only · 34 Apache-2.0 · 20 LicenseRef-OpenRisk-Commercial
Every file is on the correct side of the three-licence boundary, and no
Apache-2.0 file imports across it.

=== full suite ===        Tests  482 passed (482)
=== typecheck (tsc -b) === exit 0
```

The relocated assertion was verified to **bite**, not merely to pass: replacing
the shim's re-export with a wrapper produces

```
AssertionError: expected [Function EmptyState] to be [Function Empty]
AssertionError: expected 'EmptyState' to be 'Empty'
      Tests  2 failed (2)
```

Acceptance criteria: 1 ✅ · 2 ✅ · 3 ✅ (proved above) · 4 ✅ (`check-license-boundary.mjs`
untouched) · 5 ✅ (`ds/Empty.tsx` and `EmptyState.tsx` untouched — empty diff).

## Honest remainders

- I did **not** run the four newly-unblocked steps locally (visual suite, opacity
  modifiers, axe/keyboard, bundle budget). They need Playwright's Chromium, and
  they have not executed in CI for long enough that I cannot predict them — **this
  PR's own run is the first time they will be exercised**, and one of them may
  well fail on something unrelated to this change.
- Independent of this PR: `actionCenterPage.test.tsx` and `signup.test.tsx` are
  timing-fragile under artificial 2× load (found while working #501). They pass in
  every single-suite run; noted as the likely source of future flapping.
