### PR TITLE
docs: amend D-024 — bklit ui declined, the chart layer is built in-house (#444)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -96,11 +96,60 @@ Recharts symbols would be work on a file no user can reach.
 
 ---
 
-### D-024 — bklit ui: a hard subset is vendored, into the lazy charts chunk · 2026-09-02
-**Decided** — Option B. A **hard subset** of `bklit/bklit-ui` charts is vendored at the
-pinned SHA `c57f66bfa7c3198edb677b567ce08cbf364ae159` (2026-07-28, tip of `main`).
-`@visx/*` is accepted as a real dependency set, in the **lazy** `charts` chunk.
-**The bundle gate is NOT raised** — see the correction below.
+### D-024 — bklit ui: declined on re-measurement; the chart layer is built in-house on visx · 2026-09-02, amended 2026-09-03
+> **AMENDMENT — 2026-09-03, and this is the decision of record. Everything below the
+> amendment box is the ORIGINAL 2026-09-02 decision, kept for the reasoning it carries
+> and SUPERSEDED on the vendoring question.**
+>
+> **Decided (owner, 2026-09-03)** — amend to Option A. No bklit source is vendored.
+> `frontend/src/shared/ds/charts/` is original work: `CartesianChart`, `PieChart` and
+> `RadarChart`, all `Copyright (c) 2026 OpenDefender Contributors`, `Apache-2.0`, built
+> on `@visx/*` as a normal npm dependency in the lazy `charts` chunk. The
+> THIRD-PARTY COMPONENTS table in `frontend/design-system/NOTICE` therefore has no rows
+> for this work, and consequence 5's "record each vendored component with its upstream
+> SHA" is void rather than outstanding.
+>
+> **Why the reversal** — the implementation reached Option A and the record was not
+> updated to match, which is the discrepancy this amendment exists to close. Measured on
+> `master` at `7c50d3c`, the outcome is better than what Option B was chosen for:
+>
+> | | Option B baseline (recharts) | shipped (visx, in-house) |
+> |---|---|---|
+> | lazy `charts` chunk, gzipped | 87.0 KB | **16.2 KB** |
+> | preloaded initial bundle | 172.1 KB | **170.6 KB** |
+>
+> The chart payload fell 81% and the preloaded bundle ended up 1.5 KB *below* master.
+> Option B's own "facts" section already recorded the maintenance case against it:
+> `@bklitui/ui` is `version: 0.0.0`, `"private": true`, never published — *"no version to
+> pin, no changelog and no upgrade path — only a SHA and a manual re-diff."* Building
+> in-house also disposes of consequences 2, 3 and 4 by construction: there is no vendored
+> source importing `motion/react`, no transitive `@base-ui/react@1.0.0-alpha.8`, and no
+> `GaugeChart` to drop. Verified on `master`: 0 files reference any of them.
+>
+> **What still binds** — consequence 1 (charts stay lazy, the budget may only ever be
+> lowered) and consequence 5's *destination* half (`frontend/src/shared/ds/`, the
+> Apache-2.0 half, per D-020). Consequence 6 (the risk matrix is built, not vendored)
+> was always the plan and shipped as `RiskMatrix.tsx`.
+>
+> **What this does NOT license** — vendoring stays governed by D-020. If bklit source is
+> ever taken, its notice is sourced and recorded first. This amendment declines the
+> vendoring; it does not pre-approve a later one.
+>
+> **Scope consequence** — #444 closes at **Recharts parity**, which is what was built.
+> The rest of its "Composants à adopter" table is split into #509 (Sankey), #510
+> (Choropleth), #511 (Candlestick + Profit/Loss), #512 (Scatter) and #513 (Brush,
+> Reference Area, Legend), each `status:needs-refinement` pending a named consuming
+> screen. They are deliberately not built speculatively.
+>
+> **Reversible** — yes. Nothing is relicensed and no upstream is now depended on, so
+> reversing means vendoring later under D-020, not undoing anything.
+
+**Superseded — the original decision, 2026-09-02:** Option B. A **hard subset** of
+`bklit/bklit-ui` charts is vendored at the pinned SHA
+`c57f66bfa7c3198edb677b567ce08cbf364ae159` (2026-07-28, tip of `main`). `@visx/*` is
+accepted as a real dependency set, in the **lazy** `charts` chunk. **The bundle gate is
+NOT raised** — see the correction below. *(The `@visx/*` and lazy-chunk halves of this
+survived the amendment; only the vendoring did not.)*
 
 **Rationale (owner)** — Chosen over the recommendation, which was A (decline and
 build in-house). The owner accepts the pre-1.0 upstream in exchange for a chart


### PR DESCRIPTION
Closes #444

Documentation only — one file, `docs/DECISIONS.md`. No code changes: the code was
already right, the record was not.

