### PR TITLE
fix(auth): MFA sign-in must carry the current business role (#338)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -896,7 +896,13 @@ func main() {
 		logoutUseCase,
 		passwordHasher,
 		authAudit,
-	).WithNewDeviceNotifier(newDeviceNotifier).WithUserLookup(userRepo).WithMFAStatus(mfaStatusResolver)
+	).WithNewDeviceNotifier(newDeviceNotifier).
+		WithUserLookup(userRepo).
+		WithMFAStatus(mfaStatusResolver).
+		// The same repository resolveSessionForOrg reads at token mint time, so
+		// /auth/me's business role and the token's permissions come from one
+		// membership row and cannot disagree (#338).
+		WithMemberLookup(userRepo)
 
 	// OAuth identity resolution: known link → verified-email link → provision.
 	// No provisioner is wired, so an identity with no OpenRisk account is refused

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -35,11 +35,27 @@ type Handler struct {
 	// rather than guessing, and the client treats an absent block as "unknown"
 	// instead of as "not required".
 	mfaStatus *auth.MFAStatusResolver
+	// memberLookup resolves the caller's membership so /auth/me can report the
+	// CURRENT business role. Optional; without it the field is omitted rather
+	// than guessed (#338).
+	memberLookup OrganizationMemberReader
 }
 
 // UserByIDReader resolves a user by id for /auth/me.
 type UserByIDReader interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.User, error)
+}
+
+// OrganizationMemberReader resolves the caller's membership in the active
+// organization.
+//
+// business_role lives on the MEMBERSHIP, not on the user: the same account can
+// be an RSSI in one organization and a viewer in another, so there is no such
+// field on domain.User to serialise. /auth/me is where every authenticated path
+// — password login, MFA, session restore — reads its profile back, which makes
+// it the one place worth resolving it (#338).
+type OrganizationMemberReader interface {
+	GetOrganizationMember(ctx context.Context, userID, orgID uuid.UUID) (*domain.OrganizationMember, error)
 }
 
 // WithNewDeviceNotifier enables the new-device sign-in alert.
