### PR TITLE
feat(cache): real tenant-safe response caching, replacing the passthrough (#337)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1060,6 +1060,12 @@ func main() {
 	api.Use(middleware.PATMiddleware(patService, resolveSession))
 	protected := api.Use(middleware.Protected(rsaKeys, jtiBlacklistChecker))
 
+	// Response-cache invalidation (#337). Mounted here, right after the gate that
+	// resolves the tenant, so every authenticated write drops that tenant's
+	// cached responses. One place rather than a hook in each handler: the next
+	// handler somebody adds cannot forget it. No-op without Redis.
+	protected.Use(handlers.InvalidateCacheOnMutation(cacheableHandlers.Decoration()))
+
 	// Per-tenant quota (audit finding F-03), mounted immediately after the auth
 	// gate because that is what populates the tenant local. Without this a single
 	// tenant — runaway integration or compromised token — can exhaust shared DB

--- a/backend/internal/handler/cache_integration.go
+++ b/backend/internal/handler/cache_integration.go
@@ -60,6 +60,17 @@ func NewCacheableHandlers(cacheInstance *cache.Cache) *CacheableHandlers {
 	}
 }
 
+// Decoration exposes the underlying cache decoration so main.go can mount the
+// invalidation middleware with the same instance the wrappers use. Nil-safe: a
+// deployment without Redis gets a nil decoration, and every method on it is a
+// no-op.
+func (ch *CacheableHandlers) Decoration() *cache.CacheDecoration {
+	if ch == nil {
+		return nil
+	}
+	return ch.decoration
+}
+
 // SetCacheConfig updates cache TTL configuration
 func (ch *CacheableHandlers) SetCacheConfig(cfg CacheConfig) {
 	if ch == nil {

--- a/backend/internal/handler/cache_invalidation.go
+++ b/backend/internal/handler/cache_invalidation.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/opendefender/openrisk/internal/middleware"
+	"github.com/opendefender/openrisk/pkg/cache"
+)
+
+// InvalidateCacheOnMutation drops the caller's cached responses after any write
+// that succeeded (#337).
+//
+// Mounted once, on the authenticated group, rather than called from each
+// handler. That is the whole point: the acceptance criterion is "resource
+// mutations invalidate dependent responses", and a per-handler hook satisfies it
+// exactly until somebody adds the next handler without one. A GRC product that
+// shows an auditor a figure from before the last change has a worse problem than
+// a cache that refills.
+//
+// The cost of the coarseness is one tenant re-computing at most five cached
+// responses after each of its own writes. The cost of the precise version is a
+// stale compliance number nobody can explain.
+//
+// Runs AFTER the handler and only on a 2xx: a rejected write changed nothing,
+// and evicting on a 403 would let an unauthorised caller flush a tenant's cache
+// at will.
+func InvalidateCacheOnMutation(decoration *cache.CacheDecoration) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if err := c.Next(); err != nil {
+			return err
+		}
+
+		switch c.Method() {
+		case fiber.MethodPost, fiber.MethodPut, fiber.MethodPatch, fiber.MethodDelete:
+		default:
+			return nil
+		}
+
+		if status := c.Response().StatusCode(); status < 200 || status > 299 {
+			return nil
+		}
+
+		ctx := middleware.GetContext(c)
+		if ctx == nil || ctx.OrganizationID.String() == "" {
+			return nil
+		}
+
+		// Best-effort, like the write itself: the mutation has already been
+		// committed and acknowledged, so a failed eviction must not turn a
+		// successful write into an error the client sees. The entry expires on
+		// its TTL regardless.
+		_ = decoration.InvalidateTenant(c.UserContext(), ctx.OrganizationID.String(), "mutation")
+		return nil
+	}
+}

