### PR TITLE
fix(auth): refuse a session for a disabled or deleted account (#350)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -702,46 +701,14 @@ func main() {
 	// every token is signed and validated by one implementation.
 	tokenManager := coreauth.NewTokenManager(database.DB, rsaKeys)
 
-	// resolveSessionForOrg re-derives a user's claims for a SPECIFIC organization,
-	// enforcing that the user is an ACTIVE member of it. It is the single
-	// authorization gate for org-scoped sessions: refresh resolves for the
-	// session's own org, and organization switching resolves for the chosen org.
-	// A user who is not an active member of orgID gets an error here, so a forged
-	// or stolen org id can never be turned into a session.
+	// Both resolvers live in session_wiring.go as named functions so they can be
+	// driven in a test without a database. They enforce ACCOUNT state as well as
+	// membership state; see the commentary there for why both are needed (#350).
 	resolveSessionForOrg := func(ctx context.Context, uid, orgID uuid.UUID) (*coreauth.SessionClaims, error) {
-		if orgID == uuid.Nil {
-			return nil, fmt.Errorf("organization is required")
-		}
-		member, err := userRepo.GetOrganizationMember(ctx, uid, orgID)
-		if err != nil {
-			return nil, err
-		}
-		if member == nil {
-			return nil, fmt.Errorf("user is not a member of this organization")
-		}
-		if !member.IsActive {
-			return nil, fmt.Errorf("membership is not active")
-		}
-		sc := &coreauth.SessionClaims{TenantID: orgID, OrgRoles: map[uuid.UUID]string{orgID: string(member.Role)}}
-		// EffectivePermissions unifies the admin wildcard, the business-role preset,
-		// and any legacy profile rules — so a business-role user keeps its
-		// permissions across a token refresh (same path as login).
-		sc.Permissions = member.EffectivePermissions()
-		return sc, nil
+		return resolveSessionClaimsForOrg(ctx, userRepo, uid, orgID)
 	}
-
-	// resolveSession re-derives a user's claims for their DEFAULT organization.
-	// Shared by IssueSession (OAuth2/SAML/MFA) and the PAT middleware, which have
-	// no notion of a chosen org.
 	resolveSession := func(ctx context.Context, uid uuid.UUID) (*coreauth.SessionClaims, error) {
-		org, err := userRepo.GetUserDefaultOrganization(ctx, uid)
-		if err != nil {
-			return nil, err
-		}
-		if org == nil {
-			return nil, fmt.Errorf("user has no organization")
-		}
-		return resolveSessionForOrg(ctx, uid, org.ID)
+		return resolveSessionClaims(ctx, userRepo, uid)
 	}
 	tokenManager.SetSessionResolver(resolveSession)
 	tokenManager.SetOrgSessionResolver(resolveSessionForOrg)

--- a/backend/cmd/server/session_refresh_e2e_test.go
+++ b/backend/cmd/server/session_refresh_e2e_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	coreauth "github.com/opendefender/openrisk/internal/auth"
+	"github.com/opendefender/openrisk/internal/domain"
+	authpkg "github.com/opendefender/openrisk/pkg/auth"
+)
+
+// The acceptance criterion of #350 stated end to end: a blocked or revoked
+// account cannot get a fresh access token out of refresh-token rotation.
+//
+// The unit tests beside this one prove the resolver refuses. This one proves the
+// REAL resolver, wired into a REAL TokenManager exactly as main() wires it,
+// turns that refusal into a refused refresh — and into a revoked family, so the
+// session dies rather than merely stalling for one request.
+
+func newRefreshHarness(t *testing.T, repo sessionAccountReader) (*coreauth.TokenManager, *gorm.DB) {
+	t.Helper()
+
+	dsn := "file:session_refresh_" + uuid.New().String() + "?mode=memory&cache=private"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, db.Exec(`
+		CREATE TABLE refresh_tokens (
+			id TEXT PRIMARY KEY,
+			user_id TEXT NOT NULL,
+			tenant_id TEXT NOT NULL,
+			family_id TEXT NOT NULL,
+			token_hash TEXT NOT NULL UNIQUE,
+			device_fingerprint TEXT,
+			ip_address TEXT,
+			user_agent TEXT,
+			expires_at DATETIME NOT NULL,
+			rotated_at DATETIME,
+			last_used_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`).Error)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tm := coreauth.NewTokenManager(db, &authpkg.RSAKeys{PrivateKey: priv, PublicKey: &priv.PublicKey})
+
+	// Wired exactly as main() wires it — the production resolvers, not a spy.
+	tm.SetOrgSessionResolver(func(ctx context.Context, uid, orgID uuid.UUID) (*coreauth.SessionClaims, error) {
+		return resolveSessionClaimsForOrg(ctx, repo, uid, orgID)
+	})
+	tm.SetSessionResolver(func(ctx context.Context, uid uuid.UUID) (*coreauth.SessionClaims, error) {
+		return resolveSessionClaims(ctx, repo, uid)
+	})
+
+	return tm, db
+}
+
+func countRefreshTokens(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table("refresh_tokens").Where("rotated_at IS NULL").Count(&n).Error)
+	return n
+}
+
+// The control: a live account refreshes normally. Without this, the refusal
+// tests below would pass against a resolver that refused everything.
+func TestRefresh_LiveAccount_Succeeds(t *testing.T) {
+	orgID := uuid.New()
+	repo := &fakeAccountRepo{user: liveUser(), member: liveMember(orgID), defaultOrg: &domain.Organization{ID: orgID}}
+	tm, db := newRefreshHarness(t, repo)
+	ctx := context.Background()
+
+	pair, err := tm.GenerateTokenPair(ctx, uuid.New(), orgID, nil, []string{"*"}, nil, coreauth.DeviceContext{})
+	require.NoError(t, err)
+
+	next, err := tm.RefreshTokenPair(ctx, pair.RefreshToken, coreauth.DeviceContext{})
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	assert.NotEmpty(t, next.AccessToken)
+	assert.Equal(t, int64(1), countRefreshTokens(t, db), "the family lives on, rotated into a new token")
+}
+
+// The issue's headline: blocked / suspended / disabled, and deleted. Each must
+// fail the refresh AND take the family with it.
+func TestRefresh_DeadAccount_RefusedAndFamilyRevoked(t *testing.T) {
+	orgID := uuid.New()
+
+	cases := map[string]func(*fakeAccountRepo){
+		"account disabled after the session was issued": func(r *fakeAccountRepo) {
+			r.user = &domain.User{ID: uuid.New(), IsActive: false}
+		},
+		"account deleted after the session was issued": func(r *fakeAccountRepo) {
+			r.user = nil
+		},
+		"membership revoked after the session was issued": func(r *fakeAccountRepo) {
+			r.member = &domain.OrganizationMember{OrganizationID: orgID, IsActive: false}
+		},
+	}
+
+	for name, kill := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := &fakeAccountRepo{user: liveUser(), member: liveMember(orgID)}
+			tm, db := newRefreshHarness(t, repo)
+			ctx := context.Background()
+
+			// A session that was perfectly legitimate when it was minted.
+			pair, err := tm.GenerateTokenPair(ctx, uuid.New(), orgID, nil, []string{"*"}, nil, coreauth.DeviceContext{})
+			require.NoError(t, err)
+			require.Equal(t, int64(1), countRefreshTokens(t, db))
+
+			// The account or the membership dies.
+			kill(repo)
+
+			next, err := tm.RefreshTokenPair(ctx, pair.RefreshToken, coreauth.DeviceContext{})
+
+			require.Error(t, err, "a dead account must not receive a fresh access token")
+			assert.Nil(t, next, "no token pair may be handed back")
+			assert.Equal(t, int64(0), countRefreshTokens(t, db),
+				"the family is revoked, so the session dies rather than surviving to the next attempt")
+		})
+	}
+}
+
+// IssueSession is the path OAuth, SAML and the MFA challenge take. It resolves
+// through the same code, so a disabled account must be refused there too — this
+// is the half the issue's "password flow / MFA flow" bullets are about.
+func TestIssueSession_DeadAccount_Refused(t *testing.T) {
+	orgID := uuid.New()
+	org := &domain.Organization{ID: orgID}
+
+	t.Run("live account is issued a session", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: liveUser(), member: liveMember(orgID), defaultOrg: org}
+		tm, _ := newRefreshHarness(t, repo)
+
+		pair, err := tm.IssueSession(context.Background(), uuid.New(), coreauth.DeviceContext{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, pair.AccessToken)
+	})
+
+	t.Run("disabled account is refused", func(t *testing.T) {
+		repo := &fakeAccountRepo{
+			user:       &domain.User{ID: uuid.New(), IsActive: false},
+			member:     liveMember(orgID),
+			defaultOrg: org,
+		}
+		tm, _ := newRefreshHarness(t, repo)
+
+		pair, err := tm.IssueSession(context.Background(), uuid.New(), coreauth.DeviceContext{})
+		require.Error(t, err)
+		assert.Nil(t, pair)
+		assert.Contains(t, err.Error(), "account is disabled")
+	})
+
+	t.Run("deleted account is refused", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: nil, member: liveMember(orgID), defaultOrg: org}
+		tm, _ := newRefreshHarness(t, repo)
+
+		pair, err := tm.IssueSession(context.Background(), uuid.New(), coreauth.DeviceContext{})
+		require.Error(t, err)
+		assert.Nil(t, pair)
+		assert.Contains(t, err.Error(), "account no longer exists")
+	})
+}