## The discrepancy

D-024 reads *"**Decided** — Option B. A **hard subset** of `bklit/bklit-ui` charts is
vendored at the pinned SHA `c57f66b…`"*, and *"Chosen over the recommendation, which was
A (decline and build in-house)."*

**What shipped in #498 is Option A.** `frontend/src/shared/ds/charts/{CartesianChart,
PieChart,RadarChart}.tsx` all carry `Copyright (c) 2026 OpenDefender Contributors` /
`SPDX-License-Identifier: Apache-2.0`, and `CartesianChart.tsx`'s header says "Built on
visx primitives (D-024, option A)". No bklit source was ever vendored, and the
THIRD-PARTY COMPONENTS table in `frontend/design-system/NOTICE` has no rows — which is
why #444's DoD criterion 3 "passed": there was nothing to record.

The owner amended the register to match the code.

## Why the amendment rather than the vendoring

Measured on `master` at `7c50d3c`:

| | Option B baseline (recharts) | shipped (visx, in-house) |
|---|---|---|
| lazy `charts` chunk, gzipped | 87.0 KB | **16.2 KB** |
| preloaded initial bundle | 172.1 KB | **170.6 KB** |

D-024's own facts section already made the maintenance case against B: `@bklitui/ui` is
`version: 0.0.0`, `"private": true`, never published — *"no version to pin, no changelog
and no upgrade path — only a SHA and a manual re-diff."*

Building in-house voids consequences 2, 3 and 4 **by construction** rather than by
diligence — no vendored source importing `motion/react`, no transitive
`@base-ui/react@1.0.0-alpha.8`, no `GaugeChart` to drop. Verified on master: 0 files
reference any of them (the single `RingChart` hit is a prose comment in
`ExecutiveDashboard`, not an import).

Consequence 1 (charts stay lazy; the budget may only ever be lowered) and the
*destination* half of consequence 5 (`shared/ds/`, the Apache-2.0 half, per D-020) still
bind and were met. **This declines a vendoring; it does not pre-approve a later one** —
D-020 still governs.

## Verification

DoD re-run on a clean worktree at `origin/master` `7c50d3c`, fresh `npm ci`:

```
DoD 1  lint:ceiling            ESLint errors: 321 (ceiling 321) — No regression
       banned imports          motion/react 0 · @number-flow/react 0 · @base-ui/react 0
                               GaugeChart 0 · SunburstChart 0 · recharts 0
DoD 2  budget                  ✓ Within budget (170.6 KB ≤ 180 KB)
       charts chunk            43,921 B raw / 16,239 B gzipped
       laziness                charts-*.js NOT referenced by index.html — lazy ✓
DoD 3  check:license-boundary  every file on the correct side, 0 crossings
DoD 4  vitest src/shared/ds    7 files, 117 tests passed
DoD 5  gallery                 'charts-v2' present in design-system.spec.ts
```

DoD 3 was ⚠️ at the last checkpoint and now passes — #504 fixed the unrelated D-021
licence crossing that was failing it.

## Scope

#444 closes at **Recharts parity**, which is what was built. The unbuilt half of its
"Composants à adopter" table is split out, each `status:needs-refinement` pending a named
consuming screen rather than built speculatively:

- **#509** Sankey — control → clause flows
- **#510** Choropleth — exposure by jurisdiction *(flagged: pulls `@visx/geo` +
  `topojson-client` **and** third-party map topology, whose licence needs sourcing under
  D-020)*
- **#511** Candlestick + Profit/Loss Line — financial impact, ALE *(grouped: same screen,
  same data shape, same axis work)*
- **#512** Scatter — *no consumer named in #444; refinement should start by asking whether
  it is wanted at all*
- **#513** Brush, Reference Area, Legend *(grouped: none is a chart; all three are
  furniture attaching to `CartesianChart`'s existing scales and frame)*

#444's body now carries a banner marking the vendoring instructions void and pointing at
these five.

## Honest remainders

- **No code was written or reviewed in this pass.** The DoD numbers above are a
  re-verification of already-merged work, not new work.
- **`ExecutiveDashboard` still has no automated coverage.** The previous checkpoint asked
  for human eyes on it before #498 merged, because D-025 deliberately redesigns an
  executive-facing screen that is authenticated and absent from the visual gallery. #498
  has since merged; **I do not know whether that look ever happened.**
- Carried over, still open and unaddressed: `pages/AnalyticsDashboard.tsx` is kept per
  D-026 but nothing imports it (dead code); the visual suite is flaky above `--workers=1`;
  in the light theme `--risk-high` and `--risk-moderate` are hard to separate in stacked
  bars (art-director question); the `charts-v2` baselines encode current rendering rather
  than an independently reviewed target. **None has an issue** — they have only ever been
  recorded in issue comments.