--- a/backend/internal/handler/cache_invalidation_test.go
+++ b/backend/internal/handler/cache_invalidation_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendefender/openrisk/internal/middleware"
+	"github.com/opendefender/openrisk/pkg/cache"
+)
+
+// #337 — a write must drop the writer's cached responses, and only theirs.
+//
+// The middleware is mounted once on the authenticated group rather than called
+// from each handler, so these tests assert the behaviour that arrangement is
+// supposed to buy: it fires for any mutation, on any route, without the handler
+// knowing it exists.
+
+// patternStore records the DeletePattern calls so a test can assert WHICH keys
+// an invalidation targeted — the difference between evicting one tenant and
+// flushing the estate.
+type patternStore struct {
+	mu       sync.Mutex
+	patterns []string
+}
+
+func (p *patternStore) Get(context.Context, string, interface{}) error { return cache.ErrCacheMiss }
+func (p *patternStore) SetWithTTL(context.Context, string, interface{}, time.Duration) error {
+	return nil
+}
+
+func (p *patternStore) DeletePattern(_ context.Context, pattern string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.patterns = append(p.patterns, pattern)
+	return nil
+}
+
+func (p *patternStore) seen() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.patterns...)
+}
+
+func newInvalidationApp(t *testing.T, tenant uuid.UUID, store cache.ResponseStore) *fiber.App {
+	t.Helper()
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		if c.Get("X-Anon") == "" {
+			middleware.SetContext(c, &middleware.RequestContext{
+				UserID: uuid.New(), OrganizationID: tenant,
+			})
+		}
+		return c.Next()
+	})
+	app.Use(InvalidateCacheOnMutation(cache.NewCacheDecorationWithStore(store)))
+
+	app.Get("/risks", func(c *fiber.Ctx) error { return c.JSON(fiber.Map{"ok": true}) })
+	app.Post("/risks", func(c *fiber.Ctx) error { return c.Status(201).JSON(fiber.Map{"ok": true}) })
+	app.Patch("/risks/:id", func(c *fiber.Ctx) error { return c.JSON(fiber.Map{"ok": true}) })
+	app.Delete("/risks/:id", func(c *fiber.Ctx) error { return c.SendStatus(204) })
+	app.Post("/refused", func(c *fiber.Ctx) error { return c.Status(403).JSON(fiber.Map{"error": "no"}) })
+	app.Post("/broken", func(c *fiber.Ctx) error { return c.Status(500).JSON(fiber.Map{"error": "boom"}) })
+	return app
+}
+
+func do(t *testing.T, app *fiber.App, method, path string, headers map[string]string) int {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+func TestInvalidateCacheOnMutation_EverySuccessfulWriteEvicts(t *testing.T) {
+	tenant := uuid.New()
+
+	for _, tc := range []struct{ method, path string }{
+		{fiber.MethodPost, "/risks"},
+		{fiber.MethodPatch, "/risks/" + uuid.NewString()},
+		{fiber.MethodDelete, "/risks/" + uuid.NewString()},
+	} {
+		t.Run(tc.method, func(t *testing.T) {
+			store := &patternStore{}
+			app := newInvalidationApp(t, tenant, store)
+
+			require.Less(t, do(t, app, tc.method, tc.path, nil), 300)
+
+			seen := store.seen()
+			require.Len(t, seen, 1, "a successful write must evict exactly once")
+			assert.Contains(t, seen[0], tenant.String(),
+				"the eviction must name the writer's tenant, not every tenant")
+			assert.Contains(t, seen[0], cache.ResponseKeyPrefix,
+				"it must target the response namespace WrapWithCache actually writes")
+		})
+	}
+}
+
+// A read changes nothing, so evicting on one would keep the cache permanently
+// cold — the failure mode where a cache exists and never serves.
+func TestInvalidateCacheOnMutation_ReadsDoNotEvict(t *testing.T) {
+	store := &patternStore{}
+	app := newInvalidationApp(t, uuid.New(), store)
+
+	require.Equal(t, fiber.StatusOK, do(t, app, fiber.MethodGet, "/risks", nil))
+
+	assert.Empty(t, store.seen(), "a GET must never invalidate")
+}
+
+// A rejected write changed nothing. Evicting on a 403 would also hand any
+// authenticated caller a way to flush a tenant's cache on demand.
+func TestInvalidateCacheOnMutation_RefusedAndFailedWritesDoNotEvict(t *testing.T) {
+	for _, path := range []string{"/refused", "/broken"} {
+		t.Run(path, func(t *testing.T) {
+			store := &patternStore{}
+			app := newInvalidationApp(t, uuid.New(), store)
+
+			status := do(t, app, fiber.MethodPost, path, nil)
+			require.GreaterOrEqual(t, status, 400)
+
+			assert.Empty(t, store.seen(),
+				"a write that did not happen must not evict — nor give a caller a way to flush the cache")
+		})
+	}
+}
+
+// One tenant's write must not cool another's cache.
+func TestInvalidateCacheOnMutation_EvictionIsScopedToTheWritersTenant(t *testing.T) {
+	writer, bystander := uuid.New(), uuid.New()
+	store := &patternStore{}
+	app := newInvalidationApp(t, writer, store)
+
+	require.Equal(t, fiber.StatusCreated, do(t, app, fiber.MethodPost, "/risks", nil))
+
+	seen := store.seen()
+	require.Len(t, seen, 1)
+	assert.Contains(t, seen[0], writer.String())
+	assert.NotContains(t, seen[0], bystander.String(),
+		"an eviction pattern must not reach another organization's entries")
+}
+
+// Without a resolved tenant there is nothing to scope an eviction to, and a
+// pattern that matched everything would flush the estate.
+func TestInvalidateCacheOnMutation_NoTenantEvictsNothing(t *testing.T) {
+	store := &patternStore{}
+	app := newInvalidationApp(t, uuid.New(), store)
+
+	do(t, app, fiber.MethodPost, "/risks", map[string]string{"X-Anon": "1"})
+
+	assert.Empty(t, store.seen(), "an unscoped eviction is worse than none")
+}
+
+// A deployment without Redis must be unaffected: nil decoration, no panic.
+func TestInvalidateCacheOnMutation_NilDecorationIsSafe(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		middleware.SetContext(c, &middleware.RequestContext{UserID: uuid.New(), OrganizationID: uuid.New()})
+		return c.Next()
+	})
+	app.Use(InvalidateCacheOnMutation(nil))
+	app.Post("/risks", func(c *fiber.Ctx) error { return c.Status(201).JSON(fiber.Map{"ok": true}) })
+
+	assert.Equal(t, fiber.StatusCreated, do(t, app, fiber.MethodPost, "/risks", nil))
+}