--- a/backend/cmd/server/session_wiring.go
+++ b/backend/cmd/server/session_wiring.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	coreauth "github.com/opendefender/openrisk/internal/auth"
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// The session resolvers decide what a freshly minted token is allowed to carry.
+//
+// They are the single re-derivation point behind every path that issues a
+// session without a password: refresh-token rotation, OAuth/SAML, the MFA
+// challenge, organization switching, and the personal-access-token middleware.
+// That makes them the one place worth enforcing account state, and the reason
+// they live here as named functions rather than as closures inside main() —
+// security logic that nothing can call in a test is security logic nobody
+// checks (#350).
+
+// sessionAccountReader is the narrow slice of the user repository the resolvers
+// need. Declared as an interface so the resolvers can be driven in a test
+// without a database.
+type sessionAccountReader interface {
+	GetByID(ctx context.Context, id uuid.UUID) (*domain.User, error)
+	GetOrganizationMember(ctx context.Context, userID, orgID uuid.UUID) (*domain.OrganizationMember, error)
+	GetUserDefaultOrganization(ctx context.Context, userID uuid.UUID) (*domain.Organization, error)
+}
+
+// resolveSessionClaimsForOrg re-derives a user's claims for a SPECIFIC
+// organization, refusing when either the account or the membership is no longer
+// live.
+//
+// Both halves matter and they fail independently:
+//
+//   - the ACCOUNT may be disabled or deleted while the membership row survives;
+//   - the MEMBERSHIP may be revoked while the account stays perfectly healthy.
+//
+// Before #350 only the second was checked. `GetOrganizationMember` reads
+// organization_members and never joins users, so nothing on this path consulted
+// the user row at all: /auth/login refused a disabled account
+// (application/auth/login.go, "account is disabled") and refresh did not, which
+// left a deactivated account minting new access tokens from its existing refresh
+// token until that token expired, and left its personal access tokens working
+// indefinitely.
+//
+// Returning an error here is what kills the session: TokenManager.RefreshTokenPair
+// revokes the whole refresh-token family when this resolver fails, so a
+// deactivated account does not merely fail one refresh — it loses the lineage.
+func resolveSessionClaimsForOrg(
+	ctx context.Context,
+	repo sessionAccountReader,
+	uid, orgID uuid.UUID,
+) (*coreauth.SessionClaims, error) {
+	if orgID == uuid.Nil {
+		return nil, fmt.Errorf("organization is required")
+	}
+
+	// Account first: a disabled account must be refused whether or not the
+	// membership row survived, so the answer cannot depend on which of the two
+	// was revoked.
+	user, err := repo.GetByID(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	// Deleted accounts resolve to nil — GORM's soft-delete scope excludes them
+	// from this read — so "deleted" and "never existed" answer identically, which
+	// is the correct answer to both.
+	if user == nil {
+		return nil, fmt.Errorf("account no longer exists")
+	}
+	if !user.IsActive {
+		return nil, fmt.Errorf("account is disabled")
+	}
+
+	member, err := repo.GetOrganizationMember(ctx, uid, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if member == nil {
+		return nil, fmt.Errorf("user is not a member of this organization")
+	}
+	if !member.IsActive {
+		return nil, fmt.Errorf("membership is not active")
+	}
+
+	sc := &coreauth.SessionClaims{
+		TenantID: orgID,
+		OrgRoles: map[uuid.UUID]string{orgID: string(member.Role)},
+	}
+	// EffectivePermissions unifies the admin wildcard, the business-role preset,
+	// and any legacy profile rules — so a business-role user keeps its
+	// permissions across a token refresh (same path as login).
+	sc.Permissions = member.EffectivePermissions()
+	return sc, nil
+}
+
+// resolveSessionClaims re-derives a user's claims for their DEFAULT
+// organization. Shared by IssueSession (OAuth2/SAML/MFA) and the PAT
+// middleware, which have no notion of a chosen org.
+//
+// The account check is inherited rather than repeated: this delegates to
+// resolveSessionClaimsForOrg, so there is exactly one place where a disabled
+// account is refused and no way for the two entry points to disagree.
+func resolveSessionClaims(
+	ctx context.Context,
+	repo sessionAccountReader,
+	uid uuid.UUID,
+) (*coreauth.SessionClaims, error) {
+	org, err := repo.GetUserDefaultOrganization(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	if org == nil {
+		return nil, fmt.Errorf("user has no organization")
+	}
+	return resolveSessionClaimsForOrg(ctx, repo, uid, org.ID)
+}

--- a/backend/cmd/server/session_wiring_test.go
+++ b/backend/cmd/server/session_wiring_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// #350: the session resolvers are the single re-derivation point behind every
+// path that mints a session without a password — refresh rotation, OAuth/SAML,
+// the MFA challenge, org switching, and the PAT middleware. They validated the
+// MEMBERSHIP and never the ACCOUNT, so a deactivated user kept minting access
+// tokens from an existing refresh token until it expired.
+//
+// The issue names five states — blocked, suspended, disabled, deleted, revoked.
+// domain.User has exactly two signals to express them, and these tests are
+// written against what exists rather than against invented states:
+//
+//	IsActive == false   → disabled / blocked / suspended
+//	row absent          → deleted (GORM's soft-delete scope hides it from GetByID)
+//
+// "revoked" is the membership's own IsActive, which was already enforced and is
+// pinned here so the new account check cannot displace it.
+
+type fakeAccountRepo struct {
+	user       *domain.User
+	userErr    error
+	member     *domain.OrganizationMember
+	memberErr  error
+	defaultOrg *domain.Organization
+	orgErr     error
+
+	userCalls   int
+	memberCalls int
+}
+
+func (f *fakeAccountRepo) GetByID(context.Context, uuid.UUID) (*domain.User, error) {
+	f.userCalls++
+	return f.user, f.userErr
+}
+
+func (f *fakeAccountRepo) GetOrganizationMember(context.Context, uuid.UUID, uuid.UUID) (*domain.OrganizationMember, error) {
+	f.memberCalls++
+	return f.member, f.memberErr
+}
+
+func (f *fakeAccountRepo) GetUserDefaultOrganization(context.Context, uuid.UUID) (*domain.Organization, error) {
+	return f.defaultOrg, f.orgErr
+}
+
+func liveUser() *domain.User {
+	return &domain.User{ID: uuid.New(), IsActive: true}
+}
+
+func liveMember(orgID uuid.UUID) *domain.OrganizationMember {
+	return &domain.OrganizationMember{OrganizationID: orgID, IsActive: true, Role: domain.RoleAdmin}
+}
+
+func TestResolveSessionClaimsForOrg_Success(t *testing.T) {
+	orgID := uuid.New()
+	repo := &fakeAccountRepo{user: liveUser(), member: liveMember(orgID)}
+
+	sc, err := resolveSessionClaimsForOrg(context.Background(), repo, uuid.New(), orgID)
+
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, orgID, sc.TenantID)
+	assert.Equal(t, string(domain.RoleAdmin), sc.OrgRoles[orgID])
+	assert.NotEmpty(t, sc.Permissions, "an active admin resolves permissions")
+}
+
+// The issue's list, mapped onto the states that exist. Every one must refuse to
+// produce claims, and must refuse BEFORE the membership is consulted — a
+// disabled account is disabled whether or not its membership row survived.
+func TestResolveSessionClaimsForOrg_RefusesDeadAccounts(t *testing.T) {
+	orgID := uuid.New()
+
+	cases := map[string]struct {
+		repo *fakeAccountRepo
+		want string
+	}{
+		"disabled / blocked / suspended": {
+			repo: &fakeAccountRepo{
+				user:   &domain.User{ID: uuid.New(), IsActive: false},
+				member: liveMember(orgID),
+			},
+			want: "account is disabled",
+		},
+		"deleted — soft-delete hides the row": {
+			repo: &fakeAccountRepo{user: nil, member: liveMember(orgID)},
+			want: "account no longer exists",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sc, err := resolveSessionClaimsForOrg(context.Background(), tc.repo, uuid.New(), orgID)
+
+			require.Error(t, err)
+			assert.Nil(t, sc, "a refused account must not carry claims")
+			assert.Contains(t, err.Error(), tc.want)
+			assert.Equal(t, 0, tc.repo.memberCalls,
+				"the account is checked first; a live membership must not rescue a dead account")
+		})
+	}
+}
+
+// "revoked" in the issue's list is the membership's own state. It was already
+// enforced; this pins it so the new account check cannot displace it.
+func TestResolveSessionClaimsForOrg_RefusesRevokedMembership(t *testing.T) {
+	orgID := uuid.New()
+
+	cases := map[string]struct {
+		member *domain.OrganizationMember
+		want   string
+	}{
+		"membership revoked": {
+			member: &domain.OrganizationMember{OrganizationID: orgID, IsActive: false},
+			want:   "membership is not active",
+		},
+		"never a member": {
+			member: nil,
+			want:   "user is not a member of this organization",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			repo := &fakeAccountRepo{user: liveUser(), member: tc.member}
+
+			sc, err := resolveSessionClaimsForOrg(context.Background(), repo, uuid.New(), orgID)
+
+			require.Error(t, err)
+			assert.Nil(t, sc)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// A read failure must not be mistaken for a healthy account.
+func TestResolveSessionClaimsForOrg_PropagatesLookupErrors(t *testing.T) {
+	orgID := uuid.New()
+	boom := errors.New("database unavailable")
+
+	t.Run("account lookup fails", func(t *testing.T) {
+		repo := &fakeAccountRepo{userErr: boom, member: liveMember(orgID)}
+		sc, err := resolveSessionClaimsForOrg(context.Background(), repo, uuid.New(), orgID)
+		require.ErrorIs(t, err, boom)
+		assert.Nil(t, sc)
+	})
+
+	t.Run("membership lookup fails", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: liveUser(), memberErr: boom}
+		sc, err := resolveSessionClaimsForOrg(context.Background(), repo, uuid.New(), orgID)
+		require.ErrorIs(t, err, boom)
+		assert.Nil(t, sc)
+	})
+}
+
+func TestResolveSessionClaimsForOrg_RequiresAnOrganization(t *testing.T) {
+	repo := &fakeAccountRepo{user: liveUser()}
+
+	sc, err := resolveSessionClaimsForOrg(context.Background(), repo, uuid.New(), uuid.Nil)
+
+	require.Error(t, err)
+	assert.Nil(t, sc)
+	assert.Contains(t, err.Error(), "organization is required")
+	assert.Equal(t, 0, repo.userCalls, "a nil org is rejected before any read")
+}
+
+// The default-org entry point — OAuth/SAML, the MFA challenge and the PAT
+// middleware all arrive here — must inherit the account check, not skip it.
+func TestResolveSessionClaims_DefaultOrg_InheritsTheAccountCheck(t *testing.T) {
+	orgID := uuid.New()
+	org := &domain.Organization{ID: orgID}
+
+	t.Run("live account resolves", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: liveUser(), member: liveMember(orgID), defaultOrg: org}
+		sc, err := resolveSessionClaims(context.Background(), repo, uuid.New())
+		require.NoError(t, err)
+		assert.Equal(t, orgID, sc.TenantID)
+	})
+
+	t.Run("disabled account is refused here too", func(t *testing.T) {
+		repo := &fakeAccountRepo{
+			user:       &domain.User{ID: uuid.New(), IsActive: false},
+			member:     liveMember(orgID),
+			defaultOrg: org,
+		}
+		sc, err := resolveSessionClaims(context.Background(), repo, uuid.New())
+		require.Error(t, err)
+		assert.Nil(t, sc)
+		assert.Contains(t, err.Error(), "account is disabled")
+	})
+
+	t.Run("deleted account is refused here too", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: nil, member: liveMember(orgID), defaultOrg: org}
+		sc, err := resolveSessionClaims(context.Background(), repo, uuid.New())
+		require.Error(t, err)
+		assert.Nil(t, sc)
+		assert.Contains(t, err.Error(), "account no longer exists")
+	})
+
+	t.Run("no default organization", func(t *testing.T) {
+		repo := &fakeAccountRepo{user: liveUser(), defaultOrg: nil}
+		sc, err := resolveSessionClaims(context.Background(), repo, uuid.New())
+		require.Error(t, err)
+		assert.Nil(t, sc)
+		assert.Contains(t, err.Error(), "user has no organization")
+	})
+}


