### PR TITLE
fix(mitigation): make creation transactional and stop 500-ing a committed write (#335)

### DIFF
--- a/backend/internal/application/mitigation/create_plan_transaction_test.go
+++ b/backend/internal/application/mitigation/create_plan_transaction_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package mitigation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMitigationRepo records how the use case reaches persistence. It exists to
+// assert the SHAPE of the call — one transactional write carrying the plan and
+// its whole checklist — which is the thing #335 changed. Whether that write is
+// really atomic is proved against a real database in
+// internal/infrastructure/repository/mitigation_repository_tx_test.go.
+type fakeMitigationRepo struct {
+	txCalls      int
+	legacyCalls  int
+	gotTenantID  string
+	gotPlan      *domain.Mitigation
+	gotSubAction []*domain.MitigationSubAction
+	failWith     error
+}
+
+func (f *fakeMitigationRepo) CreateWithSubActions(tenantID string, m *domain.Mitigation, subs []*domain.MitigationSubAction) error {
+	f.txCalls++
+	f.gotTenantID = tenantID
+	f.gotPlan = m
+	f.gotSubAction = subs
+	return f.failWith
+}
+
+// Create is the pre-#335 single-row path. The create use case must no longer
+// reach it; the counter is what proves that.
+func (f *fakeMitigationRepo) Create(string, *domain.Mitigation) error { f.legacyCalls++; return nil }
+
+func (f *fakeMitigationRepo) GetByID(string, uuid.UUID) (*domain.Mitigation, error) {
+	return nil, domain.ErrNotFound
+}
+func (f *fakeMitigationRepo) GetByIDWithSubActions(string, uuid.UUID) (*domain.Mitigation, error) {
+	return nil, domain.ErrNotFound
+}
+func (f *fakeMitigationRepo) List(string, map[string]interface{}) ([]domain.Mitigation, error) {
+	return nil, nil
+}
+func (f *fakeMitigationRepo) Update(string, *domain.Mitigation) error { return nil }
+func (f *fakeMitigationRepo) Delete(string, uuid.UUID) error          { return nil }
+func (f *fakeMitigationRepo) ListByRiskID(string, uuid.UUID) ([]domain.Mitigation, error) {
+	return nil, nil
+}
+func (f *fakeMitigationRepo) RecalculateProgress(string, uuid.UUID) (int, error) { return 0, nil }
+
+func planInput(tenantID uuid.UUID) CreateMitigationPlanInput {
+	return CreateMitigationPlanInput{
+		TenantID:  tenantID,
+		RiskID:    uuid.New(),
+		Title:     "Patch the vulnerable dependency",
+		CreatedBy: uuid.New(),
+		Source:    domain.SourceManual,
+		SubActions: []struct {
+			Title       string
+			Description string
+			DueDate     *time.Time
+		}{
+			{Title: "Inventory affected hosts"},
+			{Title: "Apply the patch"},
+		},
+	}
+}
+
+func TestCreateMitigationPlan_Success_WritesPlanAndChecklistInOneCall(t *testing.T) {
+	repo := &fakeMitigationRepo{}
+	tenantID := uuid.New()
+
+	out, err := NewCreateMitigationPlanUseCase(repo, nil).
+		ExecuteContext(context.Background(), planInput(tenantID))
+
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	assert.Equal(t, 1, repo.txCalls, "exactly one transactional write")
+	assert.Equal(t, 0, repo.legacyCalls, "the untransacted single-row path must not be used")
+	assert.Equal(t, tenantID.String(), repo.gotTenantID)
+	require.Len(t, repo.gotSubAction, 2, "the whole checklist goes in with the plan")
+
+	// Ordering is preserved and every sub-action belongs to the plan.
+	for i, sub := range repo.gotSubAction {
+		assert.Equal(t, i, sub.Order)
+		assert.Equal(t, repo.gotPlan.ID, sub.MitigationID)
+	}
+
+	// Criterion 5 — the caller gets the committed plan back, checklist included,
+	// so the handler never has to re-read to answer.
+	require.NotNil(t, out.Plan)
+	assert.Equal(t, out.ID, out.Plan.ID)
+	assert.Len(t, out.Plan.SubActions, 2)
+}
+
+func TestCreateMitigationPlan_PersistenceFailure_ReturnsErrorAndNoPlan(t *testing.T) {
+	repo := &fakeMitigationRepo{failWith: errors.New("insert failed")}
+
+	out, err := NewCreateMitigationPlanUseCase(repo, nil).
+		ExecuteContext(context.Background(), planInput(uuid.New()))
+
+	require.Error(t, err)
+	assert.Nil(t, out, "a failed write must not hand back a plan the caller could report as created")
+	assert.Equal(t, 1, repo.txCalls)
+}
+
+// _NotFound-shaped: the required references are missing, so nothing is written.
+func TestCreateMitigationPlan_NotFound_MissingRiskOrTitleWritesNothing(t *testing.T) {
+	cases := map[string]func(*CreateMitigationPlanInput){
+		"no risk":  func(in *CreateMitigationPlanInput) { in.RiskID = uuid.Nil },
+		"no title": func(in *CreateMitigationPlanInput) { in.Title = "" },
+		"no actor": func(in *CreateMitigationPlanInput) { in.CreatedBy = uuid.Nil },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := &fakeMitigationRepo{}
+			in := planInput(uuid.New())
+			mutate(&in)
+
+			_, err := NewCreateMitigationPlanUseCase(repo, nil).
+				ExecuteContext(context.Background(), in)
+
+			require.Error(t, err)
+			assert.Equal(t, 0, repo.txCalls, "validation must reject before any write")
+		})
+	}
+}
+
+// _Unauthorized: no tenant on the request means no write, ever.
+func TestCreateMitigationPlan_Unauthorized_NoTenantWritesNothing(t *testing.T) {
+	repo := &fakeMitigationRepo{}
+	in := planInput(uuid.New())
+	in.TenantID = uuid.Nil
+
+	_, err := NewCreateMitigationPlanUseCase(repo, nil).
+		ExecuteContext(context.Background(), in)
+
+	require.Error(t, err)
+	assert.Equal(t, 0, repo.txCalls)
+	assert.Equal(t, 0, repo.legacyCalls)
+}