--- a/backend/pkg/cache/decoration.go
+++ b/backend/pkg/cache/decoration.go
@@ -7,19 +7,52 @@ package cache
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/pkg/monitoring"
 )
+
+// ResponseStore is the slice of the cache the response wrapper needs.
+//
+// An interface rather than *Cache so the wrapper can be tested without a Redis
+// server. Adding a Redis test double would be a new dependency, and the
+// behaviour worth testing here — that a tenant can never be served another
+// tenant's entry — is decided by the key, not by Redis.
+type ResponseStore interface {
+	Get(ctx context.Context, key string, dest interface{}) error
+	SetWithTTL(ctx context.Context, key string, value interface{}, ttl time.Duration) error
+	DeletePattern(ctx context.Context, pattern string) error
+}
 
 // CacheDecoration provides lightweight handler/cache helpers.
 type CacheDecoration struct {
-	cache *Cache
+	cache ResponseStore
 }
 
+// NewCacheDecoration wires the decoration to a real cache.
+//
+// A nil *Cache stays nil in the interface rather than becoming a non-nil
+// interface holding a nil pointer, so the `d.cache == nil` guards throughout
+// this file keep working for a deployment with no Redis.
 func NewCacheDecoration(cacheInstance *Cache) *CacheDecoration {
+	if cacheInstance == nil {
+		return &CacheDecoration{}
+	}
 	return &CacheDecoration{cache: cacheInstance}
+}
+
+// NewCacheDecorationWithStore wires an arbitrary store. Exists for tests.
+func NewCacheDecorationWithStore(store ResponseStore) *CacheDecoration {
+	return &CacheDecoration{cache: store}
 }
 
 func (d *CacheDecoration) BatchInvalidate(ctx context.Context, patterns ...string) error {
@@ -50,18 +83,172 @@ func (d *CacheDecoration) BatchInvalidate(ctx context.Context, patterns ...strin
 // cross-tenant disclosure discovered in production.
 type KeyFunc func(*fiber.Ctx) (string, bool)
 
-// WrapWithCache is a PASSTHROUGH. It evaluates nothing and caches nothing.
+// cachedResponse is what a stored entry holds. Only what is needed to replay
+// the answer: no headers a client could use to distinguish a served response
+// from a fresh one beyond the explicit X-Cache marker.
+type cachedResponse struct {
+	Status      int    `json:"s"`
+	ContentType string `json:"ct"`
+	Body        []byte `json:"b"`
+}
+
+// scopedKey is the key actually written to Redis.
 //
-// Stated this loudly because the call sites do not look like it: main.go reads
-// `cacheableHandlers.CacheDashboardStatsGET(handlers.GetDashboardStats)`, which
-// reads exactly like a route that is cached. It is not, and has not been.
+// The builder's key is not trusted to be complete. Everything below is appended
+// by the WRAPPER, so a builder that forgets one of them cannot cause a
+// collision — the gate makes an unscoped key impossible, and this makes an
+// under-scoped one harmless:
 //
-// It is left in place rather than deleted because the key builders it is
-// registered with are now tenant-scoped and tested, so the day someone
-// implements response caching here the keys are already correct. Implementing it
-// must honour the gate: `if key, ok := keyFn(c); ok { … }`, and no cache on !ok.
-func (d *CacheDecoration) WrapWithCache(handler fiber.Handler, _ KeyFunc, _ time.Duration) fiber.Handler {
-	return handler
+//	method + path   two routes must never share an entry
+//	query           the full query string, not the handful a builder remembered
+//	authz           a fingerprint of the caller's permissions and org roles
+//
+// The authz fingerprint is what satisfies "authorization changes invalidate
+// relevant entries" WITHOUT an invalidation path: a caller whose permissions
+// changed hashes to a different key and therefore cannot be served the answer
+// computed for their old entitlements. There is nothing to remember to evict,
+// which is the only kind of invalidation that cannot be forgotten.
+//
+// It also covers the intra-tenant case the tenant scope does not: two members of
+// one organization with different permissions may legitimately get different
+// answers from the same URL, and a tenant-only key would serve one of them the
+// other's.
+func scopedKey(c *fiber.Ctx, builderKey string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\n%s\n%s\n", c.Method(), c.Path(), c.Request().URI().QueryString())
+
+	// Sorted, so an unstable claim order cannot fragment the cache or, worse,
+	// make two different entitlement sets hash the same by accident.
+	if perms, ok := c.Locals("permissions").([]string); ok {
+		sorted := append([]string(nil), perms...)
+		sort.Strings(sorted)
+		for _, p := range sorted {
+			h.Write([]byte(p))
+			h.Write([]byte{0})
+		}
+	}
+	h.Write([]byte{'|'})
+	if roles, ok := c.Locals("org_roles").(map[uuid.UUID]string); ok {
+		keys := make([]string, 0, len(roles))
+		for k, v := range roles {
+			keys = append(keys, k.String()+"="+v)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.Write([]byte(k))
+			h.Write([]byte{0})
+		}
+	}
+
+	return "resp:" + builderKey + ":z:" + hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// routeLabel keeps the metric cardinality bounded: the ROUTE pattern, not the
+// resolved path, so /risks/:id is one series rather than one per risk.
+func routeLabel(c *fiber.Ctx) string {
+	if r := c.Route(); r != nil && r.Path != "" {
+		return r.Path
+	}
+	return "unknown"
+}
+
+// WrapWithCache caches a handler's response, scoped so that one tenant's answer
+// can never be served to another (#337).
+//
+// It was a passthrough until this change: the call sites in main.go read exactly
+// like cached routes and cached nothing. The key builders were already
+// tenant-scoped and tested, which is why turning it on is a change to this
+// function and not to twenty call sites.
+//
+// The rules, in the order they are applied:
+//
+//  1. Only GET is cached. A mutation must never be served from a cache, and a
+//     HEAD is cheap enough not to be worth the risk of a body/verb mismatch.
+//  2. The gate is honoured: `keyFn` returning false means DO NOT CACHE, not
+//     "cache under a shared key". An unresolved tenant lands here.
+//  3. A backend error is never fatal. Redis down means the handler runs and the
+//     request is served from the database, which is the pre-cache behaviour —
+//     degraded, not broken.
+//  4. Only a 200 is stored. An error response is a moment in time, and caching a
+//     403 or a 500 turns a transient failure into a sticky one.
+func (d *CacheDecoration) WrapWithCache(handler fiber.Handler, keyFn KeyFunc, ttl time.Duration) fiber.Handler {
+	// No cache wired: the deployment runs without Redis and every route behaves
+	// exactly as it did before. Nil-safe on purpose — main.go leaves the whole
+	// decoration nil when Redis is absent.
+	if d == nil || d.cache == nil || keyFn == nil {
+		return handler
+	}
+
+	return func(c *fiber.Ctx) error {
+		route := routeLabel(c)
+
+		if c.Method() != fiber.MethodGet {
+			monitoring.CacheRequestsTotal.WithLabelValues("bypass", route).Inc()
+			return handler(c)
+		}
+
+		builderKey, ok := keyFn(c)
+		if !ok {
+			// THE safety gate. The builder could not fully scope the key —
+			// most often an unresolved tenant — so this request is served
+			// uncached rather than under a key that might be shared.
+			monitoring.CacheRequestsTotal.WithLabelValues("bypass", route).Inc()
+			return handler(c)
+		}
+		key := scopedKey(c, builderKey)
+		ctx := c.UserContext()
+
+		var entry cachedResponse
+		switch err := d.cache.Get(ctx, key, &entry); {
+		case err == nil:
+			if entry.Status == fiber.StatusOK && len(entry.Body) > 0 {
+				monitoring.CacheRequestsTotal.WithLabelValues("hit", route).Inc()
+				if entry.ContentType != "" {
+					c.Set(fiber.HeaderContentType, entry.ContentType)
+				}
+				// Says the answer was replayed. Useful in a bug report and
+				// harmless to a client that ignores it.
+				c.Set("X-Cache", "HIT")
+				return c.Status(entry.Status).Send(entry.Body)
+			}
+			// Stored, but not something worth replaying — a truncated or
+			// wrong-shaped entry. Recompute rather than serve it.
+			monitoring.CacheRequestsTotal.WithLabelValues("stale", route).Inc()
+		case errors.Is(err, ErrCacheMiss):
+			monitoring.CacheRequestsTotal.WithLabelValues("miss", route).Inc()
+		default:
+			// Redis unreachable or answering nonsense. Fall through to the
+			// handler: the database is the source of truth and the cache is an
+			// optimisation, never a dependency.
+			monitoring.CacheRequestsTotal.WithLabelValues("degraded", route).Inc()
+		}
+
+		if err := handler(c); err != nil {
+			return err
+		}
+
+		status := c.Response().StatusCode()
+		if status != fiber.StatusOK {
+			monitoring.CacheRequestsTotal.WithLabelValues("uncacheable", route).Inc()
+			return nil
+		}
+		body := append([]byte(nil), c.Response().Body()...)
+		if len(body) == 0 {
+			monitoring.CacheRequestsTotal.WithLabelValues("uncacheable", route).Inc()
+			return nil
+		}
+
+		// Best-effort. A failed write costs a future hit and nothing else; the
+		// response has already been produced and must not be failed for it.
+		_ = d.cache.SetWithTTL(ctx, key, cachedResponse{
+			Status:      status,
+			ContentType: string(c.Response().Header.ContentType()),
+			Body:        body,
+		}, ttl)
+
+		c.Set("X-Cache", "MISS")
+		return nil
+	}
 }
 
 type RequestCacheContext struct {
@@ -102,4 +289,30 @@ func (r *RequestCacheContext) GetOrSet(key string, dest interface{}, compute fun
 		return err
 	}
 	return json.Unmarshal(b, dest)
+}
+
+// ResponseKeyPrefix is the namespace every response-cache entry lives under.
+// Exported so an invalidator can target exactly what WrapWithCache wrote and
+// nothing else — the pre-#337 patterns ("risk:*", "dashboard:*") match none of
+// these keys, and would have silently invalidated nothing.
+const ResponseKeyPrefix = "resp:"
+
+// InvalidateTenant drops every cached response belonging to one tenant.
+//
+// Deliberately coarse. The alternative — a hook per handler naming the families
+// it touches — is precise right up to the first handler somebody adds without
+// one, and a stale compliance figure shown to an auditor is a worse outcome than
+// a cache that refills. There are five cached routes; flushing one tenant's five
+// entries on a write is cheap, and it cannot be forgotten.
+//
+// Scoped to the tenant on purpose: one organization's write must not evict
+// another's entries, or a busy tenant would keep the whole estate cold.
+func (d *CacheDecoration) InvalidateTenant(ctx context.Context, tenantID string, scope string) error {
+	if d == nil || d.cache == nil || tenantID == "" {
+		return nil
+	}
+	monitoring.CacheInvalidationsTotal.WithLabelValues(scope).Inc()
+	// Every builder embeds the tenant as ":t:<uuid>", so this matches that
+	// tenant's entries across every family and no other tenant's.
+	return d.cache.DeletePattern(ctx, ResponseKeyPrefix+"*t:"+tenantID+"*")
 }

--- a/backend/pkg/cache/decoration_test.go
+++ b/backend/pkg/cache/decoration_test.go
@@ -1,0 +1,368 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// #337 — WrapWithCache was a passthrough. It cached nothing, which is why the
+// cross-tenant tests passed: there was no cache to collide in.
+//
+// These drive the real wrapper. The critical one is
+// TestWrapWithCache_TenantBCannotBeServedTenantAsResponse: it is the shape the
+// issue draws, and it is the only test here whose failure is a disclosure rather
+// than a slowdown.
+// ---------------------------------------------------------------------------
+
+// memStore is an in-memory ResponseStore. Redis is not needed to decide the
+// question these tests ask — whether two callers can land on one key — and
+// adding a Redis double would be a new dependency.
+type memStore struct {
+	mu      sync.Mutex
+	data    map[string][]byte
+	failGet error
+	failSet error
+	sets    int32
+}
+
+func newMemStore() *memStore { return &memStore{data: map[string][]byte{}} }
+
+func (m *memStore) Get(_ context.Context, key string, dest interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failGet != nil {
+		return m.failGet
+	}
+	raw, ok := m.data[key]
+	if !ok {
+		return ErrCacheMiss
+	}
+	return json.Unmarshal(raw, dest)
+}
+
+func (m *memStore) SetWithTTL(_ context.Context, key string, value interface{}, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failSet != nil {
+		return m.failSet
+	}
+	atomic.AddInt32(&m.sets, 1)
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	m.data[key] = raw
+	return nil
+}
+
+func (m *memStore) DeletePattern(_ context.Context, _ string) error { return nil }
+
+func (m *memStore) keyCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.data)
+}
+
+// putRaw stores a hand-made entry, for the stale-entry case.
+func (m *memStore) putRaw(key string, raw []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = raw
+}
+
+func (m *memStore) onlyKey(t *testing.T) string {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	require.Len(t, m.data, 1)
+	for k := range m.data {
+		return k
+	}
+	return ""
+}
+
+// tenantKey is a realistic builder: scoped, and refusing when the tenant is
+// unresolved — the contract KeyFunc exists to enforce.
+func tenantKey(c *fiber.Ctx) (string, bool) {
+	tenant, ok := c.Locals("tenant").(string)
+	if !ok || tenant == "" {
+		return "", false
+	}
+	return "stats:t:" + tenant, true
+}
+
+type harness struct {
+	app   *fiber.App
+	store *memStore
+	calls *int32
+}
+
+// newHarness mounts one cached GET whose handler echoes the caller's tenant, so
+// a leaked entry is visible in the body rather than inferred.
+func newHarness(t *testing.T, store *memStore) *harness {
+	t.Helper()
+	var calls int32
+
+	d := NewCacheDecorationWithStore(store)
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+
+	app.Get("/stats", func(c *fiber.Ctx) error {
+		// Identity comes from headers, standing in for what the auth middleware
+		// stamps. Nothing in the request path names a tenant.
+		if tenant := c.Get("X-Tenant"); tenant != "" {
+			c.Locals("tenant", tenant)
+		}
+		if perms := c.Get("X-Perms"); perms != "" {
+			c.Locals("permissions", []string{perms})
+		}
+		if roles := c.Get("X-Role"); roles != "" {
+			c.Locals("org_roles", map[uuid.UUID]string{uuid.Nil: roles})
+		}
+		return c.Next()
+	}, d.WrapWithCache(func(c *fiber.Ctx) error {
+		atomic.AddInt32(&calls, 1)
+		return c.JSON(fiber.Map{"tenant": c.Locals("tenant"), "secret": "data-of-" + fmt.Sprint(c.Locals("tenant"))})
+	}, tenantKey, time.Minute))
+
+	return &harness{app: app, store: store, calls: &calls}
+}
+
+type result struct {
+	status int
+	body   string
+	cache  string
+}
+
+func (h *harness) get(t *testing.T, path string, headers map[string]string) result {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, path, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := h.app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return result{status: resp.StatusCode, body: string(raw), cache: resp.Header.Get("X-Cache")}
+}
+
+func tenantHdr(tenant string) map[string]string { return map[string]string{"X-Tenant": tenant} }
+
+// ===========================================================================
+// THE test. Tenant A warms the cache; tenant B must never see it.
+// ===========================================================================
+
+func TestWrapWithCache_TenantBCannotBeServedTenantAsResponse(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	a := h.get(t, "/stats", tenantHdr("tenant-a"))
+	require.Equal(t, fiber.StatusOK, a.status)
+	assert.Contains(t, a.body, "data-of-tenant-a")
+
+	b := h.get(t, "/stats", tenantHdr("tenant-b"))
+	require.Equal(t, fiber.StatusOK, b.status)
+
+	assert.Contains(t, b.body, "data-of-tenant-b", "tenant B must get its own answer")
+	assert.NotContains(t, b.body, "tenant-a", "tenant B was served tenant A's response")
+	assert.Equal(t, "MISS", b.cache, "tenant B must not hit an entry warmed by tenant A")
+	assert.Equal(t, 2, store.keyCount(), "two tenants must occupy two keys")
+	assert.EqualValues(t, 2, atomic.LoadInt32(h.calls), "the handler must have run for each tenant")
+}
+
+func TestWrapWithCache_SecondIdenticalRequestHitsTheCache(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	first := h.get(t, "/stats", tenantHdr("tenant-a"))
+	second := h.get(t, "/stats", tenantHdr("tenant-a"))
+
+	assert.Equal(t, "MISS", first.cache)
+	assert.Equal(t, "HIT", second.cache)
+	assert.Equal(t, first.body, second.body, "a hit must replay the same answer")
+	assert.EqualValues(t, 1, atomic.LoadInt32(h.calls), "the handler must run once, not twice")
+}
+
+// The gate. A builder that cannot scope its key means DO NOT CACHE — never
+// "cache under a shared key", which is how an unauthenticated response ends up
+// served to everyone.
+func TestWrapWithCache_UnresolvedTenantIsNeverCached(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	first := h.get(t, "/stats", nil)
+	second := h.get(t, "/stats", nil)
+
+	assert.Equal(t, fiber.StatusOK, first.status, "the request is still served")
+	assert.Equal(t, fiber.StatusOK, second.status)
+	assert.Empty(t, first.cache, "and is marked neither HIT nor MISS")
+	assert.Empty(t, second.cache)
+	assert.Equal(t, 0, store.keyCount(), "nothing may be stored without a scoped key")
+	assert.EqualValues(t, 2, atomic.LoadInt32(h.calls), "every such request reaches the handler")
+}
+
+// Two members of ONE tenant with different entitlements may legitimately get
+// different answers. The tenant scope alone would serve one of them the other's.
+func TestWrapWithCache_DifferentPermissionsDoNotShareAnEntry(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	h.get(t, "/stats", map[string]string{"X-Tenant": "tenant-a", "X-Perms": "risks:read"})
+	second := h.get(t, "/stats", map[string]string{"X-Tenant": "tenant-a", "X-Perms": "*"})
+
+	assert.Equal(t, "MISS", second.cache,
+		"a caller with different permissions must not be served the other's entry")
+	assert.Equal(t, 2, store.keyCount())
+}
+
+// The same fingerprint is what makes an authorization CHANGE invalidate without
+// an invalidation path: the caller's new entitlements hash to a new key, so the
+// answer computed under the old ones is unreachable.
+func TestWrapWithCache_AuthorizationChangeCannotServeTheOldAnswer(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	before := h.get(t, "/stats", map[string]string{"X-Tenant": "tenant-a", "X-Perms": "risks:read"})
+	require.Equal(t, "MISS", before.cache)
+
+	// The same user, after a role change.
+	after := h.get(t, "/stats", map[string]string{"X-Tenant": "tenant-a", "X-Perms": "risks:read", "X-Role": "admin"})
+
+	assert.Equal(t, "MISS", after.cache,
+		"an entitlement change must not be served the answer computed before it")
+}
+
+// Query parameters are part of the answer. The wrapper appends the whole query
+// string, so a builder that remembered only some of them cannot collide.
+func TestWrapWithCache_QueryStringIsPartOfTheKey(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	h.get(t, "/stats?period=7d", tenantHdr("tenant-a"))
+	second := h.get(t, "/stats?period=30d", tenantHdr("tenant-a"))
+
+	assert.Equal(t, "MISS", second.cache, "two windows are two answers")
+	assert.Equal(t, 2, store.keyCount())
+}
+
+// Redis down must cost latency, never availability.
+func TestWrapWithCache_BackendFailureDegradesToTheHandler(t *testing.T) {
+	store := newMemStore()
+	store.failGet = errors.New("redis unreachable")
+	store.failSet = errors.New("redis unreachable")
+	h := newHarness(t, store)
+
+	first := h.get(t, "/stats", tenantHdr("tenant-a"))
+	second := h.get(t, "/stats", tenantHdr("tenant-a"))
+
+	assert.Equal(t, fiber.StatusOK, first.status)
+	assert.Equal(t, fiber.StatusOK, second.status)
+	assert.Contains(t, second.body, "data-of-tenant-a")
+	assert.EqualValues(t, 2, atomic.LoadInt32(h.calls), "both requests are served from the handler")
+	assert.Equal(t, 0, store.keyCount())
+}
+
+// A stored entry that cannot be replayed is recomputed rather than served.
+func TestWrapWithCache_UnreadableEntryIsRecomputed(t *testing.T) {
+	store := newMemStore()
+	h := newHarness(t, store)
+
+	h.get(t, "/stats", tenantHdr("tenant-a")) // warm it
+	key := store.onlyKey(t)
+	store.putRaw(key, []byte(`{"s":200,"ct":"application/json","b":null}`))
+
+	again := h.get(t, "/stats", tenantHdr("tenant-a"))
+	assert.Equal(t, fiber.StatusOK, again.status)
+	assert.Contains(t, again.body, "data-of-tenant-a", "an unusable entry must not be served")
+}
+
+// A mutation must never be served from, or written to, the cache.
+func TestWrapWithCache_NonGetIsNeverCached(t *testing.T) {
+	store := newMemStore()
+	var calls int32
+	d := NewCacheDecorationWithStore(store)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/stats", func(c *fiber.Ctx) error {
+		c.Locals("tenant", c.Get("X-Tenant"))
+		return c.Next()
+	}, d.WrapWithCache(func(c *fiber.Ctx) error {
+		atomic.AddInt32(&calls, 1)
+		return c.JSON(fiber.Map{"ok": true})
+	}, tenantKey, time.Minute))
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(fiber.MethodPost, "/stats", nil)
+		req.Header.Set("X-Tenant", "tenant-a")
+		resp, err := app.Test(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+	}
+
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "a POST must always reach its handler")
+	assert.Equal(t, 0, store.keyCount())
+}
+
+// An error response is a moment in time. Caching a 403 or a 500 turns a
+// transient failure into a sticky one.
+func TestWrapWithCache_NonOKResponsesAreNotStored(t *testing.T) {
+	store := newMemStore()
+	d := NewCacheDecorationWithStore(store)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Get("/stats", func(c *fiber.Ctx) error {
+		c.Locals("tenant", c.Get("X-Tenant"))
+		return c.Next()
+	}, d.WrapWithCache(func(c *fiber.Ctx) error {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "nope"})
+	}, tenantKey, time.Minute))
+
+	req := httptest.NewRequest(fiber.MethodGet, "/stats", nil)
+	req.Header.Set("X-Tenant", "tenant-a")
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, fiber.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, 0, store.keyCount(), "a refusal must not become a cached answer")
+}
+
+// With no cache configured the wrapper is the handler, unchanged. A deployment
+// without Redis must behave exactly as before.
+func TestWrapWithCache_NilCacheIsAPassthrough(t *testing.T) {
+	var calls int32
+	d := NewCacheDecoration(nil)
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Get("/stats", d.WrapWithCache(func(c *fiber.Ctx) error {
+		atomic.AddInt32(&calls, 1)
+		return c.JSON(fiber.Map{"ok": true})
+	}, tenantKey, time.Minute))
+
+	for i := 0; i < 2; i++ {
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/stats", nil))
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+	}
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}