### PR DESCRIPTION
Closes #350

## What was wrong

`GetOrganizationMember` (`gorm_user_repository.go:130-142`) queries only the
`organization_members` table — it never joins `users`. So `resolveSessionForOrg` validated the
**membership** and never the **account**.

`/auth/login` does check (`application/auth/login.go:167`, `if !user.IsActive` → "account is
disabled"). Refresh did not. Deactivate an account and its existing refresh token kept minting
new access tokens until that token expired. A soft-deleted account was missed the same way, since
`users.deleted_at` was never read.

**It was wider than `/auth/refresh`.** The same resolvers back `IssueSession` — OAuth, SAML and
the MFA challenge — and, per `main.go:750-751`, the Personal Access Token middleware. A
deactivated user's PAT kept working indefinitely.

## The fix

The check goes in the resolver, the single re-derivation point behind every path that mints a
session without a password, so one change closes refresh, OAuth/SAML, the MFA challenge, org
switching and PATs together.

Two supporting decisions worth calling out:

- **Account is checked *before* membership.** A disabled account must be refused whether or not
  its membership row survived, so the answer cannot depend on which of the two was revoked. The
  tests assert the membership is never even read for a dead account.
- **Returning an error kills the lineage, not just the request.** `RefreshTokenPair` already
  revokes the whole refresh-token family when the resolver fails (`token.go:337-341`), so this
  behaviour came free and consistent with how removed-membership was already handled.

Both resolvers moved out of `main()` into **`cmd/server/session_wiring.go`** as named functions,
following the `*_wiring.go` convention already in that directory. They were closures inside a
1000-line `main()`, which meant nothing could call them from a test — security logic that nothing
can call in a test is security logic nobody checks.

## On the five states the issue names

`domain.User` has no blocked/suspended/revoked enum. It has exactly two signals, and I implemented
against what exists rather than inventing states:

| Issue's word | Real signal |
|---|---|
| blocked · suspended · disabled | `User.IsActive == false` |
| deleted | row absent — GORM's soft-delete scope hides it from `GetByID` |
| revoked | `OrganizationMember.IsActive == false` — already enforced, now pinned by a test |

If you want genuinely distinct states (a suspension with an end date, a block with a reason),
that is a schema change and a different issue. Say the word and I will open it.

## Verification

```
$ go test ./cmd/server/ -v          # 25 assertions, abridged
--- PASS: TestResolveSessionClaimsForOrg_Success
--- PASS: TestResolveSessionClaimsForOrg_RefusesDeadAccounts/disabled_/_blocked_/_suspended
--- PASS: TestResolveSessionClaimsForOrg_RefusesDeadAccounts/deleted_—_soft-delete_hides_the_row
--- PASS: TestResolveSessionClaimsForOrg_RefusesRevokedMembership/membership_revoked
--- PASS: TestResolveSessionClaimsForOrg_RefusesRevokedMembership/never_a_member
--- PASS: TestResolveSessionClaimsForOrg_PropagatesLookupErrors/account_lookup_fails
--- PASS: TestResolveSessionClaimsForOrg_PropagatesLookupErrors/membership_lookup_fails
--- PASS: TestResolveSessionClaimsForOrg_RequiresAnOrganization
--- PASS: TestResolveSessionClaims_DefaultOrg_InheritsTheAccountCheck/*  (4)
--- PASS: TestRefresh_LiveAccount_Succeeds
--- PASS: TestRefresh_DeadAccount_RefusedAndFamilyRevoked/account_disabled_after_the_session_was_issued
--- PASS: TestRefresh_DeadAccount_RefusedAndFamilyRevoked/account_deleted_after_the_session_was_issued
--- PASS: TestRefresh_DeadAccount_RefusedAndFamilyRevoked/membership_revoked_after_the_session_was_issued
--- PASS: TestIssueSession_DeadAccount_Refused/*  (3)

$ go test ./internal/auth/... ./internal/handler/auth/... ./cmd/server/...
ok  	github.com/opendefender/openrisk/internal/auth	1.047s
ok  	github.com/opendefender/openrisk/internal/handler/auth	1.129s
ok  	github.com/opendefender/openrisk/cmd/server	0.474s
```

`go build ./...` clean · `go vet` clean · `gofmt -l` empty.

`TestRefresh_DeadAccount_RefusedAndFamilyRevoked` is the acceptance criterion end to end: it
drives the **real** resolvers through a **real** `TokenManager` wired exactly as `main()` wires
it, mints a legitimate session, then kills the account and asserts both that no pair comes back
and that `refresh_tokens` is empty.

### Proved non-vacuous

Removing the account check and re-running:

```
--- FAIL: TestRefresh_DeadAccount_RefusedAndFamilyRevoked/account_disabled_after_the_session_was_issued
--- FAIL: TestRefresh_DeadAccount_RefusedAndFamilyRevoked/account_deleted_after_the_session_was_issued
--- FAIL: TestIssueSession_DeadAccount_Refused/disabled_account_is_refused
--- FAIL: TestIssueSession_DeadAccount_Refused/deleted_account_is_refused
--- FAIL: TestResolveSessionClaimsForOrg_RefusesDeadAccounts/disabled_/_blocked_/_suspended
--- FAIL: TestResolveSessionClaimsForOrg_RefusesDeadAccounts/deleted_—_soft-delete_hides_the_row
```

Exactly the account cases fail, on all three surfaces. The controls — `TestRefresh_LiveAccount_Succeeds`,
the `membership_revoked` case, `live_account_is_issued_a_session` — keep passing, so the suite is
not simply failing everything. Restored from a backup and re-verified green.

## Honest remainders

- **Existing sessions are not killed at the moment of deactivation.** A disabled account keeps its
  *current* access token until it expires; it just cannot obtain another. Closing that window
  means revoking refresh families when an account is deactivated, which touches the deactivation
  flow and is a behavioural change beyond this issue. Worth its own issue if you want it.
- **The issue asked for tests covering "password flow" and "MFA flow".** Login already refused a
  disabled account before this PR and I did not add a test for it; the MFA challenge is covered
  through `IssueSession`, which is the code it actually calls. I am not claiming coverage I did
  not write.
- **The resolvers now live in `cmd/server`, not the application layer.** That is where they were,
  and moving them into `internal/application/auth` would be the architecturally cleaner home — but
  it is a refactor with its own review surface and this is a P0. The extraction to named functions
  is the minimum that made them testable.
- **No integration test runs against PostgreSQL.** These use in-memory SQLite, the house pattern.
  The behaviour under test is Go control flow, not SQL semantics.
