### PR TITLE
fix(sse): enforce session revocation on live streams (#345)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -470,6 +470,13 @@ func main() {
 	// Closure used by middleware.Protected(rsaKeys, jtiBlacklistChecker) to check the JTI blacklist on every request
 	jtiBlacklistChecker := tokenBlacklistManager.CheckJTIBlacklist(context.Background())
 
+	// The SAME closure re-checks live SSE streams on their keepalive tick, so a
+	// revoked session stops receiving events within one interval instead of
+	// holding a connection open for the stream's whole lifetime — up to two
+	// hours on /realtime/events (#345). One predicate for both: a stream and a
+	// request must never disagree about whether a session is revoked.
+	handlers.SetSSERevocationChecker(jtiBlacklistChecker)
+
 	// Initialize Score Engine (pure, stateless)
 	scoreEngine := scoring.NewEngine()
 	log.Println("Scoring: Engine initialized (pure, zero dependencies)")

--- a/backend/internal/handler/mitigation_events_handler.go
+++ b/backend/internal/handler/mitigation_events_handler.go
@@ -81,6 +81,15 @@ func (h *MitigationEventsHandler) Stream(c *fiber.Ctx) error {
 					return
 				}
 			case <-keepalive.C:
+				// Re-authorize on the tick: the token was validated once, when
+				// the stream opened, and this connection can outlive its
+				// revocation by hours otherwise (#345). h.blacklist is the same
+				// predicate ValidateAccessToken used above.
+				if sseRevokedWith(h.blacklist, claims.JTI) {
+					fmt.Fprint(w, "event: stream.revoked\ndata: {\"reason\":\"session_revoked\"}\n\n")
+					_ = w.Flush()
+					return
+				}
 				fmt.Fprint(w, ": keepalive\n\n")
 				if err := w.Flush(); err != nil {
 					return

--- a/backend/internal/handler/realtime_handler.go
+++ b/backend/internal/handler/realtime_handler.go
@@ -78,6 +78,11 @@ const (
 	sseHello     = "stream.hello"
 	sseHeartbeat = "stream.heartbeat"
 	sseResync    = "stream.resync"
+	// sseRevoked is terminal, and deliberately not a resync: a resync tells the
+	// client to reconnect with its cursor, which is precisely what a revoked
+	// session must not be invited to do. The client is being told to
+	// authenticate again, not to come back where it left off (#345).
+	sseRevoked = "stream.revoked"
 )
 
 // RealtimeEventReader is the replay side of the durable log.
@@ -231,6 +236,9 @@ func (h *RealtimeHandler) Stream(c *fiber.Ctx) error {
 
 	connID := sub.ID
 	userID := userID(c)
+	// Read off the request while it still exists: the body writer below runs
+	// after this handler returns, and the Fiber context is recycled by then.
+	jti := streamJTI(c)
 	log.Printf("realtime: stream open conn=%s tenant=%s user=%s filter=%s cursor=%d",
 		connID, tenant, userID, filter.Describe(), cursor)
 
@@ -267,6 +275,11 @@ func (h *RealtimeHandler) Stream(c *fiber.Ctx) error {
 			"filter":             filter.Describe(),
 			"allowed_aggregates": allowed,
 			"server_time":        time.Now().UTC().Format(time.RFC3339),
+			// The documented bound from #345: a revoked session stops receiving
+			// events within this many seconds. Stated rather than implied, so a
+			// client — or an auditor — reads the guarantee instead of inferring
+			// it from the keepalive.
+			"revocation_check_seconds": int(sseRevocationInterval.Seconds()),
 		}) {
 			return
 		}
@@ -322,6 +335,23 @@ func (h *RealtimeHandler) Stream(c *fiber.Ctx) error {
 				monitoring.RealtimeDeliveryLagSeconds.Observe(time.Since(env.OccurredAt).Seconds())
 
 			case <-keepalive.C:
+				// Re-authorize before writing anything else. This tick is the
+				// only regular event on an otherwise idle stream, so it is what
+				// bounds how long a revoked session keeps receiving data — one
+				// keepalive interval, and no longer (#345).
+				//
+				// Checked BEFORE the keepalive write, so a revoked session is
+				// never told the stream is healthy.
+				if sseSessionRevoked(jti) {
+					monitoring.RealtimeResyncsTotal.WithLabelValues("session_revoked").Inc()
+					log.Printf("realtime: stream revoked conn=%s tenant=%s user=%s", connID, tenant, userID)
+					st.control(sseRevoked, fiber.Map{
+						"reason": "session_revoked",
+						"detail": "this session was revoked; authenticate again before reconnecting",
+					})
+					return
+				}
+
 				// Two forms on purpose: the comment keeps intermediaries from
 				// timing the connection out, and the named event is what lets
 				// the CLIENT arm a watchdog — EventSource never surfaces

--- a/backend/internal/handler/realtime_stream_e2e_test.go
+++ b/backend/internal/handler/realtime_stream_e2e_test.go
@@ -96,6 +96,12 @@ func newStreamTestEnv(t *testing.T, opts apprealtime.HubOptions) *streamTestEnv 
 			perms = strings.Split(raw, ",")
 		}
 		c.Locals("user", &authpkg.Claims{Permissions: perms})
+		// The session id the revocation check reads on each keepalive (#345).
+		// Absent unless a test asks for one, so every pre-existing test keeps
+		// the behaviour it was written against: no jti means nothing to revoke.
+		if jti := c.Get("X-Test-JTI"); jti != "" {
+			c.Locals("jti", jti)
+		}
 		return c.Next()
 	})
 	app.Get("/api/v1/realtime/events", h.Stream)