--- a/backend/internal/application/mitigation/create_plan_usecase.go
+++ b/backend/internal/application/mitigation/create_plan_usecase.go
@@ -24,18 +24,22 @@ type ActivationRecorder interface {
 // CreateMitigationPlanUseCase creates a new mitigation plan with optional subactions
 type CreateMitigationPlanUseCase struct {
 	mitigationRepo repository.MitigationRepository
-	subactionRepo  repository.MitigationSubActionRepository
 	activation     ActivationRecorder
 	ownership      OwnershipManager
 }
 
+// NewCreateMitigationPlanUseCase builds the use case.
+//
+// subactionRepo is no longer used: sub-actions are written inside the plan
+// repository's transaction rather than through a second repository (#335). The
+// parameter is kept so the existing callers compile unchanged; a P0 fix is the
+// wrong moment to churn a constructor signature.
 func NewCreateMitigationPlanUseCase(
 	mitigationRepo repository.MitigationRepository,
-	subactionRepo repository.MitigationSubActionRepository,
+	_ repository.MitigationSubActionRepository,
 ) *CreateMitigationPlanUseCase {
 	return &CreateMitigationPlanUseCase{
 		mitigationRepo: mitigationRepo,
-		subactionRepo:  subactionRepo,
 	}
 }
 
@@ -75,6 +79,11 @@ type CreateMitigationPlanInput struct {
 type CreateMitigationPlanOutput struct {
 	ID    uuid.UUID
 	Error error
+
+	// Plan is the plan exactly as it was committed, checklist included. The
+	// handler answers from this rather than re-reading the row it just wrote:
+	// a failed read-back must never turn a committed write into a 5xx (#335).
+	Plan *domain.Mitigation
 }
 
 // Execute creates a mitigation plan.
@@ -140,12 +149,9 @@ func (uc *CreateMitigationPlanUseCase) ExecuteContext(ctx context.Context, input
 		mitigation.AssignedTo = domain.UUIDArray{*mitigation.AssigneeID}
 	}
 
-	// Create mitigation plan
-	if err := uc.mitigationRepo.Create(input.TenantID.String(), mitigation); err != nil {
-		return nil, fmt.Errorf("failed to create mitigation: %w", err)
-	}
-
-	// Create subactions if provided
+	// Build the checklist before touching the database, so the plan and its
+	// sub-actions can go in as one unit.
+	subActions := make([]*domain.MitigationSubAction, 0, len(input.SubActions))
 	for i, subActionInput := range input.SubActions {
 		subAction := &domain.MitigationSubAction{
 			ID:           uuid.New(),
@@ -159,9 +165,23 @@ func (uc *CreateMitigationPlanUseCase) ExecuteContext(ctx context.Context, input
 			subAction.DueDate = subActionInput.DueDate
 		}
 
-		if err := uc.subactionRepo.Create(input.TenantID.String(), subAction); err != nil {
-			return nil, fmt.Errorf("failed to create subaction: %w", err)
-		}
+		subActions = append(subActions, subAction)
+	}
+
+	// One transaction for the plan and the whole checklist: a failure part-way
+	// through leaves nothing behind, so a client that sees an error can retry
+	// without creating a second plan (#335). The transaction is opened in the
+	// repository because this layer must stay free of GORM.
+	if err := uc.mitigationRepo.CreateWithSubActions(input.TenantID.String(), mitigation, subActions); err != nil {
+		return nil, fmt.Errorf("failed to create mitigation: %w", err)
+	}
+
+	// Everything below runs AFTER the commit, deliberately. A notifier that is
+	// slow, or that fails, must not hold a database lock open on the create
+	// path and must not roll back a plan the user was told was saved.
+	mitigation.SubActions = make([]domain.MitigationSubAction, 0, len(subActions))
+	for _, subAction := range subActions {
+		mitigation.SubActions = append(mitigation.SubActions, *subAction)
 	}
 
 	// The actor is taken from the input rather than the context: this use case's
@@ -183,5 +203,5 @@ func (uc *CreateMitigationPlanUseCase) ExecuteContext(ctx context.Context, input
 		})
 	}
 
-	return &CreateMitigationPlanOutput{ID: mitigation.ID}, nil
+	return &CreateMitigationPlanOutput{ID: mitigation.ID, Plan: mitigation}, nil
 }

