### PR TITLE
test(dashboard): pin the trend empty-state to the register, not the series (#343)

### DIFF
--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -585,7 +585,10 @@ function HeatmapCard({
 // band split uses each risk's CURRENT criticality — the register does not version
 // criticality per day, and inventing a per-day band would be a number nobody
 // could reconcile.
-function TrendCard({
+// Exported for its tests. The decision this component makes — "no risks" versus
+// "no risks in THIS window" — was wrong once (#343) and the two states have
+// opposite remedies, so it is pinned by tests rather than left to inspection.
+export function TrendCard({
   trend,
   registerTotal,
   isLoading,

--- a/frontend/src/features/dashboard/__tests__/TrendCard.test.tsx
+++ b/frontend/src/features/dashboard/__tests__/TrendCard.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TrendCard } from '../DashboardPage';
+import type { PeriodSelection } from '../period';
+import { useUIStore } from '../../../store/uiStore';
+import type { RiskTrend, RiskTrendPoint } from '../useCommandCenter';
+
+// The three cases issue 343 requires turn on ONE decision: is this widget empty
+// because the register is empty, or because the selected window is? The two
+// have opposite remedies — "create your first risk" versus "widen the period" —
+// and showing the wrong one tells a tenant with a populated register that it has
+// no risks.
+//
+// The decision was previously derived from the series' last `cumulative_total`.
+// That is a stock counted at each bucket's end, so any window in the past reads
+// 0 for a register first populated afterwards, and the widget concluded the
+// tenant was empty. These tests pin the decision to the REGISTER's own total.
+
+const PERIOD: PeriodSelection = { kind: 'preset', preset: '30d' };
+
+function point(bucket: string, opened: number, cumulative: number): RiskTrendPoint {
+  return {
+    bucket,
+    opened,
+    opened_by_band: opened ? { CRITICAL: opened } : {},
+    cumulative_total: cumulative,
+  };
+}
+
+function trendOf(points: RiskTrendPoint[]): RiskTrend {
+  return { from: '2026-08-04', to: '2026-09-03', granularity: 'day', points };
+}
+
+function renderTrend(props: {
+  trend?: RiskTrend;
+  registerTotal: number;
+  onWidenPeriod?: () => void;
+}) {
+  return render(
+    <TrendCard
+      trend={props.trend}
+      registerTotal={props.registerTotal}
+      isLoading={false}
+      error={null}
+      retry={() => {}}
+      selection={PERIOD}
+      onWidenPeriod={props.onWidenPeriod ?? (() => {})}
+    />,
+  );
+}
+
+// The card reads its language from the store, not from a prop. Pinning it makes
+// these assertions independent of the app's default locale, which is French.
+beforeEach(() => {
+  useUIStore.setState({ lang: 'en' });
+});
+
+afterEach(cleanup);
+
+describe('TrendCard empty-state semantics — issue 343', () => {
+  // Case 1 of the issue.
+  it('a tenant with NO risks is told the register is empty, not the period', () => {
+    renderTrend({ trend: trendOf([]), registerTotal: 0 });
+
+    expect(screen.getByText(/no trend yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nothing in this period/i)).not.toBeInTheDocument();
+    // Widening the window cannot help a register that holds nothing, so the
+    // action that says so must not be offered.
+    expect(screen.queryByRole('button', { name: /show all time/i })).not.toBeInTheDocument();
+  });
+
+  // Case 2 of the issue.
+  it('a tenant with risks AND activity in the window gets the chart, not an empty state', () => {
+    renderTrend({
+      trend: trendOf([point('2026-09-01', 2, 7), point('2026-09-02', 1, 8)]),
+      registerTotal: 8,
+    });
+
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    expect(screen.queryByText(/no trend yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/nothing in this period/i)).not.toBeInTheDocument();
+  });
+
+  // Case 3 of the issue — the one the bug got wrong.
+  it('a tenant with risks but NO activity in the window is told the PERIOD is empty', () => {
+    const onWidenPeriod = vi.fn();
+    renderTrend({
+      // Buckets exist, nothing was opened in them. The register holds 8 risks,
+      // all created before this window.
+      trend: trendOf([point('2026-09-01', 0, 0), point('2026-09-02', 0, 0)]),
+      registerTotal: 8,
+      onWidenPeriod,
+    });
+
+    expect(screen.getByText(/nothing in this period/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no trend yet/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show all time/i })).toBeInTheDocument();
+  });
+
+  // The regression guard. This is the exact shape that was misread: a window in
+  // the past over a register populated later, so every `cumulative_total` in the
+  // series is 0 while the register is not empty. Deriving the decision from the
+  // series again would fail here and nowhere else.
+  it('does not conclude "no risks" from a zero cumulative series', () => {
+    renderTrend({
+      trend: trendOf([point('2026-01-01', 0, 0), point('2026-01-02', 0, 0)]),
+      registerTotal: 8,
+    });
+
+    expect(screen.getByText(/nothing in this period/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no trend yet/i)).not.toBeInTheDocument();
+  });
+
+  // The mirror of the guard above: a non-zero cumulative must not be allowed to
+  // stand in for the register either. Nothing opened, nothing in the register —
+  // the series' stock is irrelevant to which empty state is correct.
+  it('does not conclude "period is empty" from a non-zero cumulative alone', () => {
+    renderTrend({
+      trend: trendOf([point('2026-09-01', 0, 5)]),
+      registerTotal: 0,
+    });
+
+    expect(screen.getByText(/no trend yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nothing in this period/i)).not.toBeInTheDocument();
+  });
+
+  // A missing payload is not the same as an empty one, and must not be reported
+  // as a period problem the user could act on.
+  it('treats an absent trend with an empty register as the empty register', () => {
+    renderTrend({ trend: undefined, registerTotal: 0 });
+
+    expect(screen.getByText(/no trend yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nothing in this period/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #343

## What I found first

**The behaviour half of this issue was already fixed on `master`.** `DashboardPage.tsx:633`
reads:

```ts
const emptyBecauseOfPeriod = opened === 0 && registerTotal > 0;
```

`registerTotal` comes from the payload (`stats?.total_risks`, line 281), not from the series,
and `WidgetState.tsx:118` already renders *"Rien sur cette période"* with a widen action,
distinct from *"Pas encore de tendance"*. The comment at lines 619-632 records the original
defect in the same terms this issue uses.

**What was missing is the half the issue actually asks for: the tests.** The one line that had
been wrong was the one line with nothing guarding it. `WidgetState.test.tsx` passes
`emptyBecauseOfPeriod` **in as a prop** — it proves the component renders correctly once told,
and never touches the derivation that decides what to tell it. There was no test file for
`TrendCard` at all.

## What changed

- `frontend/src/features/dashboard/__tests__/TrendCard.test.tsx` — **new**, 6 tests.
- `frontend/src/features/dashboard/DashboardPage.tsx` — `TrendCard` is now exported, with a
  comment saying why. That is the entire production diff: **+4 −1**, no behaviour change.

The three cases the issue enumerates:

1. tenant with **no risks** → "no trend yet", and the widen-period button is **absent**, because
   widening cannot help an empty register;
2. tenant with **risks and activity** in the window → the chart renders, neither empty state;
3. tenant with **risks but no activity** in the window → "nothing in this period", widen button
   present.

Plus two guards on the derivation itself:

4. a series whose every `cumulative_total` is 0 over a register holding 8 — the exact shape the
   old code misread, a window in the past over a register populated later;
5. its mirror: a non-zero cumulative must not stand in for a register that is genuinely empty.

And one on absent data: no payload with an empty register is the empty register, not a period
problem the user could act on.

## Verification

```
$ npx vitest run src/features/dashboard/__tests__/TrendCard.test.tsx
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ npx vitest run src/features/dashboard/          # whole feature, no regressions
 Test Files  5 passed (5)
      Tests  47 passed (47)

$ npx tsc --noEmit                                # exit 0
$ npx prettier --check <both files>
All matched files use Prettier code style!
$ npx eslint <both files>                         # exit 0, no new warnings
```

### The tests are not vacuous — proved, not asserted

A test that also passes against the broken code is worthless. I temporarily reverted the
derivation to the buggy version (`opened === 0 && lastCumulative > 0`) and re-ran:

```
× a tenant with risks but NO activity in the window is told the PERIOD is empty
× does not conclude "no risks" from a zero cumulative series
× does not conclude "period is empty" from a non-zero cumulative alone
 Tests  3 failed | 3 passed (6)
```

Exactly the three discriminating tests fail, and no others — cases 1 and 2 and the absent-data
case do not distinguish the two derivations, so they correctly still pass. The production file
was restored from a backup and re-verified green.

## Honest remainders

- **I did not change the copy.** The issue asks for a *"Élargir la période"* action; the shipped
  string is *"Voir tout l'historique"* (`WidgetState.tsx:129`). Both say the same thing, and the
  string lives in shared `WidgetState` used by other widgets, so changing it is a wording
  decision with a blast radius beyond this card — yours to make, not mine to slip into a test PR.
  The tests assert by role and by the title, so they will not break if you reword the button.
- **`TrendCard` had to be exported to be tested.** The alternative was rendering the whole
  `DashboardPage` behind mocked stores and queries, which tests the harness more than the rule.
- **These are component tests, not end-to-end.** They prove the card decides correctly given a
  payload; they do not prove the server populates `total_risks` for every period. That contract
  is the dashboard aggregate's and is covered on the backend.
- **A pre-existing lint rule reads issue references as colours.** `openrisk/no-raw-colors` fails
  on the literal `#343` in a comment or string, since it is three hex digits. I reworded to
  "issue 343" rather than suppress the rule, but any issue whose number is hex-shaped will hit
  this. Worth an issue if it bites again.
- `DashboardPage.tsx` carries 3 pre-existing `react-hooks/exhaustive-deps` warnings at lines
  166, 168 and 861. Untouched — they are not mine and not this issue.