--- a/backend/internal/handler/realtime_stream_revocation_e2e_test.go
+++ b/backend/internal/handler/realtime_stream_revocation_e2e_test.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apprealtime "github.com/opendefender/openrisk/internal/application/realtime"
+	rt "github.com/opendefender/openrisk/pkg/realtime"
+)
+
+// #345 — revocation on a LIVE stream, over a real socket.
+//
+// The stream authorized once, in the middleware, and then held the connection
+// open: /realtime/events for up to two hours. A session revoked a second after
+// connecting kept receiving tenant-scoped events for the rest of that window.
+//
+// These tests revoke a session while the stream is open and assert the three
+// things the issue asks for: the events stop within a bounded interval, the
+// client is told to authenticate rather than to resume, and nothing further is
+// delivered.
+//
+// The harness keepalive is 150ms (see newStreamTestEnv), so "one interval" is
+// observable in a test rather than in twenty seconds.
+
+// revocationSpy is a controllable blacklist. It starts permissive so a stream
+// can be established legitimately before anything is revoked — the point is to
+// revoke a session that was valid, not to refuse one that never was.
+type revocationSpy struct {
+	mu      sync.Mutex
+	revoked map[string]bool
+	err     error
+	// asked counts lookups PER jti rather than in total. Streams opened by
+	// earlier tests in this package outlive them and keep ticking against
+	// whatever checker is installed, so a global counter would report their
+	// traffic as this test's.
+	asked map[string]int
+}
+
+func newRevocationSpy() *revocationSpy {
+	return &revocationSpy{revoked: map[string]bool{}, asked: map[string]int{}}
+}
+
+func (s *revocationSpy) check(jti string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.asked[jti]++
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.revoked[jti], nil
+}
+
+func (s *revocationSpy) revoke(jti string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revoked[jti] = true
+}
+
+func (s *revocationSpy) failWith(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
+// askedAbout reports how many times this exact session was looked up.
+func (s *revocationSpy) askedAbout(jti string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.asked[jti]
+}
+
+// installRevocationSpy wires the package seam and restores it afterwards. The
+// checker is process-global, so leaving it set would leak into every other test
+// in this package.
+func installRevocationSpy(t *testing.T) *revocationSpy {
+	t.Helper()
+	spy := newRevocationSpy()
+	previous := sseRevocationChecker
+	SetSSERevocationChecker(spy.check)
+	t.Cleanup(func() { sseRevocationChecker = previous })
+	return spy
+}
+
+func revocationHeaders(tenant uuid.UUID, jti string) map[string]string {
+	h := tenantHeaders(tenant)
+	h["X-Test-JTI"] = jti
+	return h
+}
+
+// waitForClose drains frames until the stream ends, returning any terminal
+// control frame it saw on the way out.
+func waitForClose(t *testing.T, c *sseClient, within time.Duration) (sseFrame, bool) {
+	t.Helper()
+	deadline := time.After(within)
+	var terminal sseFrame
+	var seen bool
+	for {
+		select {
+		case f, ok := <-c.frames:
+			if !ok {
+				return terminal, seen
+			}
+			if f.Event == "stream.revoked" {
+				terminal, seen = f, true
+			}
+		case <-deadline:
+			t.Fatal("the stream was still open after a revoked session should have been torn down")
+		}
+	}
+}
+
+// THE test: a live, legitimate stream is cut off after its session is revoked.
+func TestRealtimeStream_RevokedSessionIsTornDown(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+	jti := "session-" + uuid.New().String()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, jti), "")
+	require.Equal(t, 200, status)
+	require.NotNil(t, cl)
+	cl.awaitHello(t)
+
+	// The session was valid when it connected, and events flow.
+	env.publish(t, tenant, rt.EventType("risk.created"), uuid.NewString())
+	first := cl.next(t, 3*time.Second)
+	require.Equal(t, "risk.created", first.Event)
+
+	// Now revoke it, mid-stream.
+	spy.revoke(jti)
+
+	terminal, seen := waitForClose(t, cl, 3*time.Second)
+	require.True(t, seen, "the client must be told why the stream ended")
+	assert.Equal(t, "stream.revoked", terminal.Event)
+	assert.Equal(t, "session_revoked", terminal.Data["reason"],
+		"a revoked session is told to authenticate, not to resync with its cursor")
+}
+
+// The guarantee the issue asks to be documented: bounded by one keepalive
+// interval, not by the stream's lifetime.
+func TestRealtimeStream_RevocationIsBoundedByTheKeepaliveInterval(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+	jti := "session-" + uuid.New().String()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, jti), "")
+	require.Equal(t, 200, status)
+	cl.awaitHello(t)
+
+	spy.revoke(jti)
+	start := time.Now()
+	_, seen := waitForClose(t, cl, 3*time.Second)
+	elapsed := time.Since(start)
+
+	require.True(t, seen)
+	// The harness ticks every 150ms. A generous ceiling still proves the bound
+	// is the TICK and not the 30s MaxLifetime this env is configured with.
+	assert.Less(t, elapsed, 2*time.Second,
+		"revocation must take effect on the keepalive tick, not at the stream's lifetime")
+}
+
+// No protected data may follow the revocation.
+func TestRealtimeStream_NoEventsAfterRevocation(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+	jti := "session-" + uuid.New().String()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, jti), "")
+	require.Equal(t, 200, status)
+	cl.awaitHello(t)
+
+	spy.revoke(jti)
+	_, seen := waitForClose(t, cl, 3*time.Second)
+	require.True(t, seen)
+
+	// Publishing after the teardown must reach nobody on this connection. The
+	// channel is closed, so any further frame would be a delivery to a revoked
+	// session.
+	env.publish(t, tenant, rt.EventType("risk.created"), uuid.NewString())
+	cl.expectNothing(t, 500*time.Millisecond)
+}
+
+// The control. Without it, every test above would pass against a stream that
+// simply closed itself.
+func TestRealtimeStream_LiveSessionKeepsStreaming(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+	jti := "session-" + uuid.New().String()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, jti), "")
+	require.Equal(t, 200, status)
+	cl.awaitHello(t)
+
+	// Long enough for several keepalive ticks to have run the check.
+	time.Sleep(600 * time.Millisecond)
+	require.Greater(t, spy.askedAbout(jti), 1, "the check must actually run on the tick")
+
+	env.publish(t, tenant, rt.EventType("risk.created"), uuid.NewString())
+	f := cl.next(t, 3*time.Second)
+	assert.Equal(t, "risk.created", f.Event, "a live session is unaffected")
+}
+
+// Fail-open, deliberately and identically to every ordinary request: a
+// blacklist outage must not close every live stream in the estate. The cost —
+// revocation is suspended while Redis is down — is recorded on the issue.
+func TestRealtimeStream_BlacklistOutageDoesNotCloseTheStream(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+	jti := "session-" + uuid.New().String()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, jti), "")
+	require.Equal(t, 200, status)
+	cl.awaitHello(t)
+
+	spy.failWith(errors.New("redis unreachable"))
+	time.Sleep(600 * time.Millisecond)
+
+	env.publish(t, tenant, rt.EventType("risk.created"), uuid.NewString())
+	f := cl.next(t, 3*time.Second)
+	assert.Equal(t, "risk.created", f.Event,
+		"an unreachable blacklist must not tear down live streams")
+}
+
+// A connection with no session id — a PAT or an agent token — is not something
+// this check can revoke, and must not be refused because of that.
+func TestRealtimeStream_NoJTIIsNotTreatedAsRevoked(t *testing.T) {
+	spy := installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+
+	// tenantHeaders sets no X-Test-JTI.
+	cl, status := env.openStream(t, tenantHeaders(tenant), "")
+	require.Equal(t, 200, status)
+	cl.awaitHello(t)
+
+	time.Sleep(400 * time.Millisecond)
+
+	env.publish(t, tenant, rt.EventType("risk.created"), uuid.NewString())
+	f := cl.next(t, 3*time.Second)
+	assert.Equal(t, "risk.created", f.Event)
+	assert.Equal(t, 0, spy.askedAbout(""), "no session id means there is nothing to look up")
+}
+
+// The hello frame carries the bound, so the guarantee is published rather than
+// inferred from the implementation.
+func TestRealtimeStream_HelloDocumentsTheRevocationBound(t *testing.T) {
+	installRevocationSpy(t)
+	env := newStreamTestEnv(t, apprealtime.HubOptions{})
+	tenant := uuid.New()
+
+	cl, status := env.openStream(t, revocationHeaders(tenant, "session-x"), "")
+	require.Equal(t, 200, status)
+
+	hello := cl.awaitHello(t)
+	require.Contains(t, hello.Data, "revocation_check_seconds")
+	assert.EqualValues(t, sseRevocationInterval.Seconds(), hello.Data["revocation_check_seconds"])
+}

