### PR TITLE
docs(decisions): open D-028 — idempotency-key storage and reach (#517)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,7 +5,41 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-None. Every entry in this register is resolved as of 2026-09-02.
+### D-028 — where the `Idempotency-Key` record lives, and which endpoints must carry it · raised 2026-09-03 · **pending**
+**Raised by** — `po-openrisk`, splitting #335. **Issue** — #517 (`status:needs-refinement`).
+
+**The question** — #335 was one issue bundling a P0 transactional-write bug with a new
+cross-cutting mechanism. The bug is now #335 alone and ships this week. The mechanism is #517
+and cannot start until two things are decided:
+
+1. **Storage.** Redis (already in the stack, TTL for free, but a lost key silently degrades to
+   today's behaviour and the guarantee we document becomes conditional) versus a PostgreSQL
+   table (durable, commits in the same transaction as the write it protects, but a new table and
+   a migration).
+2. **Reach.** Which mutation endpoints must carry the header, and whether it is optional or
+   required. Requiring it is a breaking change for every existing client.
+
+Three further design questions — key scope (key alone, or key + tenant + body hash),
+concurrency semantics, and retention — are `tech-lead`'s to settle, not the owner's, once 1 and
+2 are answered.
+
+**Recommendation** — **PostgreSQL, and optional on every mutation endpoint.** Redis is
+attractive until you write the sentence we would have to publish: "retrying is safe unless the
+cache evicted your key", which is not a guarantee an integrator can build on. A durable record
+that commits with the write is the only version that is true. Optional-not-required because
+requiring the header breaks existing clients for a benefit only retrying clients need; make it
+honoured when present, and document it. Recommend an ADR: this touches every mutation endpoint
+and the reasoning should outlive the issue.
+
+**Cost of delay** — low and bounded, which is exactly why the split was made. #335 removes the
+cause of the duplicates users are actually reporting; what remains uncovered is the retry after
+a response that never arrived. Nothing blocks on this until an integrator asks for a retry
+guarantee, or until #239 (W8-06, Wave 8) reaches its idempotency line and finds no design. It
+should not, however, sit unanswered past Wave 8 planning.
+
+**Not urgent. Answer at the next convenient decision round, not ahead of anything on Wave 1.**
+
+---
 
 ## Resolved
 


### PR DESCRIPTION
Records **D-028** as pending in `docs/DECISIONS.md`. Relates to #517; does not close it — #517
stays `status:needs-refinement` until this decision is answered.

## Why this is a PR and not a loose edit

`po-openrisk` raised D-028 while refining #335 and appended it to the working tree. It sat
uncommitted among unrelated changes, on a branch it had nothing to do with, where it would have
been swept into whatever PR was next. A decision record that nobody can find is not a decision
record. This puts it on its own branch off `master` so it lands as one reviewable commit.

## The decision

Splitting #335 (the P0 transactional-write bug, now PR #518) from #517 (the `Idempotency-Key`
mechanism) left two questions only you can answer:

1. **Storage** — Redis, or a PostgreSQL table.
2. **Reach** — which mutation endpoints carry the header, and whether it is optional or required.

The recommendation recorded is **PostgreSQL, optional on every mutation endpoint**, with an ADR.
The reasoning, in one line: Redis is attractive until you write the sentence you would have to
publish — *"retrying is safe unless the cache evicted your key"* — which is not a guarantee an
integrator can build on.

Three further questions (key scope, concurrency semantics, retention) are noted as `tech-lead`'s
to settle once 1 and 2 are answered, not yours.

## Verification

```
$ git diff --stat docs/DECISIONS.md
 docs/DECISIONS.md | 36 +++++++++++++++++++++++++++++++++++-
 1 file changed, 35 insertions(+), 1 deletion(-)
```

The register's `## Open` section previously read "None. Every entry in this register is resolved
as of 2026-09-02"; that line is replaced by the D-028 entry. No resolved entry is touched.

## Honest remainders

- **Cost of delay is low, and the entry says so.** #518 removes the cause of the duplicates
  users actually report. What stays uncovered is a retry after a response that never arrived —
  nothing blocks on it until an integrator asks for a retry guarantee, or #239 reaches its
  idempotency line and finds no design. It should not sit past Wave 8 planning.
- I did not write the D-028 text; `po-openrisk` did. I reviewed it, agree with the
  recommendation, and moved it somewhere it can be found. The recommendation is not mine to
  approve — that is what "pending" means.
