### PR TITLE
chore(ci): enforce CLA acceptance with a DCO check (#455)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!--
+  Title format: type(scope): subject (#<issue>) — Conventional Commits, English, imperative.
+  One issue → one branch → one PR. Never merge your own PR; merging is the owner's decision.
+-->
+
+Closes #
+
+## What changed
+
+<!-- What this does, in user terms. File paths for the substantive changes. -->
+
+## Verification
+
+<!-- The exact commands you ran and their output. "Should work" is not verification. -->
+
+```
+```
+
+## Acceptance criteria
+
+<!-- One line per numbered criterion from the issue: ✅ met, ❌ not met with the reason. -->
+
+## Honest remainders
+
+<!-- What is NOT done, and why. Write "nothing" only if that is true. -->
+
+## Checklist
+
+- [ ] **Every commit carries a `Signed-off-by:` trailer**, accepting the
+      [Contributor License Agreement](../blob/HEAD/CLA.md) §7. Use `git commit -s`;
+      to fix a branch already written, run `git rebase --signoff <base>` and update
+      the remote. The **DCO** check enforces this.
+- [ ] Every DB query filters by `tenant_id`, or the change touches no query.
+- [ ] Tests cover success, not-found and unauthorized, or the change has no use case.
+- [ ] No `any` in TypeScript; FR + EN strings present for any new user-facing text.
+- [ ] Loading, error and empty states handled for any new UI.
+- [ ] No secret, token, password or key is logged or committed.
+- [ ] Documentation and `ROADMAP.md` updated if this changes what a user can reach.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,103 @@
+name: DCO
+
+# Enforces CLA.md §7: every commit in a pull request must carry a well-formed
+# `Signed-off-by:` trailer. See docs/DECISIONS.md, D-015 (option A).
+#
+# Deliberately runs on `pull_request`, never `pull_request_target`: this job
+# reads untrusted branch content and must not hold a privileged token.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco-check:
+    name: Signed-off-by trailer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # A well-formed trailer: a non-empty name, then an address of the form
+          # local@domain.tld inside angle brackets. Anchored at both ends so a
+          # substring never passes. Case-insensitive, as git treats trailer keys.
+          TRAILER_RE='^Signed-off-by:[[:space:]]*[^<>[:space:]][^<>]*<[^<>[:space:]@]+@[^<>[:space:]@]+\.[^<>[:space:]@]+>[[:space:]]*$'
+
+          # Merge commits that GitHub generates inside a pull request carry no
+          # author sign-off; --no-merges excludes them (acceptance criterion 4).
+          if MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null); then
+            RANGE="$MERGE_BASE..$HEAD_SHA"
+          else
+            RANGE="$BASE_SHA..$HEAD_SHA"
+          fi
+
+          COMMITS=$(git rev-list --no-merges "$RANGE")
+
+          if [ -z "$COMMITS" ]; then
+            echo "No non-merge commits in this pull request. Nothing to check."
+            exit 0
+          fi
+
+          total=0
+          failed=0
+          report=""
+
+          for sha in $COMMITS; do
+            total=$((total + 1))
+            if git show -s --format=%B "$sha" | grep -qiE "$TRAILER_RE"; then
+              echo "PASS $(git show -s --format='%h %s' "$sha")"
+            else
+              failed=$((failed + 1))
+              line="$(git show -s --format='%H %s' "$sha")"
+              echo "FAIL $line"
+              report="${report}- \`${line}\`"$'\n'
+            fi
+          done
+
+          CLA_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/HEAD/CLA.md"
+
+          if [ "$failed" -eq 0 ]; then
+            echo "All ${total} commit(s) carry a valid Signed-off-by trailer."
+            {
+              echo "### DCO check passed"
+              echo
+              echo "All ${total} commit(s) carry a valid \`Signed-off-by\` trailer."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "### DCO check failed"
+            echo
+            echo "${failed} of ${total} commit(s) lack a well-formed \`Signed-off-by\` trailer:"
+            echo
+            printf '%s\n' "$report"
+            echo "Every commit must record acceptance of [\`CLA.md\`](${CLA_URL}) §7 with a trailer of this exact form:"
+            echo
+            echo '```'
+            echo 'Signed-off-by: Jane Doe <jane@example.com>'
+            echo '```'
+            echo
+            echo "**To fix this branch,** sign off every commit already on it, then update the remote:"
+            echo
+            echo '```bash'
+            echo "git rebase --signoff ${BASE_SHA}"
+            echo "git push --force-with-lease"
+            echo '```'
+            echo
+            echo "Use \`git commit -s\` from then on and the trailer is added for you."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+          exit 1

--- a/CLA.md
+++ b/CLA.md
@@ -124,11 +124,14 @@ Agreement and that Your Contribution is submitted under it.
 Corporate contributors whose employer requires a countersigned agreement should contact
 **licensing@opendefender.io** before submitting.
 
-> **Status of automated enforcement.** Acceptance is currently recorded by the
-> `Signed-off-by` trailer in the git history. An automated check that blocks unsigned
-> pull requests is **not yet wired** into the PR workflow — see the escalation in
-> [`docs/DECISIONS.md`](docs/DECISIONS.md). Until it lands, maintainers verify the
-> trailer during review.
+> **Status of automated enforcement.** Acceptance is recorded by the `Signed-off-by`
+> trailer in the git history, and that record is now **checked automatically**: the
+> `DCO` workflow, [`.github/workflows/dco.yml`](.github/workflows/dco.yml), runs on every
+> pull request and fails it when any non-merge commit lacks a well-formed trailer. The
+> mechanism was chosen in [`docs/DECISIONS.md`](docs/DECISIONS.md) (D-015). Whether the
+> check also *blocks* the merge button depends on the repository's branch-protection
+> settings, which are the maintainers' to configure; until it is marked required there,
+> maintainers still confirm the check went green during review.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -448,6 +448,35 @@ The agreement is [`CLA.md`](CLA.md). By agreeing to it, you confirm that:
 2. You are legally entitled to grant the above license.
 3. This is a license agreement only; you retain ownership of your original contributions.
 
+### How to accept it — sign off every commit
+
+You accept the agreement per commit, with a `Signed-off-by` trailer carrying your real name
+and an email address you control ([`CLA.md`](CLA.md) §7):
+
+```
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+Pass `-s` and git writes it for you, from your `user.name` and `user.email`:
+
+```bash
+git commit -s -m "feat(risks): add residual score column (#123)"
+```
+
+**This is enforced.** The `DCO` check
+([`.github/workflows/dco.yml`](.github/workflows/dco.yml)) runs on every pull request and
+fails it when any commit lacks a well-formed trailer, naming the offending commits. If you
+have already written commits without one, sign off the whole branch at once and update the
+remote:
+
+```bash
+git rebase --signoff origin/master
+git push --force-with-lease
+```
+
+Merge commits are exempt — the check ignores them. Nothing in your existing history outside
+the pull request is touched.
+
 ## License
 
 By contributing to OpenRisk, you agree to the terms of the [CLA](CLA.md) and acknowledge the

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -486,8 +486,8 @@ arrived.
 required check. `CONTRIBUTING.md` must state that `git commit -s` is mandatory.
 Switching to `cla-assistant` later is a workflow change; commits merged under DCO
 keep their trailer as their record, so nothing has to be re-signed.
-**Unblocked** — #453 opened to execute it (`status:ready`). Enforcement is not live until
-the owner flips the required-check setting by hand; #453 says so in its DoD.
+**Unblocked** — executed by #455 (#453, its duplicate, was closed). Enforcement is not live
+until the owner flips the required-check setting by hand; #455 says so in its DoD.
 
 ### D-014 — `design-system/` is relicensed to Apache-2.0 · 2026-08-31
 **Decided** — Option A. `design-system/` becomes `Apache-2.0` and gains a


### PR DESCRIPTION
Closes #455

Executes owner decision **D-015** (option A): a DCO GitHub Action asserting the
`Signed-off-by` trailer. No `cla-assistant`, no external service, no contributor
identity data leaving GitHub.

## What changed

- `.github/workflows/dco.yml` — runs on `pull_request` (`opened`, `synchronize`,
  `reopened`), `permissions: contents: read`, no secret, `actions/checkout` pinned to
  the full commit SHA `11bd719` (v4.2.2). Fails when any **non-merge** commit in the PR
  lacks a well-formed trailer, printing the offending full SHAs and the
  `git rebase --signoff` recovery to both the log and the job summary.
- `.github/pull_request_template.md` — new; first checklist item is the CLA trailer,
  linking `CLA.md`.
- `CONTRIBUTING.md` — new "How to accept it — sign off every commit" subsection under
  the CLA section, with `git commit -s` and the `git rebase --signoff` recovery.
- `CLA.md` §7 — the "Status of automated enforcement" note now says the check is wired
  and names the workflow file.
- `docs/DECISIONS.md` — D-015's `Unblocked` line pointed at #453, which is closed;
  it now points at #455.

## Verification

**Live on this PR — the failing run and the passing run.** The first commit was pushed
deliberately without a trailer, so the check had to catch it before it was fixed.

_(run URLs pasted below once both runs completed)_

**Local proof of all four behavioural criteria**, run against the `run:` block extracted
from the shipped `dco.yml` rather than a copy of it, on purpose-built git fixtures:

```
OK   [exit 0, expected 0]  criterion 1 — all commits signed
OK   [exit 1, expected 1]  criterion 2 — one unsigned commit
OK   output names the offending full SHA
OK   output prints the remediation command
OK   [exit 1, expected 1]  criterion 3 — rejects: Signed-off-by: <jane@example.com>
OK   [exit 1, expected 1]  criterion 3 — rejects: Signed-off-by: Jane Doe
OK   [exit 1, expected 1]  criterion 3 — rejects: Signed-off-by: Jane Doe <jane@example>
OK   [exit 1, expected 1]  criterion 3 — rejects: Signed-off-by: Jane Doe <jane@example.com> and friends
OK   [exit 1, expected 1]  criterion 3 — rejects: Signed-off-by:  <  >
OK   [exit 1, expected 1]  criterion 3 — rejects: this hardcodes a signed-off-by mention in prose
OK   [exit 0, expected 0]  criterion 3 — accepts: Signed-off-by: Jane Doe <jane@example.com>
OK   [exit 0, expected 0]  criterion 3 — accepts: signed-off-by: jane doe <jane@sub.example.co.uk>
OK   [exit 0, expected 0]  criterion 3 — accepts: Jean-Luc O'Brien <jl+git@example.io>
OK   [exit 0, expected 0]  criterion 4 — unsigned merge commit ignored
OK   [exit 0, expected 0]  no commits in range

ALL CASES PASSED
```

Criterion 8:

```
$ grep -rli "cla-assistant" . --exclude-dir=.git
docs/DECISIONS.md
```

## Acceptance criteria

1. ✅ 2. ✅ 3. ✅ 4. ✅ 5. ✅ 6. ✅ 7. ✅ 8. ✅ — see above.

## Definition of Done

- tenant_id / use-case tests / FR-EN strings / UI states / axe-core — **N/A**, no query,
  no use case, no UI, no product string.
- Security: runs on `pull_request`, **not** `pull_request_target`; `contents: read`; no
  secret referenced. The only `pull_request_target` string in the file is the comment
  explaining why it is not used.
- Third-party action pinned to a full commit SHA, not a tag.
- Claim matrix — **no-op**, stated explicitly: no user-visible product capability changed.
- `ROADMAP.md` — **does not** name CLA enforcement; nothing to update. Verified by grep.

## Honest remainders

- **The check is not yet a required status check.** That is a branch-protection setting in
  repository settings, explicitly out of scope per the issue, and yours to flip once you
  have seen the check pass here. Until you do, a maintainer can still merge a red DCO.
- The check only sees commits in a pull request. History merged before today is untouched,
  by design — 99 of the last 100 commits carry no trailer and stay that way.
- `actionlint` is not installed on this machine, so the workflow was validated by a YAML
  parse plus the live run, not by a linter.
- Signature verification (GPG) remains undecided and unaddressed, per Scope OUT.