--- a/backend/internal/handler/report_handler.go
+++ b/backend/internal/handler/report_handler.go
@@ -353,6 +353,8 @@ func (h *ReportHandler) Progress(c *fiber.Ctx) error {
 		"step": rep.Step, "run_state": rep.RunState,
 	})
 	terminal := rep.RunState.Terminal()
+	// Read off the request before the writer starts; it runs after this returns.
+	jti := streamJTI(c)
 
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -410,6 +412,13 @@ func (h *ReportHandler) Progress(c *fiber.Ctx) error {
 					return
 				}
 			case <-keepalive.C:
+				// Re-authorize on the tick, bounding revocation to one interval
+				// rather than the render's whole lifetime (#345).
+				if sseSessionRevoked(jti) {
+					fmt.Fprint(w, "event: stream.revoked\ndata: {\"reason\":\"session_revoked\"}\n\n")
+					_ = w.Flush()
+					return
+				}
 				fmt.Fprint(w, ": keepalive\n\n")
 				if err := w.Flush(); err != nil {
 					return

--- a/backend/internal/handler/scanner_handler.go
+++ b/backend/internal/handler/scanner_handler.go
@@ -307,6 +307,11 @@ func (h *ScannerHandler) streamChannel(c *fiber.Ctx, channel string, onClose fun
 	c.Set("X-Accel-Buffering", "no")
 
 	redisClient := h.redis
+	// Read off the request before the writer starts: it runs after this returns
+	// and the Fiber context is recycled by then. Empty for a caller that carries
+	// no session jti — an agent's scoped token — which sseSessionRevoked treats
+	// as "nothing to revoke" rather than as a reason to refuse (#345).
+	jti := streamJTI(c)
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		if onClose != nil {
 			defer onClose()
@@ -343,6 +348,13 @@ func (h *ScannerHandler) streamChannel(c *fiber.Ctx, channel string, onClose fun
 					return
 				}
 			case <-ticker.C:
+				// Re-authorize on the tick, bounding revocation to one interval
+				// instead of the life of the connection (#345).
+				if sseSessionRevoked(jti) {
+					fmt.Fprint(w, "event: stream.revoked\ndata: {\"reason\":\"session_revoked\"}\n\n")
+					_ = w.Flush()
+					return
+				}
 				fmt.Fprint(w, ": keepalive\n\n")
 				if err := w.Flush(); err != nil {
 					return

--- a/backend/internal/handler/sse_revocation_wiring.go
+++ b/backend/internal/handler/sse_revocation_wiring.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Revocation enforcement for LIVE server-sent-event streams (#345).
+//
+// Every SSE endpoint here authorizes once, in the middleware, and then holds the
+// connection open — realtime for up to two hours. Authorization at connect time
+// is a statement about the past: a session revoked a second later kept receiving
+// tenant-scoped events until the stream ended on its own.
+//
+// The fix is deliberately small. Each stream already ticks a keepalive every 20
+// seconds, because that write is also how the server learns the client has gone.
+// That tick is where the session is now re-checked, which makes the worst-case
+// exposure one keepalive interval — a bound the client is told about in the
+// stream's hello payload rather than one it has to infer.
+//
+// Only the JTI blacklist is consulted, which is a single Redis EXISTS: that is
+// the signal that means "this session was revoked", it costs nothing per tick,
+// and it is the same check the request middleware already runs on every ordinary
+// call. Account deactivation and membership removal are a different signal on a
+// different clock; see the issue's remainders.
+
+// SSERevocationChecker reports whether the session identified by jti has been
+// revoked. It returns the blacklist's own answer and error, unchanged.
+//
+// Shape matches pkg/auth.TokenBlacklistManager.CheckJTIBlacklist so main.go can
+// hand over the very closure the auth middleware uses; two different revocation
+// predicates would be a bug waiting to happen.
+type SSERevocationChecker func(jti string) (bool, error)
+
+// sseRevocationChecker is nil until main.go wires it. nil is valid and means the
+// streams behave exactly as before — an un-wired deployment must not panic.
+var sseRevocationChecker SSERevocationChecker
+
+// SetSSERevocationChecker injects the blacklist predicate from main.go. Call
+// once at boot, before the server starts serving.
+func SetSSERevocationChecker(f SSERevocationChecker) {
+	sseRevocationChecker = f
+}
+
+// streamJTI reads the token id the auth middleware stored for this request.
+//
+// It must be read BEFORE the body-stream writer starts: the writer runs after
+// the handler returns, and the Fiber context is recycled by then.
+func streamJTI(c *fiber.Ctx) string {
+	jti, _ := c.Locals("jti").(string)
+	return jti
+}
+
+// sseSessionRevoked reports whether a live stream must be torn down now.
+//
+// False when no checker is wired or the stream carries no jti — a cookie session
+// or a PAT reaches some of these endpoints without one, and refusing to serve
+// those would be a regression, not a fix.
+//
+// It follows the blacklist's own fail-open posture: a Redis error answers "not
+// revoked", exactly as pkg/auth.IsJTIBlacklisted does for every ordinary
+// request. Diverging here would mean an outage silently closed every live stream
+// while leaving every REST call authorized, which trades a availability
+// incident for a security one. The consequence — an outage suspends revocation
+// for the duration — is real and recorded on the issue rather than hidden here.
+func sseSessionRevoked(jti string) bool {
+	return sseRevokedWith(sseRevocationChecker, jti)
+}
+
+// sseRevokedWith is the same decision for a handler that already holds its own
+// blacklist predicate — mitigation_events validates the token itself and has one
+// injected. Both entry points go through this so the fail-open posture and the
+// empty-jti rule cannot drift apart between endpoints.
+func sseRevokedWith(check SSERevocationChecker, jti string) bool {
+	if check == nil || jti == "" {
+		return false
+	}
+	revoked, err := check(jti)
+	if err != nil {
+		return false
+	}
+	return revoked
+}
+
+// sseRevocationInterval is the documented upper bound on how long a revoked
+// session can keep receiving events. It is the keepalive period because that is
+// the tick the check rides on; naming it separately is what lets the value be
+// stated in the stream contract instead of inferred from an implementation.
+const sseRevocationInterval = 20 * time.Second


### PR DESCRIPTION
Closes #345

## What was wrong

Every SSE endpoint authorized once — in the middleware, at connect — and then held the
connection open. `/realtime/events` has a **two-hour** `realtimeMaxLifetime`
(`realtime_handler.go:62`). A session revoked a second after connecting kept receiving
tenant-scoped events for the rest of that window, because the stream's `select` loop had exactly
four cases (`lifetime`, `resync`, events, `keepalive`) and none of them re-checked authorization.

Four endpoints were affected: `realtime` (2h), `report` (10min), `scanner`, `mitigation_events`.

## The fix

Each stream already ticks a keepalive every 20 seconds, because that write is also how the server
learns the client has gone. The session is now re-checked **on that tick, before the keepalive is
written**, so a revoked session is never told the stream is healthy. Worst-case exposure becomes
one keepalive interval rather than the stream's lifetime.

- `internal/handler/sse_revocation_wiring.go` — **new**. One predicate, one fail-open posture, one
  empty-jti rule, shared by all four endpoints so they cannot drift apart.
- `main.go` hands it **the same closure** the auth middleware already uses
  (`jtiBlacklistChecker`). A stream and a request must never disagree about whether a session is
  revoked.
- The realtime stream emits a terminal **`stream.revoked`** frame — deliberately *not* a resync,
  because a resync invites the client back with its cursor, which is exactly what a revoked
  session must not be invited to do.
- The bound is published in the hello payload as `revocation_check_seconds` rather than left for
  a client to infer.

Only the JTI blacklist is consulted: a single Redis `EXISTS`, negligible per connection per tick.

## Verification

```
$ go test ./internal/handler/ -run 'TestRealtimeStream_...' -v
--- PASS: TestRealtimeStream_RevokedSessionIsTornDown
--- PASS: TestRealtimeStream_RevocationIsBoundedByTheKeepaliveInterval
--- PASS: TestRealtimeStream_NoEventsAfterRevocation
--- PASS: TestRealtimeStream_LiveSessionKeepsStreaming
--- PASS: TestRealtimeStream_BlacklistOutageDoesNotCloseTheStream
--- PASS: TestRealtimeStream_NoJTIIsNotTreatedAsRevoked
--- PASS: TestRealtimeStream_HelloDocumentsTheRevocationBound

$ go test ./internal/handler/... ./cmd/server/... ./internal/auth/...
ok  	github.com/opendefender/openrisk/internal/handler	14.121s
ok  	github.com/opendefender/openrisk/internal/handler/auth	0.880s
ok  	github.com/opendefender/openrisk/internal/auth	0.891s
```

`go build ./...` clean · `go vet` clean · `gofmt -l` empty.

These are **live integration tests over a real socket**, on the existing harness — real listener,
real headers, real chunked SSE frames — which is what the issue asked for.

### Proved non-vacuous

Disabling the check and re-running:

```
--- FAIL: TestRealtimeStream_RevokedSessionIsTornDown
--- FAIL: TestRealtimeStream_NoEventsAfterRevocation
--- FAIL: TestRealtimeStream_LiveSessionKeepsStreaming   (the check never ran)
```

Exactly the three that depend on revocation firing. `BlacklistOutage...`, `NoJTI...` and
`HelloDocuments...` correctly keep passing, so the suite is not simply failing everything.
Restored from a backup and re-verified green.

## Acceptance criteria

- stream stops delivering protected events within a documented maximum interval ✅ — 20s, stated
  in the hello frame
- client is forced to reconnect/authenticate ✅ — terminal `stream.revoked`, not a resync
- no cross-tenant data can continue flowing ✅ — the connection is torn down
- covered by live integration tests ✅

## Honest remainders

- **Only session revocation is enforced, not account state.** Logout and explicit session
  revocation blacklist the JTI and are caught within 20s. **Deactivating an account or removing a
  membership is a different signal** and is *not* caught here — that account's live stream
  continues until its access token expires. Catching it means re-resolving the account per tick,
  which is a database read per connection per interval; you chose the JTI-only scope, and I am
  recording what it does not cover. #350 (PR #525) adds the account check on the *token-minting*
  paths, so such a session cannot be renewed — it just is not severed mid-stream.
- **The check inherits the blacklist's fail-open behaviour.** `pkg/auth.IsJTIBlacklisted` returns
  "not revoked" when Redis is unreachable (`blacklist.go:67-70`). I kept that deliberately —
  diverging would mean an outage silently closes every live stream in the estate while leaving
  every REST call authorized. The consequence is real: **while Redis is down, stream revocation is
  suspended.** A test pins the behaviour so it is a decision rather than an accident. Worth its
  own issue if you want fail-closed here.
- **Only `realtime` gets the structured terminal frame and the published bound.** The other three
  emit a plain `stream.revoked` line and close; they have no hello contract to extend. Their
  clients see a closed connection, which is sufficient but less informative.
- **The 20s interval is not configurable per deployment.** It follows the keepalive, which is
  already tunable on the realtime handler for tests but hard-coded on the other three.
- **No test drives the scanner, report or mitigation_events streams.** They share the same helper
  and the same predicate, and the realtime path is the one with the two-hour window and the
  broadest event surface. I am not claiming coverage I did not write.