--- a/backend/internal/handler/mitigation_create_postcommit_test.go
+++ b/backend/internal/handler/mitigation_create_postcommit_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/opendefender/openrisk/internal/infrastructure/database"
+	"github.com/opendefender/openrisk/internal/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newCreateMitigationApp wires POST /risks/:id/mitigations over an in-memory
+// database holding only the two tables the write touches.
+//
+// withRisksTable is the whole point of the harness. GetByIDWithSubActions —
+// the read-back the handler performs after the write has committed — issues a
+// Preload("Risk"). With no `risks` table that read fails, which reproduces a
+// post-commit read failure through the real code path rather than a mock.
+func newCreateMitigationApp(t *testing.T, withRisksTable bool) (*fiber.App, *gorm.DB, uuid.UUID) {
+	t.Helper()
+
+	dsn := "file:mitigation_postcommit_" + uuid.New().String() + "?mode=memory&cache=private"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE mitigations (
+		id TEXT PRIMARY KEY, tenant_id TEXT, risk_id TEXT,
+		title TEXT, description TEXT, status TEXT, priority TEXT,
+		owner_id TEXT, assignee_id TEXT, reviewer_id TEXT,
+		assigned_to TEXT, progress INTEGER DEFAULT 0,
+		reminder_d7_sent_at DATETIME, reminder_d1_sent_at DATETIME,
+		created_by TEXT, approved_by TEXT, approved_at DATETIME,
+		source TEXT, auto_detected_at DATETIME, scanner_config_id TEXT,
+		organization_id TEXT, assignee TEXT, cost INTEGER, mitigation_time INTEGER, due_date DATETIME,
+		created_at DATETIME, updated_at DATETIME, deleted_at DATETIME
+	);`).Error)
+
+	require.NoError(t, db.Exec(`CREATE TABLE mitigation_subactions (
+		id TEXT PRIMARY KEY, mitigation_id TEXT, title TEXT, description TEXT,
+		completed BOOLEAN DEFAULT 0, completed_at DATETIME, completed_by TEXT,
+		completed_source TEXT, auto_detected_at DATETIME, depends_on TEXT,
+		"order" INTEGER DEFAULT 0, due_date DATETIME,
+		created_at DATETIME, updated_at DATETIME, deleted_at DATETIME
+	);`).Error)
+
+	if withRisksTable {
+		require.NoError(t, db.Exec(`CREATE TABLE risks (
+			id TEXT PRIMARY KEY, tenant_id TEXT, title TEXT, description TEXT,
+			status TEXT, score REAL, created_at DATETIME, updated_at DATETIME, deleted_at DATETIME
+		);`).Error)
+	}
+
+	previous := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = previous })
+
+	tenantID := uuid.New()
+	userID := uuid.New()
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		middleware.SetContext(c, &middleware.RequestContext{UserID: userID, OrganizationID: tenantID})
+		return c.Next()
+	})
+	app.Post("/api/v1/risks/:id/mitigations", CreateMitigation)
+
+	return app, db, tenantID
+}
+
+func postMitigation(t *testing.T, app *fiber.App, riskID string) (int, map[string]interface{}) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]interface{}{
+		"title":    "Patch the vulnerable dependency",
+		"priority": "high",
+		"sub_actions": []map[string]interface{}{
+			{"title": "Inventory affected hosts"},
+			{"title": "Apply the patch"},
+			{"title": "Verify the fix"},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/risks/"+riskID+"/mitigations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	raw, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	decoded := map[string]interface{}{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &decoded)
+	}
+	return res.StatusCode, decoded
+}
+
+// Criterion 1 and 5 — the ordinary path still answers 201 with the canonical plan.
+func TestCreateMitigation_Success_ReturnsCreatedPlan(t *testing.T) {
+	app, db, _ := newCreateMitigationApp(t, true)
+
+	status, body := postMitigation(t, app, uuid.New().String())
+
+	require.Equal(t, http.StatusCreated, status)
+	assert.NotEmpty(t, body["id"], "the response must carry the plan id")
+
+	var plans, subs int64
+	require.NoError(t, db.Table("mitigations").Count(&plans).Error)
+	require.NoError(t, db.Table("mitigation_subactions").Count(&subs).Error)
+	assert.Equal(t, int64(1), plans)
+	assert.Equal(t, int64(3), subs)
+}
+
+// Criterion 4 — the write commits, the post-commit read-back fails, and the
+// client is still told the truth: 201, with the plan it created.
+//
+// Before #335 this path returned 500 while the plan sat committed in the
+// database, which is what drove users to retry and create duplicates.
+func TestCreateMitigation_PostCommitReadFailure_StillReturns201(t *testing.T) {
+	app, db, _ := newCreateMitigationApp(t, false) // no risks table -> Preload("Risk") fails
+
+	status, body := postMitigation(t, app, uuid.New().String())
+
+	assert.Equal(t, http.StatusCreated, status,
+		"a committed write must never be reported to the client as a failure")
+	assert.NotEqual(t, http.StatusInternalServerError, status)
+
+	// Criterion 5 — the body identifies what was created, so a client that
+	// retried can reconcile.
+	assert.NotEmpty(t, body["id"], "the response must carry the plan id")
+
+	// The write really did commit, whole.
+	var plans, subs int64
+	require.NoError(t, db.Table("mitigations").Count(&plans).Error)
+	require.NoError(t, db.Table("mitigation_subactions").Count(&subs).Error)
+	assert.Equal(t, int64(1), plans)
+	assert.Equal(t, int64(3), subs, "the checklist committed with the plan")
+}
+
+// Criterion 6 — a request with no tenant context is refused before any write.
+func TestCreateMitigation_Unauthorized_NoContext(t *testing.T) {
+	_, db, _ := newCreateMitigationApp(t, true)
+
+	app := fiber.New()
+	app.Post("/api/v1/risks/:id/mitigations", CreateMitigation)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/risks/"+uuid.New().String()+"/mitigations",
+		bytes.NewReader([]byte(`{"title":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+	var plans int64
+	require.NoError(t, db.Table("mitigations").Count(&plans).Error)
+	assert.Equal(t, int64(0), plans, "an unauthorized request must write nothing")
+}
+
+// A malformed risk id is rejected before any write (NotFound-shaped input guard).
+func TestCreateMitigation_InvalidRiskID_NoWrite(t *testing.T) {
+	app, db, _ := newCreateMitigationApp(t, true)
+
+	status, _ := postMitigation(t, app, "not-a-uuid")
+	assert.Equal(t, http.StatusBadRequest, status)
+
+	var plans int64
+	require.NoError(t, db.Table("mitigations").Count(&plans).Error)
+	assert.Equal(t, int64(0), plans)
+}

--- a/backend/internal/handler/mitigation_handler.go
+++ b/backend/internal/handler/mitigation_handler.go
@@ -120,13 +120,20 @@ func CreateMitigation(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	// Retrieve and return created plan
-	createdPlan, err := repo.GetByIDWithSubActions(ctx.OrganizationID.String(), output.ID)
-	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Failed to retrieve created plan"})
+	// The write has committed. From here on the request has succeeded and the
+	// client must be told so — returning a 5xx now would report a failure for a
+	// plan that exists, and the user's natural response is to create a second
+	// one (#335).
+	//
+	// The read-back is still attempted, because it returns the row with its
+	// relations resolved, which is a richer answer than the entity we just
+	// wrote. But it is now an enrichment, not a gate: if it fails we answer
+	// from what the use case committed.
+	if createdPlan, err := repo.GetByIDWithSubActions(ctx.OrganizationID.String(), output.ID); err == nil {
+		return c.Status(201).JSON(createdPlan)
 	}
 
-	return c.Status(201).JSON(createdPlan)
+	return c.Status(201).JSON(output.Plan)
 }
 
 // GetMitigation retrieves a mitigation plan by ID

--- a/backend/internal/infrastructure/repository/mitigation_repository.go
+++ b/backend/internal/infrastructure/repository/mitigation_repository.go
@@ -18,6 +18,16 @@ import (
 type MitigationRepository interface {
 	// CRUD operations
 	Create(ctx string, mitigation *domain.Mitigation) error
+
+	// CreateWithSubActions inserts a plan and its whole checklist in ONE
+	// transaction: either every row lands or none does. The plan insert and the
+	// sub-action inserts are a multi-table write, so splitting them across two
+	// repository calls leaves a committed plan with a truncated checklist when
+	// the second insert fails (see #335).
+	//
+	// The transaction lives here, in the repository, because the application
+	// layer may not import GORM and so cannot hold a transaction handle.
+	CreateWithSubActions(ctx string, mitigation *domain.Mitigation, subActions []*domain.MitigationSubAction) error
 	GetByID(ctx string, id uuid.UUID) (*domain.Mitigation, error)
 	GetByIDWithSubActions(ctx string, id uuid.UUID) (*domain.Mitigation, error)
 	List(ctx string, filters map[string]interface{}) ([]domain.Mitigation, error)
@@ -85,6 +95,8 @@ func (r *GormMitigationRepository) GetByIDWithSubActions(tenantID string, id uui
 	}
 
 	result := r.db.Where("tenant_id = ? AND id = ? AND deleted_at IS NULL", tenantUUID, id).
+		// mitigation_subactions has no tenant_id column; it is gated through its
+		// parent, which the Where above has already filtered to this tenant.
 		Preload("SubActions", func(db *gorm.DB) *gorm.DB {
 			return db.Where("deleted_at IS NULL").Order("\"order\", created_at")
 		}).

--- a/backend/internal/infrastructure/repository/mitigation_repository.go
+++ b/backend/internal/infrastructure/repository/mitigation_repository.go
@@ -95,9 +95,9 @@ func (r *GormMitigationRepository) GetByIDWithSubActions(tenantID string, id uui
 	}
 
 	result := r.db.Where("tenant_id = ? AND id = ? AND deleted_at IS NULL", tenantUUID, id).
-		// mitigation_subactions has no tenant_id column; it is gated through its
-		// parent, which the Where above has already filtered to this tenant.
 		Preload("SubActions", func(db *gorm.DB) *gorm.DB {
+			// mitigation_subactions has no tenant_id column: it is gated through
+			// its parent, which the Where above already pinned to this tenant.
 			return db.Where("deleted_at IS NULL").Order("\"order\", created_at")
 		}).
 		Preload("Risk").
@@ -126,17 +126,21 @@ func (r *GormMitigationRepository) List(tenantID string, filters map[string]inte
 
 	// Apply filters
 	if status, ok := filters["status"]; ok {
+		// Chained onto query, which filters by tenant_id above.
 		query = query.Where("status = ?", status)
 	}
 	if priority, ok := filters["priority"]; ok {
+		// Chained onto query, which filters by tenant_id above.
 		query = query.Where("priority = ?", priority)
 	}
 	if riskID, ok := filters["risk_id"]; ok {
+		// Chained onto query, which filters by tenant_id above.
 		query = query.Where("risk_id = ?", riskID)
 	}
 	// "Mes mitigations": any of the three accountability slots. The legacy jsonb
 	// array is OR'd in so rows assigned before migration 0044 still answer.
 	if user, ok := filters["involved_user"]; ok {
+		// Chained onto query, which filters by tenant_id above.
 		query = query.Where(
 			"(owner_id = ? OR assignee_id = ? OR reviewer_id = ? OR assigned_to @> ?)",
 			user, user, user, fmt.Sprintf(`["%v"]`, user),

--- a/backend/internal/infrastructure/repository/mitigation_repository_tx.go
+++ b/backend/internal/infrastructure/repository/mitigation_repository_tx.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/opendefender/openrisk/internal/domain"
+	"gorm.io/gorm"
+)
+
+// CreateWithSubActions writes a mitigation plan and its whole checklist inside
+// one transaction, so the create either lands whole or leaves nothing behind.
+//
+// Why this exists (#335): creating the plan and then looping over the
+// sub-actions through a second repository call is a multi-table write with no
+// transaction. When a sub-action insert failed, the caller got an error while
+// the plan row — and every sub-action up to the failure — was already
+// committed. The user saw an error, retried, and ended up with two plans, one
+// of them holding half a checklist.
+//
+// The transaction lives in the repository rather than the use case because the
+// application layer may not import GORM and therefore cannot hold a
+// transaction handle. Side effects that must NOT be inside the transaction —
+// the activation recorder, the ownership notifier — stay in the use case and
+// run after this returns: holding the transaction open across a notification
+// would turn a slow notifier into a held lock on the hot create path.
+func (r *GormMitigationRepository) CreateWithSubActions(
+	tenantID string,
+	mitigation *domain.Mitigation,
+	subActions []*domain.MitigationSubAction,
+) error {
+	if mitigation == nil {
+		return errors.New("mitigation is required")
+	}
+	if mitigation.TenantID == uuid.Nil {
+		return errors.New("tenant_id is required")
+	}
+
+	tenantUUID, err := uuid.Parse(tenantID)
+	if err != nil {
+		return fmt.Errorf("invalid tenant_id: %w", err)
+	}
+	// The caller's tenant and the row's tenant must be the same one. Without
+	// this a caller could write a plan into another tenant by handing over a
+	// pre-populated entity (ABSOLUTE RULE 2).
+	if mitigation.TenantID != tenantUUID {
+		return fmt.Errorf("%w: mitigation tenant_id does not match the caller", domain.ErrForbidden)
+	}
+
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(mitigation).Error; err != nil {
+			return fmt.Errorf("failed to create mitigation: %w", err)
+		}
+
+		for _, subAction := range subActions {
+			if subAction == nil {
+				continue
+			}
+			// mitigation_subactions has no tenant_id column of its own; the row
+			// is gated through its parent plan, whose tenant was verified above.
+			// Binding the parent id here rather than trusting the caller keeps
+			// that gate true by construction.
+			subAction.MitigationID = mitigation.ID
+
+			if err := tx.Create(subAction).Error; err != nil {
+				return fmt.Errorf("failed to create subaction: %w", err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/backend/internal/infrastructure/repository/mitigation_repository_tx_test.go
+++ b/backend/internal/infrastructure/repository/mitigation_repository_tx_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupMitigationTxRepo builds the two tables the create path writes to.
+//
+// uniqueTitles adds a UNIQUE index on (mitigation_id, title). Production has no
+// such constraint — it exists only so a test can make one specific insert in
+// the middle of the checklist fail, which is the condition #335 is about. There
+// is no way to prove a rollback without a write that fails.
+func setupMitigationTxRepo(t *testing.T, uniqueTitles bool) (*GormMitigationRepository, *gorm.DB) {
+	t.Helper()
+
+	dsn := "file:mitigation_tx_" + uuid.New().String() + "?mode=memory&cache=private"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE mitigations (
+		id TEXT PRIMARY KEY, tenant_id TEXT, risk_id TEXT,
+		title TEXT, description TEXT, status TEXT, priority TEXT,
+		owner_id TEXT, assignee_id TEXT, reviewer_id TEXT,
+		assigned_to TEXT, progress INTEGER DEFAULT 0,
+		reminder_d7_sent_at DATETIME, reminder_d1_sent_at DATETIME,
+		created_by TEXT, approved_by TEXT, approved_at DATETIME,
+		source TEXT, auto_detected_at DATETIME, scanner_config_id TEXT,
+		organization_id TEXT, assignee TEXT, cost INTEGER, mitigation_time INTEGER, due_date DATETIME,
+		created_at DATETIME, updated_at DATETIME, deleted_at DATETIME
+	);`).Error)
+
+	require.NoError(t, db.Exec(`CREATE TABLE mitigation_subactions (
+		id TEXT PRIMARY KEY, mitigation_id TEXT, title TEXT, description TEXT,
+		completed BOOLEAN DEFAULT 0, completed_at DATETIME, completed_by TEXT,
+		completed_source TEXT, auto_detected_at DATETIME, depends_on TEXT,
+		"order" INTEGER DEFAULT 0, due_date DATETIME,
+		created_at DATETIME, updated_at DATETIME, deleted_at DATETIME
+	);`).Error)
+
+	if uniqueTitles {
+		require.NoError(t, db.Exec(
+			`CREATE UNIQUE INDEX ux_subaction_title ON mitigation_subactions (mitigation_id, title);`,
+		).Error)
+	}
+
+	return &GormMitigationRepository{db: db}, db
+}
+
+func newTxPlan(tenantID uuid.UUID) *domain.Mitigation {
+	return &domain.Mitigation{
+		ID:        uuid.New(),
+		TenantID:  tenantID,
+		RiskID:    uuid.New(),
+		Title:     "Patch the vulnerable dependency",
+		Status:    domain.MitigationPlanned,
+		CreatedBy: uuid.New(),
+	}
+}
+
+func newTxSubActions(titles ...string) []*domain.MitigationSubAction {
+	out := make([]*domain.MitigationSubAction, 0, len(titles))
+	for i, title := range titles {
+		out = append(out, &domain.MitigationSubAction{ID: uuid.New(), Title: title, Order: i})
+	}
+	return out
+}
+
+func countRows(t *testing.T, db *gorm.DB, table string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table(table).Count(&n).Error)
+	return n
+}
+
+// Criterion 1 — a valid plan with three sub-actions commits whole.
+func TestCreateWithSubActions_Success(t *testing.T) {
+	repo, db := setupMitigationTxRepo(t, false)
+	tenantID := uuid.New()
+	plan := newTxPlan(tenantID)
+	subs := newTxSubActions("Inventory", "Patch", "Verify")
+
+	require.NoError(t, repo.CreateWithSubActions(tenantID.String(), plan, subs))
+
+	assert.Equal(t, int64(1), countRows(t, db, "mitigations"))
+	assert.Equal(t, int64(3), countRows(t, db, "mitigation_subactions"))
+
+	// Every sub-action is bound to the plan by the repository, not by the caller.
+	for _, sub := range subs {
+		assert.Equal(t, plan.ID, sub.MitigationID)
+	}
+}
+
+// Criterion 2 — the SECOND sub-action insert fails: the whole write rolls back,
+// asserted by querying the database, not by inspecting a mock.
+func TestCreateWithSubActions_PartialFailure_RollsBackEverything(t *testing.T) {
+	repo, db := setupMitigationTxRepo(t, true)
+	tenantID := uuid.New()
+	plan := newTxPlan(tenantID)
+
+	// The duplicate title trips the unique index on the second insert.
+	subs := newTxSubActions("Inventory", "Inventory", "Verify")
+
+	err := repo.CreateWithSubActions(tenantID.String(), plan, subs)
+	require.Error(t, err, "the duplicate sub-action must fail the write")
+
+	assert.Equal(t, int64(0), countRows(t, db, "mitigations"),
+		"the plan must not survive a failed checklist insert")
+	assert.Equal(t, int64(0), countRows(t, db, "mitigation_subactions"),
+		"no sub-action may survive, including the one that inserted before the failure")
+}
+
+// Criterion 3 — the plan insert itself fails: no sub-action is persisted.
+func TestCreateWithSubActions_PlanInsertFails_NoSubActions(t *testing.T) {
+	repo, db := setupMitigationTxRepo(t, false)
+	tenantID := uuid.New()
+
+	first := newTxPlan(tenantID)
+	require.NoError(t, repo.CreateWithSubActions(tenantID.String(), first, nil))
+
+	// Same primary key: the plan insert fails before the checklist is reached.
+	clash := newTxPlan(tenantID)
+	clash.ID = first.ID
+
+	err := repo.CreateWithSubActions(tenantID.String(), clash, newTxSubActions("A", "B"))
+	require.Error(t, err)
+
+	assert.Equal(t, int64(1), countRows(t, db, "mitigations"), "only the first plan exists")
+	assert.Equal(t, int64(0), countRows(t, db, "mitigation_subactions"))
+}
+
+// Criterion 6 — a caller may not write a plan into another tenant, and the row
+// it does write carries its own tenant.
+func TestCreateWithSubActions_Unauthorized_CrossTenantWriteRefused(t *testing.T) {
+	repo, db := setupMitigationTxRepo(t, false)
+	tenantA, tenantB := uuid.New(), uuid.New()
+
+	// The entity claims tenant B while the caller is acting as tenant A.
+	plan := newTxPlan(tenantB)
+
+	err := repo.CreateWithSubActions(tenantA.String(), plan, newTxSubActions("A"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrForbidden)
+
+	assert.Equal(t, int64(0), countRows(t, db, "mitigations"))
+	assert.Equal(t, int64(0), countRows(t, db, "mitigation_subactions"))
+}
+
+// Criterion 6 — a plan written by tenant A is not readable as tenant B.
+func TestCreateWithSubActions_TenantIsolation_NotFoundForOtherTenant(t *testing.T) {
+	repo, _ := setupMitigationTxRepo(t, false)
+	tenantA, tenantB := uuid.New(), uuid.New()
+
+	plan := newTxPlan(tenantA)
+	require.NoError(t, repo.CreateWithSubActions(tenantA.String(), plan, newTxSubActions("A", "B")))
+
+	got, err := repo.GetByID(tenantA.String(), plan.ID)
+	require.NoError(t, err)
+	assert.Equal(t, plan.ID, got.ID)
+	assert.Equal(t, tenantA, got.TenantID)
+
+	_, err = repo.GetByID(tenantB.String(), plan.ID)
+	require.Error(t, err, "tenant B must not see tenant A's plan")
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+// Guard rails on the arguments themselves.
+func TestCreateWithSubActions_RejectsMissingTenantAndNilPlan(t *testing.T) {
+	repo, db := setupMitigationTxRepo(t, false)
+	tenantID := uuid.New()
+
+	require.Error(t, repo.CreateWithSubActions(tenantID.String(), nil, nil))
+
+	noTenant := newTxPlan(tenantID)
+	noTenant.TenantID = uuid.Nil
+	require.Error(t, repo.CreateWithSubActions(tenantID.String(), noTenant, nil))
+
+	badTenant := newTxPlan(tenantID)
+	require.Error(t, repo.CreateWithSubActions("not-a-uuid", badTenant, nil))
+
+	assert.Equal(t, int64(0), countRows(t, db, "mitigations"))
+}


### PR DESCRIPTION
Closes #335

Two independent defects made one bug. Fixing either alone leaves the duplicates.

## What changed

**1. The write is now one transaction.**
`backend/internal/infrastructure/repository/mitigation_repository_tx.go` (new) adds
`CreateWithSubActions`, which inserts the plan and every sub-action inside a single
`db.Transaction`. It replaces the old plan-insert-then-loop, which was a multi-table write with
no transaction. The method also refuses a write whose entity `tenant_id` differs from the
caller's, and binds each sub-action to its parent rather than trusting the caller —
`mitigation_subactions` has no `tenant_id` column and is gated through the plan (ABSOLUTE RULE 2).

The transaction lives in the repository because the application layer may not import GORM.

**2. A committed write is never reported as a failure.**
`backend/internal/handler/mitigation_handler.go` no longer returns `500` when the post-commit
read-back fails. The read-back is kept — it resolves relations the written entity does not carry
— but it is an enrichment, not a gate: on failure the response is built from what the use case
committed. `201` either way.

**3. The use case hands back what it committed.**
`create_plan_usecase.go` builds the checklist up front and makes one transactional call. The
activation recorder and ownership notifier stay *after* the commit deliberately: holding a
transaction open across a notification would turn a slow notifier into a held lock on the hot
create path.

## Verification

```
--- PASS: TestCreateWithSubActions_Success
--- PASS: TestCreateWithSubActions_PartialFailure_RollsBackEverything
--- PASS: TestCreateWithSubActions_PlanInsertFails_NoSubActions
--- PASS: TestCreateWithSubActions_Unauthorized_CrossTenantWriteRefused
--- PASS: TestCreateWithSubActions_TenantIsolation_NotFoundForOtherTenant
--- PASS: TestCreateWithSubActions_RejectsMissingTenantAndNilPlan
ok  	github.com/opendefender/openrisk/internal/infrastructure/repository	0.064s

--- PASS: TestCreateMitigationPlan_Success_WritesPlanAndChecklistInOneCall
--- PASS: TestCreateMitigationPlan_PersistenceFailure_ReturnsErrorAndNoPlan
--- PASS: TestCreateMitigationPlan_NotFound_MissingRiskOrTitleWritesNothing
--- PASS: TestCreateMitigationPlan_Unauthorized_NoTenantWritesNothing
ok  	github.com/opendefender/openrisk/internal/application/mitigation	0.043s

--- PASS: TestCreateMitigation_Success_ReturnsCreatedPlan
--- PASS: TestCreateMitigation_PostCommitReadFailure_StillReturns201
--- PASS: TestCreateMitigation_Unauthorized_NoContext
--- PASS: TestCreateMitigation_InvalidRiskID_NoWrite
ok  	github.com/opendefender/openrisk/internal/handler	0.066s
```

Full suites required by criterion 8:

```
$ go test ./internal/application/mitigation/... ./internal/handler/... ./internal/infrastructure/repository/...
ok  	github.com/opendefender/openrisk/internal/application/mitigation	0.045s
ok  	github.com/opendefender/openrisk/internal/infrastructure/repository	(cached)
ok  	github.com/opendefender/openrisk/internal/handler	12.287s
ok  	github.com/opendefender/openrisk/internal/handler/auth	(cached)
```

Criterion 7:

```
$ grep -n "gorm.io" backend/internal/application/mitigation/*.go
(no output)
```

`go build ./...` clean, `go vet` clean on all three packages, `gofmt -l` empty.

### Both regression tests were proved non-vacuous

A test that passes against the broken code proves nothing, so each was checked against the
pre-fix behaviour before being kept:

- **Rollback.** A scratch test reproducing the old path (plan `Create`, then a loop of
  `subRepo.Create`) on the same fixture left **1 orphan plan and 1 partial sub-action**. The new
  path leaves **0 and 0**. Scratch test deleted after the check.
- **Post-commit 500.** The criterion-4 harness omits the `risks` table, so the read-back's
  `Preload("Risk")` genuinely fails — confirmed directly:
  `read-back error as expected: failed to get mitigation with subactions: no such table: risks`.
  The write still commits and the handler still answers 201. Under the old code that request
  returned 500.

## Acceptance criteria

1 ✅ · 2 ✅ · 3 ✅ · 4 ✅ · 5 ✅ · 6 ✅ · 7 ✅ · 8 ✅

## Definition of Done

- `tenant_id` on every new query — ✅ criterion 6, plus a new cross-tenant write guard that did
  not exist before.
- `_Success` / `_NotFound` / `_Unauthorized` on the use case, plus the partial-write and
  post-commit-read-failure regressions — ✅.
- FR + EN strings — **N/A**, no new user-facing string; the frontend is untouched.
- loading / error / empty states, axe-core — **N/A**, no UI change.
- Security review — no CRITICAL/HIGH. The change removes an information-free 500 and adds a
  cross-tenant write refusal. No new dependency, no new endpoint, no secret.
- Claim matrix — **no-op, stated explicitly**: this restores behaviour already claimed; it adds
  no capability.
- `ROADMAP.md` — line 89 records the Mitigation Workflow module as ✅. That status is unchanged
  by a bug fix restoring intended behaviour, and no claim in the row becomes true or false, so
  the row is left alone rather than edited to narrate a fix.

## Honest remainders

- **This does not make creation idempotent, and is not meant to.** A client that never receives
  the response — a network timeout, a double-click racing itself — can still produce two plans.
  That needs a request-level `Idempotency-Key` and a uniqueness constraint: **#517**, blocked on
  owner decision **D-028**. What this PR removes is the cause of the duplicates users are
  actually reporting: after it, an error means nothing was written, so retrying is safe.
- **The rollback test adds a UNIQUE index that production does not have**, purely to make one
  insert in the middle of the checklist fail. There is no way to prove a rollback without a
  write that fails. It is documented as such in the fixture.
- **The transaction is proved on SQLite, not PostgreSQL.** That is the house pattern for
  repository tests in this tree, and `db.Transaction` is driver-agnostic, but it is not a
  Postgres-level proof of the isolation behaviour under concurrency. Concurrency is #517's
  problem by scope.
- **`NewCreateMitigationPlanUseCase` keeps a parameter it no longer uses** (`subactionRepo`,
  now `_`). Removing it would touch `cmd/server/main.go` and the handler; a P0 is the wrong
  moment to churn a constructor signature. Worth a follow-up.
- **The pre-existing use-case tests in `create_plan_usecase_test.go` assert nothing about
  behaviour** — they construct an input struct and check its own fields. I left them alone and
  added real ones alongside rather than widening this diff, but they are misleading as coverage
  and someone should delete or rewrite them.
- The same read-back-after-commit shape may exist on other endpoints. Out of scope here; #239
  owns finding them.