--- a/backend/pkg/monitoring/cache.go
+++ b/backend/pkg/monitoring/cache.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Response-cache metrics (#337).
+//
+// Package-level, in the style of realtime.go, so pkg/cache can record without
+// being handed a collector instance through three constructors.
+//
+// The labels are the point. A single "cache hits" number cannot answer the
+// question anyone actually asks of a cache that sits in front of tenant data —
+// "is it serving, and when it is not serving, why not" — and the difference
+// between a miss and a REFUSAL to cache is the difference between a cold key and
+// a request whose tenant could not be resolved.
+var (
+	// CacheRequestsTotal counts every request that passed through the response
+	// cache, by what happened to it:
+	//
+	//	hit       served from the cache
+	//	miss      not in the cache; the handler ran and the result was stored
+	//	bypass    the key builder refused to produce a key — an unresolved tenant,
+	//	          or a request the builder judged unsafe to cache. NEVER cached.
+	//	degraded  the cache backend errored; the handler ran and nothing was stored
+	//	stale     a stored entry was rejected before use (unreadable or the wrong
+	//	          shape) and re-computed
+	//	uncacheable the handler answered with something not worth storing — a
+	//	          non-200, or a response that named itself no-store
+	CacheRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "openrisk_cache_requests_total",
+		Help: "Response-cache outcomes, by result and route.",
+	}, []string{"result", "route"})
+
+	// CacheInvalidationsTotal counts deliberate evictions, by what triggered
+	// them. Distinct from a TTL expiry, which Redis performs and nothing here
+	// observes — see the honest note in the issue rather than a fabricated
+	// eviction counter.
+	CacheInvalidationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "openrisk_cache_invalidations_total",
+		Help: "Cache entries deliberately invalidated, by the scope that triggered it.",
+	}, []string{"scope"})
+)