@@ -57,6 +73,12 @@ func (h *Handler) WithUserLookup(r UserByIDReader) *Handler {
 // WithMFAStatus makes /auth/me carry the resolved MFA requirement (OR26-03).
 func (h *Handler) WithMFAStatus(r *auth.MFAStatusResolver) *Handler {
 	h.mfaStatus = r
+	return h
+}
+
+// WithMemberLookup makes /auth/me report the caller's current business role.
+func (h *Handler) WithMemberLookup(r OrganizationMemberReader) *Handler {
+	h.memberLookup = r
 	return h
 }
 
@@ -506,6 +528,15 @@ func (h *Handler) Me(c *fiber.Ctx) error {
 			if mfaBlock != nil {
 				body["mfa"] = mfaBlock
 			}
+			// The CURRENT business role, re-read per call like everything else
+			// here. The client picks its persona and its landing route from
+			// this; before #338 the field did not exist on this response, so
+			// every path that restores a profile through /auth/me — MFA login
+			// above all — resolved it to "" and dropped the user on the default
+			// dashboard while their permissions said otherwise.
+			if role, ok := h.resolveBusinessRole(c, mwCtx.UserID, mwCtx.OrganizationID); ok {
+				body["business_role"] = role
+			}
 			return c.JSON(body)
 		}
 		if err == nil && user == nil {
@@ -524,6 +555,31 @@ func (h *Handler) Me(c *fiber.Ctx) error {
 		body["mfa"] = mfaBlock
 	}
 	return c.JSON(body)
+}
+
+// resolveBusinessRole reads the caller's CURRENT business role for the active
+// organization. The bool reports whether it could be resolved at all.
+//
+// Omitted rather than defaulted when it cannot be, for the same reason as the
+// MFA block below: "" is a REAL value — root and admin carry no job-role preset
+// — so returning it on a database error would assert "this user is an admin"
+// when the truthful answer is "not known". An absent key leaves the client on
+// what it already had; a present "" is an answer.
+func (h *Handler) resolveBusinessRole(c *fiber.Ctx, userID, orgID uuid.UUID) (domain.BusinessRoleKey, bool) {
+	if h.memberLookup == nil || orgID == uuid.Nil {
+		return "", false
+	}
+	member, err := h.memberLookup.GetOrganizationMember(c.UserContext(), userID, orgID)
+	if err != nil || member == nil {
+		return "", false
+	}
+	// A revoked membership is not a persona. Enforcement lives at token mint and
+	// in the request guard; reporting a role here for a membership that no longer
+	// authorizes anything would only mislead the navigation.
+	if !member.IsActive {
+		return "", false
+	}
+	return member.BusinessRole, true
 }
 
 // resolveMFABlock resolves the caller's MFA requirement, or nil when it cannot

--- a/backend/internal/handler/auth/me_business_role_test.go
+++ b/backend/internal/handler/auth/me_business_role_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/middleware"
+)
+
+// /auth/me is the one place every authenticated path reads its profile back:
+// password login, MFA challenge, mandated enrolment, session restore. Before
+// #338 it did not report business_role at all, so any path that went through it
+// resolved the persona to "" — an MFA user landed on the default dashboard while
+// their token carried an RSSI's permissions.
+//
+// business_role lives on the MEMBERSHIP, not on domain.User, which is why it has
+// to be resolved here rather than serialised with the user.
+
+type stubUserReader struct {
+	user *domain.User
+	err  error
+}
+
+func (s stubUserReader) GetByID(context.Context, uuid.UUID) (*domain.User, error) {
+	return s.user, s.err
+}
+
+type stubMemberReader struct {
+	member *domain.OrganizationMember
+	err    error
+	calls  int
+	gotUID uuid.UUID
+	gotOrg uuid.UUID
+}
+
+func (s *stubMemberReader) GetOrganizationMember(_ context.Context, userID, orgID uuid.UUID) (*domain.OrganizationMember, error) {
+	s.calls++
+	s.gotUID, s.gotOrg = userID, orgID
+	return s.member, s.err
+}
+
+func meApp(t *testing.T, h *Handler, userID, orgID uuid.UUID) *fiber.App {
+	t.Helper()
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		middleware.SetContext(c, &middleware.RequestContext{UserID: userID, OrganizationID: orgID})
+		return c.Next()
+	})
+	app.Get("/auth/me", h.Me)
+	return app
+}
+
+func callMe(t *testing.T, app *fiber.App) (int, map[string]any) {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/auth/me", nil))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	body := map[string]any{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &body)
+	}
+	return resp.StatusCode, body
+}
+
+func handlerWith(user *domain.User, member *stubMemberReader) *Handler {
+	h := NewHandler(nil, nil, nil, nil, nil, nil).WithUserLookup(stubUserReader{user: user})
+	if member != nil {
+		h = h.WithMemberLookup(member)
+	}
+	return h
+}
+
+func TestMe_ReportsTheCurrentBusinessRole(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	member := &stubMemberReader{member: &domain.OrganizationMember{
+		UserID: userID, OrganizationID: orgID, IsActive: true, BusinessRole: "rssi",
+	}}
+
+	status, body := callMe(t, meApp(t, handlerWith(&domain.User{ID: userID}, member), userID, orgID))
+
+	require.Equal(t, http.StatusOK, status)
+	assert.Equal(t, "rssi", body["business_role"])
+
+	// Resolved for the CALLER and the ACTIVE organization, not from anything the
+	// client could supply.
+	assert.Equal(t, 1, member.calls)
+	assert.Equal(t, userID, member.gotUID)
+	assert.Equal(t, orgID, member.gotOrg)
+}
+
+// The role changed server-side; the next /auth/me must report the new one. This
+// is the acceptance criterion: a role change followed by re-authentication
+// produces the current role, because nothing is cached between the two.
+func TestMe_ReflectsARoleChangeOnTheNextCall(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	member := &stubMemberReader{member: &domain.OrganizationMember{
+		UserID: userID, OrganizationID: orgID, IsActive: true, BusinessRole: "auditor",
+	}}
+	app := meApp(t, handlerWith(&domain.User{ID: userID}, member), userID, orgID)
+
+	_, first := callMe(t, app)
+	require.Equal(t, "auditor", first["business_role"])
+
+	member.member.BusinessRole = "rssi"
+
+	_, second := callMe(t, app)
+	assert.Equal(t, "rssi", second["business_role"],
+		"the role must be re-read per call, never served from a cached profile")
+	assert.Equal(t, 2, member.calls)
+}
+
+// An admin or root carries no job-role preset. "" is a REAL answer here and must
+// be present, so the client stops showing whatever persona it had before.
+func TestMe_AnEmptyRoleIsAnAnswer_NotAnOmission(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+	member := &stubMemberReader{member: &domain.OrganizationMember{
+		UserID: userID, OrganizationID: orgID, IsActive: true, BusinessRole: "",
+	}}
+
+	_, body := callMe(t, meApp(t, handlerWith(&domain.User{ID: userID}, member), userID, orgID))
+
+	role, present := body["business_role"]
+	assert.True(t, present, "an admin's empty role must be reported, not omitted")
+	assert.Equal(t, "", role)
+}
+
+// The mirror: when the role cannot be RESOLVED, the field is omitted rather than
+// defaulted to "". A present "" asserts "this user is an admin"; an absent key
+// says "not known" and leaves the client on what it had.
+func TestMe_OmitsTheRoleWhenItCannotBeResolved(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+
+	cases := map[string]*stubMemberReader{
+		"lookup fails":       {err: errors.New("database down")},
+		"no membership":      {member: nil},
+		"membership revoked": {member: &domain.OrganizationMember{UserID: userID, OrganizationID: orgID, IsActive: false, BusinessRole: "rssi"}},
+	}
+
+	for name, member := range cases {
+		t.Run(name, func(t *testing.T) {
+			status, body := callMe(t, meApp(t, handlerWith(&domain.User{ID: userID}, member), userID, orgID))
+
+			require.Equal(t, http.StatusOK, status, "an unresolvable role must not fail the call")
+			_, present := body["business_role"]
+			assert.False(t, present, "the field must be absent, not an empty string")
+			assert.NotNil(t, body["user"], "the rest of the profile still answers")
+		})
+	}
+}
+
+// A deployment that wired no member lookup must not fabricate a persona.
+func TestMe_OmitsTheRoleWhenNoLookupIsWired(t *testing.T) {
+	userID, orgID := uuid.New(), uuid.New()
+
+	_, body := callMe(t, meApp(t, handlerWith(&domain.User{ID: userID}, nil), userID, orgID))
+
+	_, present := body["business_role"]
+	assert.False(t, present)
+}
+
+// Without a tenant there is no membership to resolve, and the lookup must not
+// even be attempted with a nil organization.
+func TestMe_Unauthorized_NoTenantResolvesNoRole(t *testing.T) {
+	userID := uuid.New()
+	member := &stubMemberReader{member: &domain.OrganizationMember{IsActive: true, BusinessRole: "rssi"}}
+
+	_, body := callMe(t, meApp(t, handlerWith(&domain.User{ID: userID}, member), userID, uuid.Nil))
+
+	_, present := body["business_role"]
+	assert.False(t, present)
+	assert.Equal(t, 0, member.calls, "a nil organization must not reach the repository")
+}
+
+// No authenticated caller at all: 401 before anything is read.
+func TestMe_Unauthorized_NoContext(t *testing.T) {
+	member := &stubMemberReader{}
+	app := fiber.New()
+	app.Get("/auth/me", handlerWith(&domain.User{ID: uuid.New()}, member).Me)
+
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/auth/me", nil))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, 0, member.calls)
+}

