### PR TITLE
fix(tooling): honour the escape hatch the tenant tripwire promises (#519)

### DIFF
--- a/.claude/hooks/format-and-lint.sh
+++ b/.claude/hooks/format-and-lint.sh
@@ -18,17 +18,35 @@ case "$FILE" in
     # Tenant-isolation tripwire on persistence code (ABSOLUTE RULE 2).
     case "$FILE" in
       */infrastructure/*|*repository*|*repo.go)
-        if grep -nE '\.Where\(' "$FILE" 2>/dev/null | grep -vq 'tenant_id'; then
+        # A .Where() with no tenant_id is reported UNLESS the line above it is a
+        # comment. That escape hatch is what the message below has always
+        # promised; before it existed, a file holding one legitimately
+        # tenant-agnostic query — a chained builder whose base already filters
+        # by tenant, or a child table gated through its parent — could never be
+        # edited again, because the wire re-tripped on lines nobody had touched.
+        #
+        # A comment is a deliberate act and it shows up in review, which is the
+        # point: the wire's job is to make an unfiltered query impossible to add
+        # by accident, not to make it impossible to explain.
+        UNJUSTIFIED=$(awk '
+          /\.Where\(/ && !/tenant_id/ {
+            if (prev !~ /^[[:space:]]*\/\//) printf "%d:%s\n", FNR, $0
+          }
+          /[^[:space:]]/ { prev = $0 }
+        ' "$FILE")
+
+        if [ -n "$UNJUSTIFIED" ]; then
           {
             echo "TENANT TRIPWIRE — $FILE"
-            echo "A .Where() clause with no tenant_id was found:"
-            grep -nE '\.Where\(' "$FILE" | grep -v 'tenant_id' | head -5
+            echo "A .Where() clause with no tenant_id, and no comment explaining it:"
+            printf '%s\n' "$UNJUSTIFIED" | head -5
             echo ""
             echo "ABSOLUTE RULE 2: every DB query filters by tenant_id."
             echo "If this table has no tenant column, gate it through the parent"
             echo "entity with an ownsX helper and say so explicitly in your report."
             echo "If this query is genuinely tenant-agnostic (migrations, health"
-            echo "checks), add a one-line comment saying why, on the line above."
+            echo "checks), or is chained onto a base query that already filters by"
+            echo "tenant, add a one-line comment saying why on the line above."
           } >&2
           exit 2
         fi ;;


### PR DESCRIPTION
Closes #519

The tenant tripwire told the author how to clear it, then ignored the instruction.

## The bug

`.claude/hooks/format-and-lint.sh:21` was a plain regex over the whole file:

```bash
if grep -nE '\.Where\(' "$FILE" 2>/dev/null | grep -vq 'tenant_id'; then
```

Any `.Where(` line lacking the literal `tenant_id` tripped it — anywhere in the file, including
lines the current edit never touched. The message then said:

> add a one-line comment saying why, on the line above

which the script had no code to honour. The practical effect: a file containing one
legitimately unfiltered query became permanently uneditable by an agent.

## The fix

A `.Where()` without `tenant_id` is cleared only when its immediately preceding non-blank line
is a `//` comment. An unannotated query still fails, unchanged.

## Verification

Run against `backend/internal/infrastructure/repository/mitigation_repository.go`, which holds
five such queries.

**Before annotating** — still trips, correctly, and now says what it actually checks:

```
TENANT TRIPWIRE — .../mitigation_repository.go
A .Where() clause with no tenant_id, and no comment explaining it:
101:			return db.Where("deleted_at IS NULL").Order("\"order\", created_at")
129:		query = query.Where("status = ?", status)
132:		query = query.Where("priority = ?", priority)
135:		query = query.Where("risk_id = ?", riskID)
140:		query = query.Where(
EXIT=2
```

**After annotating those five lines** (done in #335's PR, #518): the hook exits 0 and the file
is editable again — confirmed by a subsequent successful `Edit` on it, which is the real
end-to-end path.

The five queries are genuinely tenant-safe: four are chained onto a `query` that filters by
`tenant_id`, and the fifth is a `Preload` closure scoped to a parent row already pinned to the
tenant. None of them needed a behaviour change — only a sentence saying so.

`bash -n` clean.

## Honest remainders

- **The wire is still whole-file, not diff-aware.** That is the better fix and a bigger one:
  it would stop an author being asked to justify code they did not write. Left out of scope
  deliberately — this PR restores the promised escape hatch, nothing more. Worth its own issue.
- **The escape hatch trusts a comment.** Anyone can silence the wire with `// because`. That is
  inherent to what the message has always promised, and a comment is at least visible in review.
  If you want it stricter, the honest version is a required marker (`// tenant-safe: <reason>`)
  that a reviewer can grep for — say the word and I will change it.
- **The force-push guard in `guard-bash.sh` is untouched.** It works as intended and is
  deliberate policy.