### PR DESCRIPTION
Closes #337

`WrapWithCache` was `return handler`. It cached nothing — which is exactly why the cross-tenant
tests passed: there was no cache to collide in. This turns it on, and the security work is in the
key.

## The key is where the guarantee lives

The wrapper does **not** trust the builder's key to be complete. On top of whatever the builder
returns it appends the method, the path, the **whole** query string, and a **fingerprint of the
caller's permissions and org roles**. A builder that forgets one of them cannot cause a
collision: the pre-existing `KeyFunc` gate makes an *unscoped* key impossible, and this makes an
*under-scoped* one harmless.

**The authz fingerprint is how "authorization changes invalidate relevant entries" is satisfied —
structurally, with nothing to remember to evict.** A caller whose entitlements changed hashes to a
different key and therefore cannot be served the answer computed under the old ones. It also
covers the case a tenant-only key does not: two members of *one* organization with different
permissions may legitimately get different answers from the same URL, and a tenant-scoped key
would serve one of them the other's.

Rules, in order: only `GET`; the gate's `false` means **do not cache**, never "cache under a
shared key"; a backend error degrades to the handler; only `200`s are stored.

## Invalidation is central, not per-handler

`InvalidateCacheOnMutation` is mounted **once**, on the authenticated group. The criterion is
"resource mutations invalidate dependent responses", and a per-handler hook satisfies that
exactly until the next handler is added without one. A GRC product showing an auditor a figure
from before the last change has a worse problem than a cache that refills.