--- a/frontend/src/hooks/__tests__/useAuthStore.adoptSession.test.ts
+++ b/frontend/src/hooks/__tests__/useAuthStore.adoptSession.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { useAuthStore } from '../useAuthStore';
+import { api } from '../../lib/api';
+
+// adoptSession is the door into a session for every path that does NOT go
+// through /auth/login: the MFA challenge, mandated MFA enrolment, and anything
+// else holding a fresh access token.
+//
+// It resolved the persona to "" on every one of them (#338). business_role lives
+// on the membership, so it is not a field of the user object /auth/me returns —
+// and adoptSession was calling withTokenClaims without the role argument, so the
+// fallback chain `businessRole ?? user.business_role ?? ''` reached the end
+// every time. Permissions come from the JWT and kept working, which is exactly
+// why an RSSI signing in with MFA landed on the default dashboard and nobody
+// read it as an authorization bug.
+
+vi.mock('../../lib/sessionScope', () => ({ clearSessionScope: vi.fn() }));
+vi.mock('../../lib/session', () => ({ setAccessToken: vi.fn() }));
+
+// A syntactically valid RS256-shaped token whose payload carries permissions but
+// NO business_role — the real shape, and the reason the field cannot come from
+// the token.
+function tokenWith(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) =>
+    btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64(payload)}.sig`;
+}
+
+const ACCESS_TOKEN = tokenWith({
+  sub: 'user-1',
+  permissions: ['risks:read', 'risks:create'],
+  tenant_id: 'tenant-1',
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  useAuthStore.setState({ user: null, token: null, isAuthenticated: false });
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('adoptSession — business_role (#338)', () => {
+  it('takes the business role from /auth/me, beside the user rather than inside it', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      data: {
+        organization_id: 'tenant-1',
+        // Note: no business_role on the user. There is no such column.
+        user: { id: 'user-1', email: 'rssi@example.com', full_name: 'R Ssi' },
+        business_role: 'rssi',
+      },
+    });
+
+    await useAuthStore.getState().adoptSession(ACCESS_TOKEN);
+
+    expect(useAuthStore.getState().user?.business_role).toBe('rssi');
+    // The permissions still come from the token, unchanged by this fix.
+    expect(useAuthStore.getState().user?.permissions).toEqual(['risks:read', 'risks:create']);
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  // The acceptance criterion: change the role, authenticate again, get the new
+  // one. Nothing may be restored from the previous session's cached profile.
+  it('a role changed server-side wins over the cached profile', async () => {
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ id: 'user-1', email: 'rssi@example.com', business_role: 'auditor' }),
+    );
+
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      data: {
+        organization_id: 'tenant-1',
+        user: { id: 'user-1', email: 'rssi@example.com' },
+        business_role: 'rssi',
+      },
+    });
+
+    await useAuthStore.getState().adoptSession(ACCESS_TOKEN);
+
+    expect(useAuthStore.getState().user?.business_role).toBe('rssi');
+    // And the cache it writes back must carry the NEW role, or the next reload
+    // reinstates the stale persona.
+    expect(JSON.parse(localStorage.getItem('auth_user') ?? '{}').business_role).toBe('rssi');
+  });
+
+  // An admin/root legitimately has no preset. "" is an answer and must replace a
+  // previously cached role rather than being treated as "no opinion".
+  it('an explicit empty role replaces a cached one', async () => {
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ id: 'user-1', email: 'a@example.com', business_role: 'rssi' }),
+    );
+
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      data: {
+        organization_id: 'tenant-1',
+        user: { id: 'user-1', email: 'a@example.com' },
+        business_role: '',
+      },
+    });
+
+    await useAuthStore.getState().adoptSession(ACCESS_TOKEN);
+
+    expect(useAuthStore.getState().user?.business_role).toBe('');
+  });
+
+  // When the server could not resolve it, the field is absent. The session is
+  // still adopted — a persona is a navigation hint, not a credential.
+  it('survives /auth/me omitting the role', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      data: {
+        organization_id: 'tenant-1',
+        user: { id: 'user-1', email: 'a@example.com' },
+      },
+    });
+
+    await useAuthStore.getState().adoptSession(ACCESS_TOKEN);
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().user?.business_role).toBe('');
+    expect(useAuthStore.getState().user?.permissions).toEqual(['risks:read', 'risks:create']);
+  });
+
+  // The identity regression this function already guards against: /auth/me
+  // answers an envelope, not a bare user, and spreading the envelope stored a
+  // profile whose id and email were undefined.
+  it('reads the profile out of the envelope, not the envelope itself', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      data: {
+        organization_id: 'tenant-1',
+        user: { id: 'user-1', email: 'rssi@example.com', full_name: 'R Ssi' },
+        business_role: 'dsi',
+      },
+    });
+
+    await useAuthStore.getState().adoptSession(ACCESS_TOKEN);
+
+    const user = useAuthStore.getState().user;
+    expect(user?.id).toBe('user-1');
+    expect(user?.email).toBe('rssi@example.com');
+    expect(user?.business_role).toBe('dsi');
+  });
+});

--- a/frontend/src/hooks/useAuthStore.ts
+++ b/frontend/src/hooks/useAuthStore.ts
@@ -160,7 +160,11 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     const { data } = await api.get('/auth/me');
     const profile = (data?.user ?? data) as Record<string, unknown> & { role?: { name?: string } };
     const base: User = { ...profile, role: profile.role?.name ?? '' } as User;
-    const user = withTokenClaims(base, accessToken);
+    // business_role sits on the MEMBERSHIP, so it arrives beside the user rather
+    // than inside it. Passing it through is what makes an MFA login land on the
+    // right persona: without it the role resolved to "" on every MFA sign-in,
+    // because the user object has no such field to fall back to (#338).
+    const user = withTokenClaims(base, accessToken, data?.business_role);
 
     localStorage.setItem('auth_user', JSON.stringify(user));
     set({ token: accessToken, user, isAuthenticated: true });


### PR DESCRIPTION
Closes #338

## What was actually wrong

The token claims were never the problem. `resolveSessionForOrg`
(`cmd/server/main.go:711-731`) already re-reads `GetOrganizationMember` from the database at
mint time and recomputes `EffectivePermissions()`, and the MFA challenge goes through
`IssueSession`, which uses it. **Permissions after an MFA login were already current.**

The profile was the gap, and it was worse than "outdated" — it was empty every time:

1. `mfa_handler.go:158` and `:241` return `LoginResponse{TokenPair, CSRFToken}`, omitting `User`,
   `Organization` and `BusinessRole`. `/auth/login` returns all four. The comment at
   `mfa_handler.go:134-136` claims these responses are "byte-identical to /auth/login" — they
   are not, and that false claim is what hid this.
2. The SPA compensates by re-reading `/auth/me`, but that returned a `domain.User`, and
   **`domain.User` has no `business_role`** — it lives on `OrganizationMember`, because the same
   account can be an RSSI in one organization and a viewer in another.
3. `business_role` is written in exactly one place on the client: `withTokenClaims`
   (`useAuthStore.ts:85`), `businessRole ?? user.business_role ?? ''`. Login passes it;
   **`adoptSession` did not**. The JWT carries no such claim either, so the chain reached `''`.

So after any MFA sign-in the persona was `''`, `AuthScreen.tsx:292` routed on it, and
`personaFor()` fell through to the default dashboard — while the user's permissions were
correct. That asymmetry is why it went unnoticed.

## The fix — one canonical source

`/auth/me` is where every authenticated path reads its profile back, so the role is resolved
there, once:

- **`backend/internal/handler/auth/handler.go`** — new `OrganizationMemberReader` port and
  `WithMemberLookup`, plus `resolveBusinessRole`. `/auth/me` now reports `business_role`,
  re-read per call.
- **`backend/cmd/server/main.go`** — wired to `userRepo`, **the same repository**
  `resolveSessionForOrg` reads at mint time, so the role and the token's permissions come from
  one membership row and cannot disagree.
- **`frontend/src/hooks/useAuthStore.ts`** — `adoptSession` passes it through. One line.

**Omitted rather than defaulted when it cannot be resolved.** `""` is a *real* value — root and
admin carry no preset — so returning it on a database error would assert "this user is an admin"
when the honest answer is "not known". An absent key leaves the client on what it had; a present
`""` is an answer. A revoked membership reports no role either.

## Verification

```
$ go test ./internal/handler/auth/
--- PASS: TestMe_ReportsTheCurrentBusinessRole
--- PASS: TestMe_ReflectsARoleChangeOnTheNextCall
--- PASS: TestMe_AnEmptyRoleIsAnAnswer_NotAnOmission
--- PASS: TestMe_OmitsTheRoleWhenItCannotBeResolved/lookup_fails
--- PASS: TestMe_OmitsTheRoleWhenItCannotBeResolved/no_membership
--- PASS: TestMe_OmitsTheRoleWhenItCannotBeResolved/membership_revoked
--- PASS: TestMe_OmitsTheRoleWhenNoLookupIsWired
--- PASS: TestMe_Unauthorized_NoTenantResolvesNoRole
--- PASS: TestMe_Unauthorized_NoContext
ok  	github.com/opendefender/openrisk/internal/handler/auth	0.940s