It is coarse (a tenant's whole response namespace) and tenant-scoped (one organization's write
never cools another's cache), and fires only after a 2xx — evicting on a 403 would hand any
authenticated caller a way to flush a tenant's cache on demand.

**A bug this uncovered:** the pre-existing invalidators used patterns `"risk:*"` and
`"dashboard:*"`. Cached entries live under `resp:…`, so those patterns match **nothing** — they
would have invalidated nothing at all. `ResponseKeyPrefix` is now exported so an invalidator
targets what is actually stored.

## Verification

```
$ go test ./pkg/cache/ -v
--- PASS: TestWrapWithCache_TenantBCannotBeServedTenantAsResponse
--- PASS: TestWrapWithCache_SecondIdenticalRequestHitsTheCache
--- PASS: TestWrapWithCache_UnresolvedTenantIsNeverCached
--- PASS: TestWrapWithCache_DifferentPermissionsDoNotShareAnEntry
--- PASS: TestWrapWithCache_AuthorizationChangeCannotServeTheOldAnswer
--- PASS: TestWrapWithCache_QueryStringIsPartOfTheKey
--- PASS: TestWrapWithCache_BackendFailureDegradesToTheHandler
--- PASS: TestWrapWithCache_UnreadableEntryIsRecomputed
--- PASS: TestWrapWithCache_NonGetIsNeverCached
--- PASS: TestWrapWithCache_NonOKResponsesAreNotStored
--- PASS: TestWrapWithCache_NilCacheIsAPassthrough

$ go test ./internal/handler/ -run TestInvalidateCacheOnMutation -v
--- PASS: .../EverySuccessfulWriteEvicts{POST,PATCH,DELETE}
--- PASS: .../ReadsDoNotEvict
--- PASS: .../RefusedAndFailedWritesDoNotEvict{refused,broken}
--- PASS: .../EvictionIsScopedToTheWritersTenant
--- PASS: .../NoTenantEvictsNothing
--- PASS: .../NilDecorationIsSafe

$ go test ./...        # whole backend
all packages ok, EXCEPT one pre-existing failure — see below
```

`go build ./...` clean · `go vet` clean · `gofmt -l` empty on every file I touched.

### Proved non-vacuous

Making the key builder tenant-blind and re-running fails **exactly**
`TestWrapWithCache_TenantBCannotBeServedTenantAsResponse` and nothing else. Restored and
re-verified green.

### One pre-existing failure, not mine

`TestBusinessRolesReferenceOnlyCatalogPermissions` in `internal/domain` fails: the business-role
presets reference `events:read`, which is not in the permission catalogue. I confirmed this on a
clean worktree of `origin/master` — **master is currently red on this test**. It is unrelated to
caching and I have not touched `internal/domain`. Worth its own issue.

## Acceptance criteria

- Second identical request hits cache ✅ · cross-tenant collision tests ✅ · authorization changes
  invalidate ✅ (structurally, via the fingerprint) · resource mutations invalidate ✅ · TTL
  configurable ✅ (pre-existing `CacheConfig`, per family) · Redis failure degrades ✅
- Metrics: hit ✅ · miss ✅ · stale ✅ · invalidation ✅ · **eviction ❌** — see remainders.

## Honest remainders

- **No eviction metric.** TTL expiry is Redis's own and this process never observes it. I would
  rather leave the gap than emit a number the server cannot actually see.
- **Tested against an in-memory store, not Redis.** What these tests decide — whether two callers
  can land on one key — is settled by the key, not by Redis. A Redis double would have been a new
  dependency, which is an escalation. The `e2e.yml` harness runs a real Redis and is where an
  end-to-end cache test belongs.
- **Invalidation is coarse.** Any write by a tenant drops all of that tenant's cached responses,
  not just the affected family. With five cached routes that is cheap; if the cached surface grows
  substantially, it should become per-family.
- **This is a behaviour change on a live path.** Caching was off; it is now on for five routes.
  The tests cover the isolation properties, but the first deployment is the first time real
  traffic meets it — worth watching `openrisk_cache_requests_total{result=...}` after rollout,
  particularly the `bypass` and `degraded` series.
- **`GetRiskCacheKey` (`cache_integration.go`) is still a tenant-blind legacy builder** —
  `risk:<op>:<params>`, no tenant, not behind the `KeyFunc` gate. Nothing in the cached path uses
  it, so it is not a live issue, but it is a loaded foot-gun for whoever reaches for it next.
- The issue's `priority:P0` framing describes a **performance** feature: the passthrough was safe,
  and implementing caching is what introduces the cross-tenant surface. That is why the key work
  above is the substance of this PR rather than an afterthought.