$ npx vitest run src/hooks/ src/features/auth/
 Test Files  7 passed (7)
      Tests  61 passed (61)
```

`go build ./...` clean · `go vet` clean · `gofmt -l` empty · `tsc --noEmit` clean · Prettier
clean · ESLint clean.

### The frontend tests are proved non-vacuous

Reverting only the one-line pass-through and re-running:

```
× takes the business role from /auth/me, beside the user rather than inside it
× a role changed server-side wins over the cached profile
× reads the profile out of the envelope, not the envelope itself
 Tests  3 failed | 2 passed (5)
```

Exactly the three discriminating tests fail. The two that still pass are the "role omitted" and
"explicit empty role" cases, which resolve to `''` under either version — correctly indifferent.
The file was restored from a backup and re-verified green.

**The backend tests are new-surface, not regression guards, and I am not claiming otherwise:**
the field did not exist before this PR, so they could not have passed against the old code — it
would not even compile without `WithMemberLookup`. The frontend tests are the real guards.

## Acceptance criteria

- Role change + MFA auth produces the current role ✅
- Token/session profile contains the current role ✅
- Correct permissions immediately effective ✅ — already true before this PR; now covered
- Navigation/persona reflects the new role ✅ (`business_role` is what `personaFor` reads)
- Regression tests cover every authentication path ⚠️ — see below
- Stale cache data cannot restore an outdated role ⚠️ — see below

## Honest remainders

- **I did not implement "one canonical authorization-profile resolution path" across all seven
  flows.** The issue names password, MFA, MFA challenge, refresh, OAuth, SAML and session
  restoration. Unifying the profile contract across those is a redesign of auth, which
  CLAUDE.md puts on your desk, not mine. What this PR does is make `/auth/me` the single place
  the role is resolved — every one of those flows already funnels through it for its profile —
  without changing the response shape of login, refresh, OAuth or SAML. If you want the literal
  seven-path unification, it wants an ADR.
- **The MFA responses still omit `User`, `Organization` and `BusinessRole`,** and the
  "byte-identical to /auth/login" comment at `mfa_handler.go:134-136` is still false. Fixing the
  comment or the responses is a separate change; the bug is cured either way because the client
  reads `/auth/me`. Worth an issue — a false comment is how this one hid.
- **One residual staleness path, unchanged by this PR.** `useAuthStore.ts:93` hydrates the user
  from `localStorage` on boot and there is no profile refetch at startup, so a role changed
  while a tab was closed stays stale until the next `adoptSession`, login, or something that
  calls `/auth/me`. The issue's criterion is about re-authentication, which is now correct.
  Adding a boot-time refresh is a behavioural change with its own trade-offs and is not smuggled
  in here.
- **`Challenge` still duplicates `issueSessionResponse`** rather than calling it
  (`mfa_handler.go:216-241` vs `:137-158`). Pre-existing, untouched — deduplicating auth code
  was not worth widening a P0 diff.
- **No end-to-end test drives a real MFA login against a live server.** These are handler-level
  and store-level. The seam between them — that the client sends what the server returns — is
  covered by both sides asserting the same field name, not by one test crossing the wire.
