### PR TITLE
security(isolation): assess all 97 Pending collection routes, and file the one that leaks (#421)

### DIFF
--- a/backend/internal/handler/stats_collection_isolation_test.go
+++ b/backend/internal/handler/stats_collection_isolation_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/infrastructure/database"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// The /stats/* collection routes (#421).
+//
+// The issue names this module as the place to start, and the reason is shape,
+// not size: these are unparameterised GETs that aggregate a whole table and
+// hand the numbers to whoever loads the dashboard. GET /timeline/recent had the
+// same shape and returned every tenant's risk history (docs/JOURNAL.md item 36).
+//
+// These handlers read their tenant from c.Locals("tenant_id"), which the auth
+// middleware sets from the signed token, and query package-global database.DB.
+// So the test drives them over a real Fiber app with a stub middleware standing
+// in for the token, and swaps database.DB for an in-memory fixture — the same
+// code path production runs, tenant resolution included, rather than a retyped
+// copy of the SQL.
+
+func newStatsIsolationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	for _, ddl := range []string{
+		`CREATE TABLE risks (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE mitigations (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE risk_histories (id TEXT PRIMARY KEY)`,
+		// ExportRisksPDF preloads Risk.Assets (many2many risk_assets), so the
+		// join table and its target have to exist for the export to run at all.
+		`CREATE TABLE assets (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE risk_assets (risk_id TEXT, asset_id TEXT)`,
+	} {
+		require.NoError(t, db.Exec(ddl).Error)
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"risks", &domain.Risk{}},
+		{"mitigations", &domain.Mitigation{}},
+		{"risk_histories", &domain.RiskHistory{}},
+		{"assets", &domain.Asset{}},
+	} {
+		require.NoError(t, sqliteschema.Reconcile(db, m.table, m.model))
+	}
+	return db
+}
+
+// useStatsDB points the package-global handle at the fixture and restores the
+// real one, so a failure here cannot leave the rest of the suite pointed at a
+// closed in-memory database.
+func useStatsDB(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	previous := database.DB
+	database.DB = db
+	t.Cleanup(func() { database.DB = previous })
+}
+
+// statsApp mounts the real handlers behind a middleware that sets the same
+// locals middleware.Protected sets from the JWT. Nothing in the request can
+// influence the tenant — that is the property under test.
+func statsApp(tenant uuid.UUID) *fiber.App {
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("tenant_id", tenant)
+		c.Locals("userID", uuid.New().String())
+		return c.Next()
+	})
+	app.Get("/stats/risk-matrix", GetRiskMatrixData)
+	app.Get("/stats/risk-distribution", GetRiskDistribution)
+	app.Get("/stats/mitigation-metrics", GetMitigationMetrics)
+	app.Get("/stats/top-vulnerabilities", GetTopVulnerabilities)
+	app.Get("/stats/trends", GetGlobalRiskTrend)
+	app.Get("/export/pdf", ExportRisksPDF)
+	return app
+}
+
+func statsGet(t *testing.T, app *fiber.App, path string) []byte {
+	t.Helper()
+	resp, err := app.Test(httptest.NewRequest("GET", path, nil), 5000)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, 200, resp.StatusCode, path)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return body
+}
+
+// pdfText inflates every FlateDecode content stream in the document and returns
+// the concatenation, so an assertion can be made about what a reader would see
+// rather than about compressed bytes.
+func pdfText(t *testing.T, doc []byte) string {
+	t.Helper()
+	var out strings.Builder
+	rest := doc
+	for {
+		i := bytes.Index(rest, []byte("stream\n"))
+		if i < 0 {
+			break
+		}
+		rest = rest[i+len("stream\n"):]
+		j := bytes.Index(rest, []byte("\nendstream"))
+		if j < 0 {
+			break
+		}
+		if zr, err := zlib.NewReader(bytes.NewReader(rest[:j])); err == nil {
+			if raw, err := io.ReadAll(zr); err == nil {
+				out.Write(raw)
+			}
+			_ = zr.Close()
+		}
+		rest = rest[j:]
+	}
+	require.NotEmpty(t, out.String(), "no readable content stream in the PDF")
+	return out.String()
+}
+
+func seedStatsRisk(t *testing.T, db *gorm.DB, tenant uuid.UUID, title string, score, impact, probability float64, level string) {
+	t.Helper()
+	now := time.Now().UTC()
+	require.NoError(t, db.Exec(
+		`INSERT INTO risks (id, tenant_id, title, status, level, criticality, score, impact, probability, created_at, updated_at)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+		uuid.NewString(), tenant.String(), title, "open", level, level,
+		score, impact, probability, now, now,
+	).Error)
+}
+
+// TestStatsCollections_NeverCrossTenants seeds two tenants and proves each of
+// the five /stats reads and the PDF export answers with the caller's rows only.
+//
+// Tenant A owns one risk and one mitigation; tenant B owns three of each, with
+// deliberately different impact/probability/level values. Every count below is
+// therefore wrong in a recognisable way if a predicate is dropped.
+func TestStatsCollections_NeverCrossTenants(t *testing.T) {
+	db := newStatsIsolationDB(t)
+	useStatsDB(t, db)
+
+	tenantA := uuid.MustParse("aaaa1111-aaaa-1111-aaaa-111111111111")
+	tenantB := uuid.MustParse("bbbb2222-bbbb-2222-bbbb-222222222222")
+
+	seedStatsRisk(t, db, tenantA, "A-only risk", 4.0, 5, 0.8, "MEDIUM")
+	for _, title := range []string{"B-one", "B-two", "B-three"} {
+		seedStatsRisk(t, db, tenantB, title, 9.0, 9, 1.0, "CRITICAL")
+	}
+	for i := 0; i < 3; i++ {
+		require.NoError(t, db.Exec(
+			`INSERT INTO mitigations (id, tenant_id, risk_id, title, status, progress, created_at, updated_at)
+			 VALUES (?,?,?,?,?,?,?,?)`,
+			uuid.NewString(), tenantB.String(), uuid.NewString(), "B mitigation", "DONE", 100,
+			time.Now(), time.Now()).Error)
+	}
+	require.NoError(t, db.Exec(
+		`INSERT INTO mitigations (id, tenant_id, risk_id, title, status, progress, created_at, updated_at)
+		 VALUES (?,?,?,?,?,?,?,?)`,
+		uuid.NewString(), tenantA.String(), uuid.NewString(), "A mitigation", "PLANNED", 0,
+		time.Now(), time.Now()).Error)
+
+	app := statsApp(tenantA)
+
+	t.Run("risk_matrix", func(t *testing.T) {
+		var cells []RiskMatrixCell
+		require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/risk-matrix"), &cells))
+		require.Len(t, cells, 1, "one (impact, probability) pair exists in tenant A")
+		require.Equal(t, 1, cells[0].Count)
+		for _, c := range cells {
+			require.NotEqual(t, float64(9), c.Impact, "tenant B's cell reached tenant A's matrix")
+		}
+	})
+
+	t.Run("risk_distribution", func(t *testing.T) {
+		var rows []RiskDistributionData
+		require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/risk-distribution"), &rows))
+		require.Len(t, rows, 1)
+		require.Equal(t, "MEDIUM", rows[0].Level)
+		require.Equal(t, 1, rows[0].Count)
+		for _, r := range rows {
+			require.NotEqual(t, "CRITICAL", r.Level, "tenant B's severity band reached tenant A")
+		}
+	})
+
+	t.Run("mitigation_metrics", func(t *testing.T) {
+		var m MitigationMetricsData
+		require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/mitigation-metrics"), &m))
+		require.Equal(t, 1, m.TotalMitigations, "tenant B's three mitigations must be absent")
+		require.Equal(t, 0, m.CompletedMitigations,
+			"tenant B's DONE mitigations must not be counted as tenant A's completions")
+		require.Equal(t, 1, m.PlannedMitigations)
+	})
+
+	t.Run("top_vulnerabilities", func(t *testing.T) {
+		var rows []TopVulnerability
+		require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/top-vulnerabilities"), &rows))
+		require.Len(t, rows, 1)
+		require.Equal(t, "A-only risk", rows[0].Title)
+		for _, r := range rows {
+			require.NotContains(t, r.Title, "B-",
+				"a tenant B risk reached tenant A's top-vulnerabilities widget")
+		}
+	})
+
+	t.Run("trends", func(t *testing.T) {
+		var points []TrendPoint
+		require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/trends"), &points))
+		require.Len(t, points, 1, "one creation day in tenant A")
+		// The average is over tenant A's single risk. Tenant B's three 9.0s
+		// would pull it to 7.75.
+		require.InDelta(t, 4.0, points[0].Score, 0.001,
+			"tenant B's scores must not enter tenant A's average")
+	})
+
+	t.Run("export_pdf", func(t *testing.T) {
+		// The export renders every row it fetched into the document, so a lost
+		// predicate here ships another tenant's register as a downloadable file.
+		// The assertion is made on the rendered text, not on the row count, for
+		// the same reason the rest of this file drives real handlers: a leak is
+		// only real once it reaches the artifact the user receives.
+		text := pdfText(t, statsGet(t, app, "/export/pdf"))
+		require.Contains(t, text, "A-only risk")
+		for _, title := range []string{"B-one", "B-two", "B-three"} {
+			require.NotContains(t, text, title,
+				"a tenant B risk was rendered into tenant A's PDF export")
+		}
+	})
+}
+
+// A request that resolves no tenant must read as an empty tenant, never as
+// every tenant. The handlers take their tenant through safeGetUUID, which
+// answers uuid.Nil when the local is absent; the predicate must still be
+// emitted, so the answer is empty rather than global.
+func TestStatsCollections_NoTenantReadsAsEmptyNotGlobal(t *testing.T) {
+	db := newStatsIsolationDB(t)
+	useStatsDB(t, db)
+
+	tenant := uuid.New()
+	seedStatsRisk(t, db, tenant, "somebody's risk", 9.0, 9, 1.0, "CRITICAL")
+
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		// No tenant_id local at all — the shape a route mounted outside the
+		// authenticated router would produce.
+		c.Locals("userID", uuid.New().String())
+		return c.Next()
+	})
+	app.Get("/stats/risk-distribution", GetRiskDistribution)
+	app.Get("/stats/top-vulnerabilities", GetTopVulnerabilities)
+
+	var rows []RiskDistributionData
+	require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/risk-distribution"), &rows))
+	require.Empty(t, rows, "an unresolved tenant must see nothing, not everything")
+
+	var top []TopVulnerability
+	require.NoError(t, json.Unmarshal(statsGet(t, app, "/stats/top-vulnerabilities"), &top))
+	require.Empty(t, top, "an unresolved tenant must see nothing, not everything")
+}

--- a/backend/internal/infrastructure/repository/automation_collection_isolation_test.go
+++ b/backend/internal/infrastructure/repository/automation_collection_isolation_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// The /automation/* collection routes (#421).
+//
+// GET /automation/rules, /executions, /sla, /sla/stats, /channels and /state are
+// unparameterised reads that aggregate a whole table. Two of them are worse than
+// a plain list if they lose their predicate: /automation/channels returns the
+// tenant's outbound notification configuration (webhook endpoints, sender
+// identities), and /automation/executions is the run history — what fired,
+// against which entity, and when.
+//
+// Same shape as the rest of the sweep: seed both tenants, read as one, prove the
+// other is absent.
+
+var (
+	autoA = uuid.MustParse("c0c0c0c0-0000-4000-8000-000000000001")
+	autoB = uuid.MustParse("d0d0d0d0-0000-4000-8000-000000000002")
+)
+
+func newAutomationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, ddl := range []string{
+		`CREATE TABLE automation_rules (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE automation_executions (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE sla_trackers (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE automation_channels (id TEXT PRIMARY KEY)`,
+	} {
+		if err := db.Exec(ddl).Error; err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"automation_rules", &domain.AutomationRule{}},
+		{"automation_executions", &domain.AutomationExecution{}},
+		{"sla_trackers", &domain.SLATracker{}},
+		{"automation_channels", &domain.AutomationChannelConfig{}},
+	} {
+		if err := sqliteschema.Reconcile(db, m.table, m.model); err != nil {
+			t.Fatalf("reconcile %s: %v", m.table, err)
+		}
+	}
+	return db
+}
+
+func TestAutomationCollections_NeverCrossTenants(t *testing.T) {
+	db := newAutomationDB(t)
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+
+	rules := NewGormAutomationRuleRepository(db)
+	executions := NewGormAutomationExecutionRepository(db)
+	slas := NewGormSLATrackerRepository(db)
+	channels := NewGormAutomationChannelRepository(db)
+
+	// Tenant A gets one of everything; tenant B gets two, so a dropped predicate
+	// shows up as 3 rather than as a subtler off-by-one.
+	seed := func(tenant uuid.UUID, n int, label string) {
+		for i := 0; i < n; i++ {
+			ruleID := uuid.New()
+			if err := rules.Create(ctx, &domain.AutomationRule{
+				ID: ruleID, TenantID: tenant, Name: label + " rule",
+				Trigger: domain.TriggerRiskCreated, Enabled: true,
+			}); err != nil {
+				t.Fatalf("create rule: %v", err)
+			}
+			if err := executions.Create(ctx, &domain.AutomationExecution{
+				ID: uuid.New(), TenantID: tenant, RuleID: ruleID,
+				Status: domain.ExecutionSuccess, StartedAt: now,
+			}); err != nil {
+				t.Fatalf("create execution: %v", err)
+			}
+			if err := slas.Create(ctx, &domain.SLATracker{
+				ID: uuid.New(), TenantID: tenant, RuleID: ruleID,
+				Status: domain.SLAOpen, DueAt: now.AddDate(0, 0, 7),
+			}); err != nil {
+				t.Fatalf("create sla: %v", err)
+			}
+		}
+		if err := channels.Upsert(ctx, &domain.AutomationChannelConfig{
+			ID: uuid.New(), TenantID: tenant,
+			SlackEnabled: true, SlackWebhookURL: "https://hooks.example/" + label,
+		}); err != nil {
+			t.Fatalf("save channels: %v", err)
+		}
+	}
+	seed(autoA, 1, "A")
+	seed(autoB, 2, "B")
+
+	t.Run("rules", func(t *testing.T) {
+		list, err := rules.List(ctx, autoA)
+		if err != nil {
+			t.Fatalf("list rules: %v", err)
+		}
+		if len(list) != 1 {
+			t.Fatalf("tenant A owns one rule, got %d", len(list))
+		}
+		for _, r := range list {
+			if r.TenantID != autoA {
+				t.Fatalf("tenant %s's rule reached tenant A", r.TenantID)
+			}
+		}
+		// GET /automation/state is computed from the same List; the trigger-scoped
+		// read the engine uses on every event is asserted with it, because a leak
+		// there would run another tenant's rules against this tenant's data.
+		enabled, err := rules.ListEnabledByTrigger(ctx, autoA, domain.TriggerRiskCreated)
+		if err != nil {
+			t.Fatalf("list by trigger: %v", err)
+		}
+		if len(enabled) != 1 || enabled[0].TenantID != autoA {
+			t.Fatalf("trigger lookup crossed the tenant boundary: %d rows", len(enabled))
+		}
+	})
+
+	t.Run("executions", func(t *testing.T) {
+		list, err := executions.List(ctx, autoA, 100, 0)
+		if err != nil {
+			t.Fatalf("list executions: %v", err)
+		}
+		if len(list) != 1 {
+			t.Fatalf("tenant A owns one execution, got %d", len(list))
+		}
+		for _, e := range list {
+			if e.TenantID != autoA {
+				t.Fatalf("tenant %s's run history reached tenant A", e.TenantID)
+			}
+		}
+	})
+
+	t.Run("sla_and_stats", func(t *testing.T) {
+		open, err := slas.ListOpen(ctx, autoA)
+		if err != nil {
+			t.Fatalf("list open sla: %v", err)
+		}
+		if len(open) != 1 || open[0].TenantID != autoA {
+			t.Fatalf("tenant A owns one open SLA, got %d", len(open))
+		}
+		stats, err := slas.Stats(ctx, autoA)
+		if err != nil {
+			t.Fatalf("sla stats: %v", err)
+		}
+		if stats.Open != 1 {
+			t.Fatalf("tenant B's two open trackers were counted into tenant A: open=%d", stats.Open)
+		}
+	})
+
+	t.Run("channels", func(t *testing.T) {
+		// The one that carries secrets. A missing predicate here hands another
+		// organisation's webhook endpoints to whoever opens the settings page.
+		cfg, err := channels.Get(ctx, autoA)
+		if err != nil {
+			t.Fatalf("get channels: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("tenant A must read back its own channel config")
+		}
+		if cfg.TenantID != autoA {
+			t.Fatalf("tenant %s's channel config reached tenant A", cfg.TenantID)
+		}
+		if cfg.SlackWebhookURL != "https://hooks.example/A" {
+			t.Fatalf("tenant A read the wrong webhook: %q", cfg.SlackWebhookURL)
+		}
+	})
+
+	t.Run("no_tenant_reads_as_empty_not_global", func(t *testing.T) {
+		list, err := rules.List(ctx, uuid.Nil)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if len(list) != 0 {
+			t.Fatalf("an unresolved tenant saw %d rules", len(list))
+		}
+		stats, err := slas.Stats(ctx, uuid.Nil)
+		if err != nil {
+			t.Fatalf("stats: %v", err)
+		}
+		if stats.Open != 0 {
+			t.Fatalf("an unresolved tenant saw %d open SLAs", stats.Open)
+		}
+	})
+}

--- a/backend/internal/infrastructure/repository/governance_collection_isolation_test.go
+++ b/backend/internal/infrastructure/repository/governance_collection_isolation_test.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// The /governance/* collection routes (#421).
+//
+// Nine unparameterised GETs — the audit trail and its export, the chain verdict,
+// the retention policy, delegations, effective permissions, workflows and
+// approvals — all reach the database through the three repositories below. The
+// handlers pass the caller's tenant from the signed token and nothing else, so
+// this is where a lost predicate would turn a list into every tenant's list.
+//
+// Shape, as everywhere in this sweep: seed the same qualifying row in two
+// tenants, ask as tenant A, prove tenant B's row is absent. The audit trail
+// matters most — it records who did what to whose data, so leaking it leaks the
+// shape of another organisation's operations even where the rows themselves
+// stayed put.
+
+var (
+	govA = uuid.MustParse("a0a0a0a0-0000-4000-8000-000000000001")
+	govB = uuid.MustParse("b0b0b0b0-0000-4000-8000-000000000002")
+)
+
+func newGovernanceDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, ddl := range []string{
+		`CREATE TABLE audit_events (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE delegations (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE approval_workflows (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE approval_requests (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE audit_chain_seals (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE audit_retention_policies (id TEXT PRIMARY KEY)`,
+	} {
+		if err := db.Exec(ddl).Error; err != nil {
+			t.Fatalf("create table: %v", err)
+		}
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"audit_events", &domain.AuditEvent{}},
+		{"delegations", &domain.Delegation{}},
+		{"approval_workflows", &domain.ApprovalWorkflow{}},
+		{"approval_requests", &domain.ApprovalRequest{}},
+		{"audit_chain_seals", &domain.AuditChainSeal{}},
+		{"audit_retention_policies", &domain.AuditRetentionPolicy{}},
+	} {
+		if err := sqliteschema.Reconcile(db, m.table, m.model); err != nil {
+			t.Fatalf("reconcile %s: %v", m.table, err)
+		}
+	}
+	return db
+}
+
+// TestGovernanceCollections_NeverCrossTenants covers GET /governance/audit-events,
+// /audit-events/export, /audit-retention, /delegations, /workflows and /approvals.
+func TestGovernanceCollections_NeverCrossTenants(t *testing.T) {
+	db := newGovernanceDB(t)
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+
+	events := NewGormAuditEventRepository(db)
+	chain := NewGormAuditChainRepository(db)
+	delegations := NewGormDelegationRepository(db)
+	approvals := NewGormApprovalRepository(db)
+	retention := NewGormAuditRetentionRepository(db)
+
+	// --- audit trail ------------------------------------------------------
+	// The SAME summary in both tenants: an assertion on counts alone would pass
+	// against a query that returns the wrong tenant's row, so the test also
+	// names the row it must never see.
+	for _, tenant := range []uuid.UUID{govA, govB} {
+		for i := 0; i < 2; i++ {
+			actor := uuid.New()
+			e := &domain.AuditEvent{
+				ID:       uuid.New(),
+				TenantID: tenant, ActorID: &actor,
+				Action: domain.AuditActionUpdate, EntityType: "risk",
+				EntityID: uuid.NewString(), Summary: "changed a risk in " + tenant.String(),
+			}
+			if err := events.Append(ctx, e); err != nil {
+				t.Fatalf("append audit event: %v", err)
+			}
+		}
+	}
+
+	t.Run("audit_events_list", func(t *testing.T) {
+		rows, total, err := events.List(ctx, govA, domain.AuditEventFilter{})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if total != 2 || len(rows) != 2 {
+			t.Fatalf("tenant A must see exactly its own 2 events, got total=%d rows=%d", total, len(rows))
+		}
+		for _, e := range rows {
+			if e.TenantID != govA {
+				t.Fatalf("tenant %s's audit event reached tenant A's trail", e.TenantID)
+			}
+		}
+	})
+
+	t.Run("audit_events_export_is_the_same_predicate", func(t *testing.T) {
+		// The export uses ListAll on the chain repository — an unpaginated read
+		// of the whole filtered trail. "Unpaginated" is exactly the shape where a
+		// missing predicate hands over everything, so it is asserted separately
+		// rather than assumed from the paginated list above.
+		all, err := chain.ListAll(ctx, govA, domain.AuditEventFilter{})
+		if err != nil {
+			t.Fatalf("list all: %v", err)
+		}
+		if len(all) != 2 {
+			t.Fatalf("export must carry tenant A's 2 events and no others, got %d", len(all))
+		}
+		for _, e := range all {
+			if e.TenantID != govA {
+				t.Fatalf("tenant %s's event was exported to tenant A", e.TenantID)
+			}
+		}
+	})
+
+	t.Run("audit_chain_verification_reads_one_tenants_seals", func(t *testing.T) {
+		// GET /governance/audit-events/verify walks this tenant's seals. A seal
+		// is the tamper-evidence anchor for a pruned segment, so reading another
+		// organisation's seal would make this tenant's chain verdict a statement
+		// about somebody else's trail.
+		//
+		// Both tenants are seeded, and the assertion names the count: a loop over
+		// an empty set proves nothing, which is what an un-seeded version of this
+		// test would have been.
+		for i, tenant := range []uuid.UUID{govA, govB, govB} {
+			if err := db.Create(&domain.AuditChainSeal{
+				ID: uuid.New(), TenantID: tenant,
+				Reason: "prune", FromSequence: 1, ToSequence: int64(i + 1),
+				PrunedCount: 1, LastHash: "hash", CreatedAt: now,
+			}).Error; err != nil {
+				t.Fatalf("seed seal: %v", err)
+			}
+		}
+		seals, err := chain.ListSeals(ctx, govA)
+		if err != nil {
+			t.Fatalf("list seals: %v", err)
+		}
+		if len(seals) != 1 {
+			t.Fatalf("tenant A owns one seal, got %d", len(seals))
+		}
+		if seals[0].TenantID != govA {
+			t.Fatalf("tenant %s's chain seal reached tenant A's verdict", seals[0].TenantID)
+		}
+	})
+
+	t.Run("audit_retention_policy", func(t *testing.T) {
+		for _, tenant := range []uuid.UUID{govA, govB} {
+			days := 90
+			if tenant == govB {
+				days = 3650
+			}
+			if err := retention.Upsert(ctx, &domain.AuditRetentionPolicy{
+				TenantID: tenant, RetentionDays: days,
+			}); err != nil {
+				t.Fatalf("upsert retention: %v", err)
+			}
+		}
+		// Read BOTH, and assert each gets its own number. Reading only one would
+		// pass against a query with no predicate whenever that tenant's row
+		// happened to be the first inserted.
+		pa, err := retention.Get(ctx, govA)
+		if err != nil {
+			t.Fatalf("get retention: %v", err)
+		}
+		if pa == nil || pa.RetentionDays != 90 {
+			t.Fatalf("tenant A must read its own 90-day policy, got %+v", pa)
+		}
+		pb, err := retention.Get(ctx, govB)
+		if err != nil {
+			t.Fatalf("get retention: %v", err)
+		}
+		if pb == nil || pb.RetentionDays != 3650 {
+			t.Fatalf("tenant B must read its own 3650-day policy, got %+v", pb)
+		}
+	})
+
+	// --- delegations ------------------------------------------------------
+	t.Run("delegations", func(t *testing.T) {
+		for _, tenant := range []uuid.UUID{govA, govB} {
+			d := &domain.Delegation{
+				ID: uuid.New(), TenantID: tenant,
+				DelegatorID: uuid.New(), DelegateID: uuid.New(),
+				Permissions: []string{"risks:read"},
+				Status:      domain.DelegationActive,
+				StartsAt:    now.AddDate(0, 0, -1), EndsAt: now.AddDate(0, 0, 30),
+			}
+			if err := delegations.Create(ctx, d); err != nil {
+				t.Fatalf("create delegation: %v", err)
+			}
+		}
+		list, err := delegations.List(ctx, govA, domain.DelegationFilter{})
+		if err != nil {
+			t.Fatalf("list delegations: %v", err)
+		}
+		if len(list) != 1 {
+			t.Fatalf("tenant A owns one delegation, got %d", len(list))
+		}
+		if list[0].TenantID != govA {
+			t.Fatal("another tenant's delegation reached tenant A")
+		}
+
+		// GET /governance/delegations/effective resolves through
+		// ActiveDelegationsTo, a second query with its own WHERE. A delegate id
+		// that exists in tenant B must resolve to nothing in tenant A.
+		bList, _ := delegations.List(ctx, govB, domain.DelegationFilter{})
+		if len(bList) != 1 {
+			t.Fatalf("fixture: tenant B must own one delegation, got %d", len(bList))
+		}
+		crossed, err := delegations.ActiveDelegationsTo(ctx, govA, bList[0].DelegateID, now)
+		if err != nil {
+			t.Fatalf("active delegations: %v", err)
+		}
+		if len(crossed) != 0 {
+			t.Fatal("tenant B's delegate resolved to permissions inside tenant A")
+		}
+	})
+
+	// --- approval workflows and requests ----------------------------------
+	t.Run("workflows_and_approvals", func(t *testing.T) {
+		for _, tenant := range []uuid.UUID{govA, govB} {
+			w := &domain.ApprovalWorkflow{
+				ID: uuid.New(), TenantID: tenant, Name: "risk sign-off",
+				EntityType: "risk", Action: "close", Enabled: true,
+			}
+			if err := approvals.CreateWorkflow(ctx, w); err != nil {
+				t.Fatalf("create workflow: %v", err)
+			}
+			r := &domain.ApprovalRequest{
+				ID: uuid.New(), TenantID: tenant,
+				EntityType: "risk", EntityID: uuid.NewString(),
+				Action: "close", Title: "close a risk",
+				Status: domain.ApprovalPending, RequestedBy: uuid.New(),
+			}
+			if err := approvals.CreateRequest(ctx, r); err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+		}
+
+		ws, err := approvals.ListWorkflows(ctx, govA)
+		if err != nil {
+			t.Fatalf("list workflows: %v", err)
+		}
+		if len(ws) != 1 || ws[0].TenantID != govA {
+			t.Fatalf("tenant A must see its own single workflow, got %d", len(ws))
+		}
+
+		rs, err := approvals.ListRequests(ctx, govA, domain.ApprovalRequestFilter{})
+		if err != nil {
+			t.Fatalf("list requests: %v", err)
+		}
+		if len(rs) != 1 || rs[0].TenantID != govA {
+			t.Fatalf("tenant A must see its own single approval request, got %d", len(rs))
+		}
+
+		// FindWorkflow is how a write decides whether sign-off is required. A
+		// workflow defined by another organisation must never route this one.
+		found, err := approvals.FindWorkflow(ctx, govA, "risk", "close")
+		if err != nil {
+			t.Fatalf("find workflow: %v", err)
+		}
+		if found == nil || found.TenantID != govA {
+			t.Fatalf("FindWorkflow returned %+v", found)
+		}
+	})
+
+	t.Run("no_tenant_reads_as_empty_not_global", func(t *testing.T) {
+		rows, total, err := events.List(ctx, uuid.Nil, domain.AuditEventFilter{})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if total != 0 || len(rows) != 0 {
+			t.Fatalf("an unresolved tenant must read the trail as empty, got %d", total)
+		}
+		// ListAll does not refuse a zero tenant, and does not need to: the
+		// predicate is still emitted, so uuid.Nil matches no row. What matters
+		// is that it reads as an EMPTY tenant and never as every tenant — the
+		// distinction the retired /timeline/recent got wrong.
+		all, err := chain.ListAll(ctx, uuid.Nil, domain.AuditEventFilter{})
+		if err != nil {
+			t.Fatalf("list all: %v", err)
+		}
+		if len(all) != 0 {
+			t.Fatalf("an unresolved tenant exported %d events", len(all))
+		}
+	})
+}

--- a/backend/internal/infrastructure/repository/notification_repository_test.go
+++ b/backend/internal/infrastructure/repository/notification_repository_test.go
@@ -171,3 +171,68 @@ func TestNotificationRepositoryPreferencesCreateAndUpdate(t *testing.T) {
 	require.Equal(t, 5, updated.EmailDeadlineAdvanceDays)
 	require.WithinDuration(t, time.Now(), updated.UpdatedAt, 2*time.Second)
 }
+
+// The two /notifications collection routes that the tests above did not reach
+// (#421). GET /notifications is covered by
+// TestNotificationRepositoryTenantIsolationReadAndDelete; the unread badge and
+// the preferences screen each run their own query, and a query that is not
+// asserted is not covered — the badge in particular is loaded on every page, so
+// a lost predicate there counts every tenant's unread notifications for
+// everyone.
+//
+// Both are keyed on (user_id, tenant_id): the same person legitimately belongs
+// to more than one organisation, so the user id alone is not the boundary. The
+// fixture therefore uses ONE user id in two tenants, which is the case a
+// user-only predicate would get wrong.
+func TestNotificationRepository_UnreadCountAndPreferences_AreTenantScoped(t *testing.T) {
+	repo := setupNotificationRepo(t)
+	userID := uuid.New()
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	insert := func(tenant uuid.UUID, subject string) {
+		require.NoError(t, repo.db.Table("notifications").Create(map[string]interface{}{
+			"id":         uuid.New().String(),
+			"user_id":    userID.String(),
+			"tenant_id":  tenant.String(),
+			"channel":    string(domain.NotificationChannelInApp),
+			"status":     string(domain.NotificationStatusPending),
+			"subject":    subject,
+			"created_at": time.Now(),
+			"updated_at": time.Now(),
+		}).Error)
+	}
+	insert(tenantA, "a-1")
+	for _, s := range []string{"b-1", "b-2", "b-3"} {
+		insert(tenantB, s)
+	}
+
+	countA, err := repo.GetUnreadCount(userID, tenantA)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), countA,
+		"tenant B's three unread notifications must not inflate tenant A's badge")
+
+	countB, err := repo.GetUnreadCount(userID, tenantB)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), countB)
+
+	countNone, err := repo.GetUnreadCount(userID, uuid.New())
+	require.NoError(t, err)
+	require.Equal(t, int64(0), countNone,
+		"a tenant the user has no notifications in must read zero, not everything")
+
+	// Preferences are per (user, tenant): the same person may want email in one
+	// organisation and nothing in another, and reading the wrong row would both
+	// leak a setting and mis-deliver.
+	require.NoError(t, repo.UpdateNotificationPreferences(userID, tenantA, map[string]interface{}{
+		"slack_enabled": true,
+	}))
+	prefsB, err := repo.GetUserNotificationPreferences(userID, tenantB)
+	require.NoError(t, err)
+	require.False(t, prefsB.SlackEnabled,
+		"tenant A's preference was read back inside tenant B")
+
+	prefsA, err := repo.GetUserNotificationPreferences(userID, tenantA)
+	require.NoError(t, err)
+	require.True(t, prefsA.SlackEnabled)
+}

--- a/backend/internal/security/isolation/coverage_test.go
+++ b/backend/internal/security/isolation/coverage_test.go
@@ -291,3 +291,97 @@ func TestIsolationGate_LegacyRecentTimelineIsRetired(t *testing.T) {
 		}
 	}
 }
+
+// genericEvidence is the string #412 stamped on every collection route when it
+// made them visible: a placeholder meaning "nobody has looked at this yet".
+//
+// #421 is the looking. This constant exists so the placeholder cannot come back
+// — not for the 97 routes it was written for, and not for the next module that
+// arrives in a hurry.
+const genericEvidence = "not assessed — collection route made visible by #412 criterion 9"
+
+// TestNoRouteCarriesTheGenericEvidenceString is #421 criterion 1.
+//
+// The registry's own rule is that a decision without a reason is
+// indistinguishable from a guess. TestEveryDecisionCarriesEvidence enforces that
+// SOME reason is present; this enforces that the reason is about this route.
+// A shared placeholder passes the first test and fails the purpose of both.
+//
+// Pending is still a legitimate status. What it may not be is anonymous: a
+// pending entry has to say what is unresolved and what would settle it, so the
+// next person can act on it without re-deriving the audit.
+func TestNoRouteCarriesTheGenericEvidenceString(t *testing.T) {
+	for _, d := range Decisions() {
+		if strings.Contains(d.Evidence, genericEvidence) {
+			t.Errorf("%s still carries the generic #412 placeholder. State what is "+
+				"specifically unresolved about THIS route and what would settle it.",
+				d.Pattern)
+		}
+	}
+}
+
+// TestCollectionGapsAreVisible is the counterpart to TestPendingGapsAreVisible,
+// for the surface that gate covers. Like it, it reports rather than fails:
+// turning acknowledged debt into a red build invites relabelling gaps as covered
+// to get green, which is the one outcome this registry exists to prevent.
+//
+// The count it logs is the honest residual — #421 criterion 6. Read it as the
+// number of collection routes whose isolation is reasoned about but not pinned
+// by a test, not as a number of known leaks.
+func TestCollectionGapsAreVisible(t *testing.T) {
+	counts := map[Status]int{}
+	var pending []string
+
+	all := collectionRoutes(t)
+	for _, r := range all {
+		d, ok := Lookup(r.Path)
+		if !ok {
+			continue // already reported by the collection gate
+		}
+		counts[d.Status]++
+		if d.Status == Pending {
+			pending = append(pending, r.String())
+		}
+	}
+
+	sort.Strings(pending)
+	t.Logf("isolation decisions across %d collection routes:", len(all))
+	for _, s := range []Status{Covered, Pending, PublicByDesign, MachineAuthenticated, SelfScoped, Unreachable} {
+		t.Logf("  %-22s %d", s, counts[s])
+	}
+	if len(pending) > 0 {
+		t.Logf("\n%d collection routes remain Pending — each states its own specific "+
+			"remainder in registry.go:", len(pending))
+		for _, p := range pending {
+			t.Logf("  %s", p)
+		}
+	}
+}
+
+// TestLookup_ExactPatternBeatsAWildcardOverTheSamePath pins the tie-break.
+//
+// A wildcard matches its own bare prefix, and it is the longer string, so the
+// original length-only comparison gave GET /api/v1/risks to /api/v1/risks/* and
+// discarded the exact entry written for it. The route was assessed, carried its
+// own decision, and still reported as unassessed — the failure mode this whole
+// registry exists to make impossible.
+//
+// This is asserted on the live registry rather than on a fixture, because the
+// value of the rule is that it holds for the entries actually recorded.
+func TestLookup_ExactPatternBeatsAWildcardOverTheSamePath(t *testing.T) {
+	for _, d := range Decisions() {
+		if strings.HasSuffix(d.Pattern, "/*") {
+			continue
+		}
+		got, ok := Lookup(d.Pattern)
+		if !ok {
+			t.Errorf("%s matches no decision, including its own", d.Pattern)
+			continue
+		}
+		if got.Pattern != d.Pattern {
+			t.Errorf("Lookup(%q) resolved to %q — a module-wide pattern is answering "+
+				"for a route that carries its own entry, so that entry is dead text",
+				d.Pattern, got.Pattern)
+		}
+	}
+}

--- a/backend/internal/security/isolation/registry.go
+++ b/backend/internal/security/isolation/registry.go
@@ -288,47 +288,270 @@ var decisions = []Decision{
 	{"/api/v1/gamification/me", SelfScoped, "the caller's own score and streak, keyed on the token's user id"},
 	{"/api/v1/ownership/me", SelfScoped, "the caller's own ownership assignments, keyed on the token's user id"},
 
-	// --- Not assessed. Visible debt, not a safety claim. -------------------
+	// --- Assessed, #421 -----------------------------------------------------
 	//
-	// Each of these returns a list. If any has lost its WHERE tenant_id, it
-	// returns every tenant's rows to whoever loads the page — the /timeline/recent
-	// shape. They are grouped by module so the remaining work is countable;
-	// tracked as #412's honest remainder rather than asserted to be safe.
-	{"/api/v1/activation/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/analytics/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/asset-dependencies", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/assets", Pending, "not assessed — collection route made visible by #412 criterion 9; this is the asset inventory list, one of the largest tenant collections in the product"},
-	{"/api/v1/ownership/assignable", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/assets/statistics", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/attack-surface/draft-risks", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/attack-surface/risk-rule", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/attack-surface/schemas", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/attack-surface/topology", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/attack-surface/topology/edge-types", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/auth/organizations", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/auth/pat", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/auth/sessions", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/automation/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/billing/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/bulk-operations", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/cti/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/dashboard/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/entitlements/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/export/pdf", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/invitations/preview", Pending, "not assessed — pre-authentication token preview; needs a decision on whether the token alone is sufficient addressing"},
-	{"/api/v1/notifications/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/onboarding/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/organization/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/realtime/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/reports/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/risk-categories", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/risk-scoring/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/score/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/search", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/security/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/stats/*", Pending, "not assessed — collection route made visible by #412 criterion 9; these return tenant statistics and are the same shape as the route that leaked"},
-	{"/api/v1/telemetry/*", Pending, "not assessed — collection route made visible by #412 criterion 9"},
-	{"/api/v1/vulnerability-connectors", Pending, "not assessed — collection route made visible by #412 criterion 9"},
+	// The 97 entries below replace one generic string that said, of every
+	// collection route in the product, "not assessed". Each one now names the
+	// query behind the route and either the test that pins it or the specific
+	// thing that is still open. The two are not interchangeable: a Covered entry
+	// names a test that seeds a SECOND tenant and asserts its rows are absent,
+	// and a Pending entry states what is unresolved and what would settle it.
+	//
+	// One route was found to be leaking and is recorded as such below, not
+	// quietly fixed and not quietly filed: GET /api/v1/audit-logs. See #532.
+	//
+	// The new tests written for this sweep were each validated by sabotage — the
+	// tenant predicate was removed from the query under test and the test was
+	// confirmed to fail. A cross-tenant test that passes against an unscoped
+	// query is worse than no test, because it is read as coverage.
+
+	// --- Governance (9) ---------------------------------------------------
+	// All nine reach the database through GormAuditEventRepository,
+	// GormAuditChainRepository, GormDelegationRepository, GormApprovalRepository
+	// or GormAuditRetentionRepository. Every one of those puts tenant_id in the
+	// WHERE clause, and the handler passes only the tenant from the signed token.
+	{"/api/v1/governance/audit-events", Covered,
+		"repository/governance_collection_isolation_test TestGovernanceCollections_NeverCrossTenants/audit_events_list seeds the same event in two tenants and asserts the caller sees only its own two"},
+	{"/api/v1/governance/audit-events/export", Covered,
+		"the export is UNPAGINATED (ListAll), the shape where a lost predicate hands over everything at once, so it is asserted separately from the paginated list: TestGovernanceCollections_NeverCrossTenants/audit_events_export_is_the_same_predicate"},
+	{"/api/v1/governance/audit-events/verify", Covered,
+		"walks this tenant's chain seals; TestGovernanceCollections_NeverCrossTenants/audit_chain_verification_reads_one_tenants_seals seeds seals in both tenants and asserts the verdict is built from one tenant's alone — reading another organisation's seal would make this tenant's tamper verdict a statement about somebody else's trail"},
+	{"/api/v1/governance/audit-retention", Covered,
+		"TestGovernanceCollections_NeverCrossTenants/audit_retention_policy writes a different retention window in each tenant and reads BOTH back — reading only one would pass against an unscoped Take() whenever that tenant's row happened to be inserted first"},
+	{"/api/v1/governance/delegations", Covered,
+		"TestGovernanceCollections_NeverCrossTenants/delegations: one delegation per tenant, and tenant A's listing contains only its own"},
+	{"/api/v1/governance/delegations/effective", Covered,
+		"resolves through ActiveDelegationsTo, a second query with its own WHERE; the same subtest asks tenant A to resolve a delegate id that exists only in tenant B and asserts it grants nothing. NOTE: the delegate_id query parameter lets a caller resolve ANOTHER USER's effective permissions inside their own tenant — that is an intra-tenant authorisation question, not a cross-tenant one, and is out of this issue's scope"},
+	{"/api/v1/governance/workflows", Covered,
+		"TestGovernanceCollections_NeverCrossTenants/workflows_and_approvals asserts both ListWorkflows and FindWorkflow — the latter is what decides whether a write needs sign-off, so another organisation's workflow routing this one would be a control failure as well as a disclosure"},
+	{"/api/v1/governance/approvals", Covered,
+		"TestGovernanceCollections_NeverCrossTenants/workflows_and_approvals: ListRequests returns tenant A's single request and not tenant B's"},
+	{"/api/v1/governance/request-types", PublicByDesign,
+		"returns domain.ApprovalRequestTypes(), a compiled-in vocabulary of decision kinds. It touches no table, so there is no row that could belong to a tenant"},
+
+	// --- Analytics (8) ----------------------------------------------------
+	// Every query runs through AnalyticsService.scoped(), which is
+	// `db.Where(\"tenant_id = ?\", tenantID)`. The handler takes the tenant from
+	// middleware.GetContext and nothing else.
+	{"/api/v1/analytics/risks/metrics", Covered,
+		"service/analytics_service_test TestAnalyticsService_GetRiskMetrics_TenantIsolation — the regression test for the leak where this service aggregated across ALL tenants"},
+	{"/api/v1/analytics/risks/trends", Covered,
+		"service/collection_routes_isolation_test TestAnalyticsCollections_NeverCrossTenants/risk_trends: tenant A owns one risk and tenant B three, and the last bucket's running total and average score are both over tenant A's register alone"},
+	{"/api/v1/analytics/mitigations/metrics", Covered,
+		"TestAnalyticsCollections_NeverCrossTenants/mitigation_metrics asserts in both directions — tenant B's completions are not counted as tenant A's, and tenant A's in-progress plan is not counted as tenant B's"},
+	{"/api/v1/analytics/frameworks", Covered,
+		"TestAnalyticsCollections_NeverCrossTenants/frameworks: the per-framework risk count sums to the tenant's own total"},
+	{"/api/v1/analytics/dashboard", Covered,
+		"TestAnalyticsCollections_NeverCrossTenants/dashboard_snapshot_and_export composes the four aggregates above and asserts the composed answer, rather than inferring it from its parts"},
+	{"/api/v1/analytics/export", Covered,
+		"the export handler calls GetDashboardSnapshot and re-encodes it, so it is the same object and the same assertion: TestAnalyticsCollections_NeverCrossTenants/dashboard_snapshot_and_export"},
+	{"/api/v1/analytics/financial", Pending,
+		"assessed, not pinned: GetFinancialSummary passes mwCtx.OrganizationID into FinancialSummaryUseCase.Execute and the request cannot influence it. What is unresolved is every query BELOW that call — the CRQ aggregation reads risks and their monetary drivers through its own path, which this sweep did not read. Settled by a two-tenant test over FinancialSummaryUseCase.Execute in the shape of TestAnalyticsCollections_NeverCrossTenants"},
+	{"/api/v1/analytics/executive", Pending,
+		"assessed, not pinned: the handler passes only the token's tenant, and the use case composes six sources (financial summary, risk repo, gap analysis, vuln repo, incident service, quantifier) that are individually tenant-scoped elsewhere. Unresolved: no test asserts the COMPOSED board, and a composition is exactly where one un-scoped source hides behind five scoped ones. Settled by a two-tenant test over ExecutiveDashboardUseCase.Execute asserting each section, not just the total"},
+
+	// --- Automation (8) ---------------------------------------------------
+	{"/api/v1/automation/rules", Covered,
+		"repository/automation_collection_isolation_test TestAutomationCollections_NeverCrossTenants/rules asserts both List and ListEnabledByTrigger — the latter is what the engine consults on every event, so a leak there would run another tenant's rules against this tenant's data"},
+	{"/api/v1/automation/executions", Covered,
+		"TestAutomationCollections_NeverCrossTenants/executions: the run history is what fired, against which entity, and when — tenant A sees one row, tenant B's two are absent"},
+	{"/api/v1/automation/sla", Covered,
+		"TestAutomationCollections_NeverCrossTenants/sla_and_stats (ListOpen branch)"},
+	{"/api/v1/automation/sla/stats", Covered,
+		"TestAutomationCollections_NeverCrossTenants/sla_and_stats: the grouped count is over the caller's trackers alone"},
+	{"/api/v1/automation/channels", Covered,
+		"the one that carries secrets — a lost predicate here hands another organisation's webhook endpoints to whoever opens the settings page. TestAutomationCollections_NeverCrossTenants/channels seeds a distinct webhook URL per tenant and asserts the caller reads its own"},
+	{"/api/v1/automation/channels/catalogue", Covered,
+		"ChannelService.ConfiguredChannels resolves through the same GormAutomationChannelRepository.Get asserted by TestAutomationCollections_NeverCrossTenants/channels; the rest of the response is domain.AllAutomationChannels(), a compiled-in list"},
+	{"/api/v1/automation/state", Covered,
+		"RuleService.State is computed from the same tenant-scoped List asserted by TestAutomationCollections_NeverCrossTenants/rules"},
+	{"/api/v1/automation/templates", PublicByDesign,
+		"renders domain.AutomationTemplates(), a compiled-in playbook catalogue, into sentences. No table is read, so no tenant owns any of it — the same reasoning as the /templates/{id}/adopt entry above"},
+
+	// --- Dashboard (7) ----------------------------------------------------
+	// DashboardDataService.scoped() is the same `Where(\"tenant_id = ?\")` shape as
+	// AnalyticsService.
+	{"/api/v1/dashboard/metrics", Covered,
+		"service/collection_routes_isolation_test TestDashboardCollections_NeverCrossTenants/metrics: tenant B's three risks are absent from tenant A's KPI tiles"},
+	{"/api/v1/dashboard/risk-trends", Covered,
+		"TestDashboardCollections_NeverCrossTenants/risk_trends"},
+	{"/api/v1/dashboard/severity-distribution", Covered,
+		"service/analytics_service_test TestDashboardDataService_SeverityDistribution_TenantIsolation. NOTE: this query filters on a `severity` column domain.Risk does not declare, so in production the GORM error is swallowed and every band reads zero. That is a counting defect, not an isolation defect — an endpoint that answers zero cannot leak — and it is out of #421's scope"},
+	{"/api/v1/dashboard/mitigation-status", Covered,
+		"TestDashboardCollections_NeverCrossTenants/mitigation_status asserts both directions. Same caveat as severity-distribution: the query matches lowercase status strings ('completed', 'in_progress') while the domain vocabulary is uppercase ('DONE', 'IN_PROGRESS'), so the tiles read zero in production. The test seeds what the query matches, because a counter stuck at zero cannot prove a predicate holds"},
+	{"/api/v1/dashboard/mitigation-progress", Covered,
+		"TestDashboardCollections_NeverCrossTenants/mitigation_progress"},
+	{"/api/v1/dashboard/top-risks", Pending,
+		"NOT a tenant-isolation gap and not claimable as covered either: GetTopRisks calls Preload(\"Team\") on domain.Risk, which declares no Team relation, so GORM refuses the query before it runs and this route answers 500 in every tenant on every request. There is no observable result to make an isolation claim about. TestDashboardCollections_NeverCrossTenants/top_risks_cannot_execute pins that refusal so the two facts stay linked. Settled by fixing the preload and then writing the isolation assertion the route will need — the tenant predicate is applied by scoped() before the preload, but that is unverified because the query cannot execute"},
+	{"/api/v1/dashboard/complete", Pending,
+		"composes the widgets above, GetTopRisks included, so it inherits that refusal wholesale and answers 500. TestDashboardCollections_NeverCrossTenants/complete_cannot_execute. Settled by the same fix"},
+
+	// --- Organization (7) -------------------------------------------------
+	{"/api/v1/organization/members", Covered,
+		"repository/gorm_membership_repository_test TestMembershipRepo_ListMembers_TenantIsolationAndFilters: four members across two tenants, and the search filter is asserted not to cross the boundary either — searching for the other tenant's member by name returns nothing"},
+	{"/api/v1/organization/invitations", Covered,
+		"repository/gorm_membership_repository_test TestMembershipRepo_Invitations_TenantIsolation"},
+	{"/api/v1/organization/counts", Covered,
+		"repository/gorm_membership_repository_test TestMembershipRepo_Counts asserts tenant B's numbers are its own — a shared counter is how a sidebar leaks"},
+	{"/api/v1/organization/members/audit", Covered,
+		"Service.MembershipAudit reads through the same AuditEventRepository.List asserted by TestGovernanceCollections_NeverCrossTenants/audit_events_list, with an entity-type allowlist applied on top; the tenant comes from the token"},
+	{"/api/v1/organization", Pending,
+		"assessed, not pinned: GetOrganization refuses uuid.Nil with ErrUnauthorized and then reads orgs.GetByID(ctx, tenantID), keyed on the organisation's own primary key taken from the token — there is no id in the request to forge. Unresolved: no test asserts that a second organisation's row cannot come back. Settled by a two-tenant assertion on the organisation directory's GetByID"},
+	{"/api/v1/organization/deletion", Pending,
+		"assessed, not pinned: GetActive(ctx, tenantID(c)) with the tenant from the token. Unresolved: the orgdeletion store's query was not read in this sweep. Settled by a two-tenant test asserting one organisation's pending deletion request is invisible to another"},
+	{"/api/v1/organization/export", Pending,
+		"assessed, not pinned, and the highest-value single response in the product: Exporter.Export(ctx, tenantID(c)) writes a whole-organisation bundle to a file and serves it. Unresolved: the exporter walks many tables and this sweep did not read each one's predicate. Settled by a two-tenant test that seeds rows in both and asserts NO tenant B identifier appears anywhere in tenant A's bundle — asserted over the bundle's bytes, not over the row counts"},
+
+	// --- Stats (6) --------------------------------------------------------
+	// Named by #421 as the place to start, and rightly: unparameterised GETs
+	// that aggregate a whole table for the dashboard. All six carry
+	// `tenant_id = ?`, and all six now have an HTTP-level two-tenant test that
+	// drives the real handler over the real tenant resolution.
+	{"/api/v1/stats", Covered,
+		"handler/dashboard_stats_test TestDashboardStats_IsTenantScopedIncludingTheTrend; GetDashboardStats also fails CLOSED with 401 when no tenant resolves, rather than querying every tenant"},
+	{"/api/v1/stats/risk-matrix", Covered,
+		"handler/stats_collection_isolation_test TestStatsCollections_NeverCrossTenants/risk_matrix"},
+	{"/api/v1/stats/risk-distribution", Covered,
+		"TestStatsCollections_NeverCrossTenants/risk_distribution"},
+	{"/api/v1/stats/mitigation-metrics", Covered,
+		"TestStatsCollections_NeverCrossTenants/mitigation_metrics"},
+	{"/api/v1/stats/top-vulnerabilities", Covered,
+		"TestStatsCollections_NeverCrossTenants/top_vulnerabilities"},
+	{"/api/v1/stats/trends", Covered,
+		"TestStatsCollections_NeverCrossTenants/trends asserts the AVERAGE, not just the count: tenant B's scores would move it, so an unscoped query cannot produce tenant A's number by accident"},
+
+	// --- RBAC (5) ---------------------------------------------------------
+	{"/api/v1/rbac/tenants", SelfScoped,
+		"lists the organisations the CALLER belongs to: UserService.GetUserTenants filters on the token's user id, and each tenant is then fetched by an id that came out of that user's own memberships. The request carries no tenant"},
+	{"/api/v1/rbac/business-roles", PublicByDesign,
+		"returns domain.PermissionCatalog and domain.ListBusinessRoles(), both compiled in. No table is read"},
+	{"/api/v1/rbac/users", Pending,
+		"assessed, not pinned: UserService.GetTenantUsers puts `tenant_id = ?` in both the count and the page query, and the handler takes the tenant from c.Locals(\"tenantID\"), set by the auth middleware from the JWT. Unresolved: no test seeds a second tenant. Settled by a two-tenant assertion on GetTenantUsers"},
+	{"/api/v1/rbac/users/stats", Pending,
+		"same query as /rbac/users (GetTenantUsers with limit 1, read for its total) and the same gap. Settled by the same test"},
+	{"/api/v1/rbac/roles", Pending,
+		"assessed, not pinned, and the predicate is deliberately WIDER than tenant_id: RoleService.ListRoles matches `(tenant_id = ? OR is_predefined = true)`, so the built-in roles are shared across the deployment by design while custom roles are not. Unresolved: nothing asserts that a role belonging to another tenant and NOT marked predefined is absent, which is the case the OR branch could mask. Settled by a two-tenant test that seeds one predefined role and one custom role per tenant"},
+
+	// --- Notifications (3) ------------------------------------------------
+	// All three key on (user_id, tenant_id). The pair matters: the same person
+	// legitimately belongs to several organisations, so the user id alone is not
+	// the boundary.
+	{"/api/v1/notifications", Covered,
+		"repository/notification_repository_test TestNotificationRepositoryTenantIsolationReadAndDelete seeds one user in two tenants and asserts the listing carries one tenant's row"},
+	{"/api/v1/notifications/unread-count", Covered,
+		"repository/notification_repository_test TestNotificationRepository_UnreadCountAndPreferences_AreTenantScoped — the badge is loaded on every page, so a lost predicate here would count every tenant's unread notifications for everyone"},
+	{"/api/v1/notifications/preferences", Covered,
+		"same test: a preference written in one tenant must not read back in another, which would both disclose a setting and mis-deliver"},
+
+	// --- Realtime (3) -----------------------------------------------------
+	{"/api/v1/realtime/catalog", PublicByDesign,
+		"the event catalogue, envelope version and transport limits — all compiled in. No tenant row is read"},
+	{"/api/v1/realtime/events", Covered,
+		"the SSE stream fails CLOSED on a zero tenant (401 rather than an unfiltered subscription), narrows the client's requested categories to what its permissions allow, and replays from a per-tenant durable log: repository/gorm_realtime_event_repository_test TestRealtimeRepo_ReplayNeverCrossesTheTenantBoundary and TestRealtimeRepo_ReplayFailsClosedWithoutATenant, plus handler/realtime_stream_e2e_test over the real stack"},
+	{"/api/v1/realtime/stats", Pending,
+		"no tenant ROWS leak, and that is not the whole question: alongside this tenant's own connection count the response carries the hub's DEPLOYMENT-WIDE counters — total connections, number of distinct tenants connected, buffered events. Any admin of any organisation can read how many other organisations are online. Unresolved: whether a tenant administrator may see deployment cardinality at all. Settled either by gating the route to a platform operator rather than the tenant's own admin role, or by dropping the three global fields and keeping tenant_connections"},
+
+	// --- Reports (3) ------------------------------------------------------
+	{"/api/v1/reports", Covered,
+		"repository/gorm_report_repository_test TestReportRepo_TenantIsolation (List branch): the other tenant's listing is empty and its total is zero. A report is a document about a whole register, so one crossing the boundary discloses the register at once"},
+	{"/api/v1/reports/jobs", Covered,
+		"repository/gorm_report_job_repository_test TestReportJob_List_ScopedToTenant"},
+	{"/api/v1/reports/types", PublicByDesign,
+		"the report catalogue: template keys, versions, titles and formats, all compiled in and localised. No table is read"},
+
+	// --- CTI (2) ----------------------------------------------------------
+	{"/api/v1/cti/vulnerabilities", PublicByDesign,
+		"the NVD/CISA feed is global threat intelligence, not tenant-owned — the same reasoning already recorded for /cti/vulnerabilities/{id}. Nothing in the response is derived from a tenant's data"},
+	{"/api/v1/cti/stats", PublicByDesign,
+		"three of the four counters are over the global CTI feed. The fourth — risks this tenant auto-created from CTI — IS tenant-scoped, on `tenant_id = ? AND source = 'cti_auto'`, and is computed only when the tenant local resolves, so an unresolved tenant yields zero rather than a global count"},
+
+	// --- Mitigations (2) --------------------------------------------------
+	{"/api/v1/mitigations", Pending,
+		"assessed, not pinned: the handler refuses a zero tenant with 401 before touching the repository, and GormMitigationRepository.List opens with `tenant_id = ? AND deleted_at IS NULL` before any filter is applied. The `mine=true` filter takes the user from the authenticated context, so \"mine=<someone else>\" is not expressible. Unresolved: no test seeds a second tenant, and the filters are applied by string key onto the same query, which is where a future filter could widen it. Settled by a two-tenant test over List with each filter exercised"},
+	{"/api/v1/mitigations/events", Pending,
+		"assessed, not pinned, and structurally different from every other entry here: an SSE stream over a SHARED Redis channel (mitigation.auto_completed), filtered in Go per message on `evt.TenantID != tenantID`, with the tenant taken from a JWT validated out of the query string. The isolation is a comparison in the handler, not a WHERE clause — so a malformed payload that fails to unmarshal is skipped, but a payload published without a TenantID would compare against uuid.Nil. Unresolved: nothing asserts the filter. Settled by a test that publishes two tenants' events onto a stub bus and asserts one subscriber receives only its own"},
+
+	// --- Onboarding and activation (3) ------------------------------------
+	{"/api/v1/onboarding/state", Pending,
+		"assessed, not pinned: the handler resolves (tenant, user) together and returns 401 unless both are present, then reads per (tenant, user). Unresolved: repository/gorm_activation_repository_test TestOnboardingProgress_MissingAndIsolated asserts a cross-tenant GET of the progress row reads back nil, but the STATE endpoint composes that row with counts drawn from other tables which this sweep did not read. Settled by a two-tenant test over onboarding.GetState asserting every composed field"},
+	{"/api/v1/onboarding/suggestions", Pending,
+		"assessed, not pinned: same (tenant, user) gate as /onboarding/state. The industry/country/goal query parameters steer a compiled-in suggestion set rather than a query. Unresolved: whether any part of the suggestion is computed from tenant rows. Settled by reading GetSuggestions' sources and asserting the tenant-derived ones"},
+	{"/api/v1/activation/state", Pending,
+		"assessed, not pinned: same (tenant, user) gate, 401 when either is missing. Unresolved: the activation state aggregates progress across several modules and this sweep did not read each source. Settled by a two-tenant test over the activation state use case"},
+
+	// --- Risks and scoring (5) --------------------------------------------
+	{"/api/v1/risks", Covered,
+		"handler/risk_isolation_test TestRiskIsolation_ListLeaksNothing drives GET /risks over the real handler and repository from one tenant against another's register; TestRiskIsolation_NilTenantIsDenied covers the unresolved-tenant case"},
+	{"/api/v1/risks/unmapped", Pending,
+		"assessed, not pinned: ListUnmapped takes the tenant from the token, and repository/gorm_risk_taxonomy_repository_test TestRiskControlMappingRepo_EnrichesAndScopesToTenant covers the mapping repository's scoping generally. Unresolved: TestRiskControlMappingRepo_UnmappedExcludesMappedAndClosed asserts WHICH risks are unmapped but does not seed a second tenant, so the tenant predicate on THIS query is untested. Settled by adding a second tenant to that test"},
+	{"/api/v1/risk-categories", Pending,
+		"assessed, not pinned: GormRiskCategoryRepository.List opens with `tenant_id = ?`, and TestRiskCategoryRepo_SlugIsUniquePerTenantOnly proves the table holds two tenants' categories at once. Unresolved: no test reads the list as one tenant while the other's categories exist — TestRiskCategoryRepo_ListHidesInactiveByDefault seeds a single tenant. Settled by adding a second tenant's category to that test and asserting it is absent"},
+	{"/api/v1/risk-scoring/weights", Pending,
+		"assessed, not pinned: the handler passes mwCtx.OrganizationID (uuid.Nil when absent) into GetRiskWeights. Unresolved: whether the weights store falls back to a shared default row on a miss, which would be correct behaviour but must not be reachable by passing a zero tenant. Settled by a two-tenant test that also asserts what uuid.Nil returns"},
+	{"/api/v1/score", Pending,
+		"assessed, not pinned: fails CLOSED with 401 on uuid.Nil before anything is read, and the optional `id` query parameter is scoped by the `scope` vocabulary (tenant|risk|asset). Unresolved: for scope=risk and scope=asset the id names a record, so this route has a parameterised route's IDOR surface in a query string — the shape this gate does not model. Settled by a test that asks, as tenant A with scope=risk, for a risk id belonging to tenant B and asserts not-found"},
+	{"/api/v1/score/model", PublicByDesign,
+		"returns scoring.Describe() — the frozen formula, its bands and its factor names. Requires a session (401 on a zero tenant) but reads no table, so there is nothing tenant-owned in the response"},
+
+	// --- Assets and attack surface (7) ------------------------------------
+	{"/api/v1/assets", Covered,
+		"the inventory list, one of the largest tenant collections in the product. ListAssetsUseCase.Search delegates to GormAssetRepository.List, which is `Where(\"tenant_id = ?\")`; repository/gorm_asset_repository_test TestAssetRepository_List_ScopedToTenant seeds both tenants and asserts each sees only its own. The category and attr.* filters are applied in memory AFTER that scoped read, so they can only narrow it"},
+	{"/api/v1/assets/statistics", Covered,
+		"repository/gorm_asset_statistics_test TestAssetStatistics_IsTenantScoped, plus TestAssetStatistics_RefusesWithoutTenant — the repository refuses uuid.Nil outright rather than emitting a predicate that matches nothing"},
+	{"/api/v1/asset-dependencies", Covered,
+		"repository/gorm_asset_dependency_repository_test TestDepRepo_CreateAndListByTenant_Isolation"},
+	{"/api/v1/attack-surface/topology/edge-types", PublicByDesign,
+		"returns domain.TopologyEdgeTypes, a compiled-in vocabulary of edge kinds. No table is read"},
+	{"/api/v1/attack-surface/topology", Pending,
+		"assessed, not pinned: GetTopologyUseCase refuses uuid.Nil with ErrForbidden, then builds the graph from assets.List(tenant) and deps.ListByTenant(tenant) — both of which ARE covered by the two tests named on /assets and /asset-dependencies above. Unresolved: the graph is assembled from those two reads plus further sources this sweep did not enumerate, and a node that entered the graph from an unscoped source would not be caught by testing its inputs. Settled by a two-tenant test over GetTopologyUseCase.Execute asserting no foreign node or edge id appears"},
+	{"/api/v1/attack-surface/schemas", Pending,
+		"assessed, not pinned: GormAssetSchemaRepository carries tenant_id in every query, and the per-category sibling /attack-surface/schemas/{id} is already recorded Covered on that basis. Unresolved: the LIST query has no test of its own. Settled by extending the assetschema test to seed a schema in a second tenant and assert the listing omits it"},
+	{"/api/v1/attack-surface/risk-rule", Pending,
+		"assessed, not pinned: GormVulnRiskRuleRepository.Get is `Where(\"tenant_id = ?\").First(...)`, one rule per tenant. Unresolved: First() on an unscoped query returns an arbitrary row, so this is precisely the shape where a single-row read hides a missing predicate behind plausible output. Settled by a two-tenant test that writes a DIFFERENT rule in each and asserts each reads back its own"},
+	{"/api/v1/attack-surface/draft-risks", Pending,
+		"assessed, not pinned: ListDrafts passes the token's tenant into a paginated draft listing. Unresolved: the draft store's query was not read in this sweep, and the page/limit parameters are taken from the query string without an upper bound, so an unscoped version would be enumerable in bulk. Settled by a two-tenant test over the draft list"},
+
+	// --- Audit logs (1) — CONFIRMED CROSS-TENANT LEAK ---------------------
+	{"/api/v1/audit-logs", Pending,
+		"LEAKING. Not a gap in coverage — a gap in the data model. domain.AuditLog carries NO tenant_id column, and AuditService.GetAuditLogsByDateRange filters on `timestamp BETWEEN ? AND ?` alone, so this route returns the authentication and authorization log of EVERY tenant in the deployment: user ids, IP addresses, actions, resource ids, error messages, user agents. The adminRole guard asks whether the caller is an admin of their OWN organisation, which every customer's admin is; it gates who may call, not whose rows come back. This is the /timeline/recent shape (docs/JOURNAL.md item 36) and for the same underlying reason — a journal table with no tenant column. Filed as its own P0: #532. Settled by that issue: a tenant_id column, a migration, the predicate on all four read queries, a stated fail-closed rule for pre-auth events, and a two-tenant test"},
+
+	// --- Caller's own identity (5) ----------------------------------------
+	{"/api/v1/auth/organizations", SelfScoped,
+		"lists the organisations the caller belongs to, keyed on mwCtx.UserID from the signed token; returns 401 rather than a global list when no user resolves. There is no tenant in the request to forge"},
+	{"/api/v1/auth/sessions", SelfScoped,
+		"the caller's own devices, keyed on mwCtx.UserID from the token; 401 when absent. The revoke sibling is already recorded SelfScoped with its cross-user test (TestRevoke_CrossUser_IsNotFound)"},
+	{"/api/v1/auth/pat", SelfScoped,
+		"ListUserTokens(callerUserID) — the caller's own personal access tokens, keyed on the token's user id; 401 when absent"},
+	{"/api/v1/tokens", SelfScoped,
+		"TokenService.ListTokens(callerUserID) — the caller's own API tokens. Note this listing is scoped by USER and not by tenant, so a person who belongs to two organisations sees all their own tokens in one list regardless of the session's organisation. That is a deliberate consequence of tokens belonging to a person rather than to a membership; it discloses nothing across the tenant boundary, because the person owns every row either way"},
+	{"/api/v1/ownership/assignable", Pending,
+		"assessed, not pinned: ListAssignableUseCase refuses uuid.Nil with ErrValidation and reads members.ListMembers(ctx, tenantID); the search, permission and only_capable filters narrow that set in memory afterwards. Unresolved: this is a DIFFERENT ListMembers from the paginated one covered by TestMembershipRepo_ListMembers_TenantIsolationAndFilters, so that test does not reach it. Settled by a two-tenant assertion on the unpaginated ListMembers"},
+
+	// --- Public / pre-authentication (3) ----------------------------------
+	{"/api/v1/invitations/preview", PublicByDesign,
+		"mounted outside the JWT gate on purpose, so an invitee with no account can see what they were invited to. Addressed by the invitation TOKEN and nothing else — there is no tenant in the request, and the response is derived from the row that token resolves to. The decision this replaces asked whether the token alone is sufficient addressing: it is, on the same basis as the webhook entries above — the token IS the credential, it is single-use, and it names exactly one invitation"},
+	{"/api/v1/ai/status", PublicByDesign,
+		"reports whether this DEPLOYMENT has an LLM backend and which model. No table is read and no tenant appears in the answer"},
+	{"/api/v1/vulnerability-connectors", PublicByDesign,
+		"returns vulnscan.Connectors(), the compiled-in list of connector kinds this build supports. Reads no table"},
+
+	// --- Remaining single routes (7) --------------------------------------
+	{"/api/v1/export/pdf", Covered,
+		"handler/stats_collection_isolation_test TestStatsCollections_NeverCrossTenants/export_pdf inflates the generated document's content streams and asserts no other tenant's risk title was rendered into it — the assertion is on the artifact the user receives, because that is where this leak would be real"},
+	{"/api/v1/bulk-operations", Covered,
+		"service/bulk_operation_isolation_test TestBulkOperation_ListIsTenantScoped"},
+	{"/api/v1/security/mfa-policy", Covered,
+		"repository/gorm_mfa_policy_repository_test TestMFAPolicyRepo_IsTenantScoped, with TestMFAPolicyRepo_UnsavedTenantReadsAsNil and TestMFAPolicyRepo_RefusesOutOfRangeAndMissingTenant covering the empty and zero-tenant cases"},
+	{"/api/v1/search", Pending,
+		"assessed, not pinned, and the broadest single read in the product: one query fans out to risks, assets, vulnerabilities, controls, audits, board reports and users. It refuses uuid.Nil before dispatching anything (application/search TestGlobalSearch_NilTenant) and every source port takes tenantID. Unresolved: TestGlobalSearch_* runs against stub sources, so it proves the fan-out passes the tenant along and proves nothing about the seven real queries behind it. Settled by a two-tenant test against the real repositories — and it is worth doing here rather than per-source, because search is where one un-scoped source out of seven would be least visible"},
+	{"/api/v1/reports/board", Pending,
+		"assessed, not pinned: BoardReportHandler.List passes tenantID(c) into the use case, and GormBoardReportRepository is described as tenant-scoped by the existing /reports/board/{id} entry. Unresolved: neither the parameterised route nor this one has a test — the {id} entry says so itself. Settled by one two-tenant test over the board report repository covering GetByID and List together"},
+	{"/api/v1/billing", Pending,
+		"assessed, not pinned: BillingService.Get(ctx, tenantID(c)) returns the subscription and INVOICES for the tenant taken from the token. Unresolved: invoices are financial records of another company, so this is a high-consequence list with no test; the billing store's query was not read in this sweep. Settled by a two-tenant test asserting neither the subscription nor any invoice of the other organisation is returned"},
+	{"/api/v1/entitlements", Pending,
+		"assessed, not pinned: EntitlementService.Resolve(ctx, tenantID(c)). Unresolved: resolution composes the plan with per-tenant overrides, and an override read without a predicate would grant one tenant another's plan rather than disclose data — a licensing failure rather than a privacy one, but a failure. Settled by a two-tenant test asserting the resolved snapshot differs when the two tenants' plans differ"},
+	{"/api/v1/telemetry", Pending,
+		"instance-level, not tenant-level, and recorded here rather than dismissed: TelemetryRepository.GetOrCreate takes NO tenant and returns the deployment's single telemetry row — consent state and instance_id — to any authenticated member of any organisation. No tenant rows leak. What is unresolved is whether a tenant's user may read a deployment identifier and the operator's consent choice at all, given the PUT sibling is restricted to admin/root. Settled either by gating the GET the same way, or by dropping instance_id from the tenant-facing response"},
 }
 
 // Normalise rewrites a concrete route path into registry pattern form, so
@@ -345,6 +568,14 @@ func Normalise(path string) string {
 
 // Lookup finds the decision for a route path, preferring the most specific
 // match so a precise entry always beats a module-wide prefix.
+//
+// "Most specific" is not the same as "longest". A wildcard also matches its own
+// bare prefix — matches("/api/v1/risks/*", "/api/v1/risks") is true — and the
+// wildcard is the longer string, so a length-only comparison hands the decision
+// for GET /api/v1/risks to the module-wide entry and silently discards the exact
+// one written for it. That is how a route can be assessed, given its own entry,
+// and still report as unassessed. So an exact pattern wins outright, and length
+// only breaks ties between patterns of the same kind (#421).
 func Lookup(path string) (Decision, bool) {
 	normalised := Normalise(path)
 
@@ -354,11 +585,21 @@ func Lookup(path string) (Decision, bool) {
 		if !matches(d.Pattern, normalised) {
 			continue
 		}
-		if !found || len(d.Pattern) > len(best.Pattern) {
+		if !found || moreSpecific(d.Pattern, best.Pattern) {
 			best, found = d, true
 		}
 	}
 	return best, found
+}
+
+// moreSpecific reports whether pattern a describes a narrower surface than b.
+func moreSpecific(a, b string) bool {
+	aWild := strings.HasSuffix(a, "/*")
+	bWild := strings.HasSuffix(b, "/*")
+	if aWild != bWild {
+		return !aWild // an exact pattern always beats a wildcard
+	}
+	return len(a) > len(b)
 }
 
 func matches(pattern, path string) bool {

--- a/backend/internal/service/collection_routes_isolation_test.go
+++ b/backend/internal/service/collection_routes_isolation_test.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/internal/testsupport/sqliteschema"
+)
+
+// The collection routes of /analytics/* and /dashboard/* (#421).
+//
+// These are the shape that leaked: a GET with no id in its path, whose answer is
+// an aggregate over a whole table. A parameterised route that forgets its check
+// hands over one row the caller had to name. One of these, having lost its
+// WHERE tenant_id, hands over EVERY tenant's numbers to whoever opens the
+// dashboard — which is what GET /timeline/recent did (docs/JOURNAL.md item 36).
+//
+// So every test here has one shape: seed the same qualifying rows in two
+// tenants, ask as tenant A, and prove tenant B's rows are absent from the
+// answer. Asserting "A sees its own" is not enough — a query with no predicate
+// at all passes that. The assertion that matters is the count tenant B's rows
+// would have changed.
+
+var (
+	crtA = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	crtB = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+)
+
+// newCollectionDB reconciles the full models, because GetTopRisks and
+// GetMitigationProgress load domain.Risk / domain.Mitigation whole (Preload
+// included) rather than selecting the handful of columns they display.
+func newCollectionDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	for _, ddl := range []string{
+		`CREATE TABLE risks (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE mitigations (id TEXT PRIMARY KEY)`,
+		// domain.Risk has an AfterSave hook that appends to risk_histories, and
+		// GetTopRisks reads that table for its trend, so the fixture carries it
+		// rather than disabling the hook.
+		`CREATE TABLE risk_histories (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE teams (id TEXT PRIMARY KEY)`,
+	} {
+		require.NoError(t, db.Exec(ddl).Error)
+	}
+	// Two columns the aggregation SQL references that domain.Risk does not
+	// declare — GetSeverityDistribution filters on `severity`, and
+	// GetFrameworkAnalytics groups on singular `framework` while the model has
+	// `frameworks pq.StringArray`. Reconcile only adds what the MODEL declares,
+	// so the fixture adds these by hand to keep the queries executable here.
+	// Their absence from the model is a separate defect (those two endpoints
+	// swallow the resulting error and answer zero in production); it is not an
+	// isolation defect and is out of scope for #421.
+	for _, col := range []string{
+		`ALTER TABLE risks ADD COLUMN severity TEXT`,
+		`ALTER TABLE risks ADD COLUMN framework TEXT`,
+	} {
+		require.NoError(t, db.Exec(col).Error)
+	}
+	for _, m := range []struct {
+		table string
+		model any
+	}{
+		{"risks", &domain.Risk{}},
+		{"mitigations", &domain.Mitigation{}},
+		{"risk_histories", &domain.RiskHistory{}},
+		{"teams", &domain.Team{}},
+	} {
+		require.NoError(t, sqliteschema.Reconcile(db, m.table, m.model))
+	}
+	return db
+}
+
+func seedCollectionRisk(t *testing.T, db *gorm.DB, tenant uuid.UUID, title string, score, impact, probability float64, status string, created time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	require.NoError(t, db.Exec(
+		`INSERT INTO risks (id, tenant_id, title, status, level, severity, framework, score, impact, probability, criticality, created_at, updated_at)
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		id.String(), tenant.String(), title, status, "high", "high", "ISO27001",
+		score, impact, probability, "high", created, created,
+	).Error)
+	return id
+}
+
+func seedCollectionMitigation(t *testing.T, db *gorm.DB, tenant, riskID uuid.UUID, title string, status string, created time.Time) {
+	t.Helper()
+	due := created.AddDate(0, 0, 30)
+	require.NoError(t, db.Exec(
+		`INSERT INTO mitigations (id, tenant_id, risk_id, title, status, progress, due_date, created_at, updated_at)
+		 VALUES (?,?,?,?,?,?,?,?,?)`,
+		uuid.NewString(), tenant.String(), riskID.String(), title, status, 50, due, created, created,
+	).Error)
+}
+
+// seedTwoTenants gives A one risk with one mitigation, and B three risks with
+// three mitigations. Every count below is therefore wrong in a specific,
+// recognisable way if the predicate is dropped: A's totals become 4, not 1.
+func seedTwoTenants(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	now := time.Now().UTC()
+
+	// The status strings are the LOWERCASE ones these two services actually
+	// match on ("in_progress", "completed") rather than the domain vocabulary
+	// ("IN_PROGRESS", "DONE"). The mismatch is a real counting defect — in
+	// production these tiles read zero — but it is not an isolation defect, and
+	// seeding what the query matches is what makes the isolation assertion mean
+	// something: a counter stuck at zero cannot prove a predicate holds.
+	rA := seedCollectionRisk(t, db, crtA, "A-only risk", 8.5, 8, 0.9, "active", now.AddDate(0, 0, -2))
+	seedCollectionMitigation(t, db, crtA, rA, "A-only mitigation", "in_progress", now.AddDate(0, 0, -1))
+
+	for i, title := range []string{"B-one", "B-two", "B-three"} {
+		rB := seedCollectionRisk(t, db, crtB, title, 9.5, 9, 1.0, "active", now.AddDate(0, 0, -i-1))
+		seedCollectionMitigation(t, db, crtB, rB, title+" mitigation", "completed", now.AddDate(0, 0, -1))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AnalyticsService — /analytics/risks/trends, /analytics/mitigations/metrics,
+// /analytics/frameworks, /analytics/dashboard, /analytics/export
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsCollections_NeverCrossTenants(t *testing.T) {
+	db := newCollectionDB(t)
+	seedTwoTenants(t, db)
+	svc := NewAnalyticsService(db)
+	ctx := context.Background()
+
+	t.Run("risk_trends", func(t *testing.T) {
+		points, err := svc.GetRiskTrends(ctx, crtA, 30)
+		require.NoError(t, err)
+		require.NotEmpty(t, points, "the trend must be computed, not skipped")
+		// Each bucket is a running total over the tenant's own register. If the
+		// predicate were gone the last bucket would carry all four risks.
+		require.Equal(t, int64(1), points[len(points)-1].Count,
+			"tenant B's three risks must not appear in tenant A's trend")
+		require.InDelta(t, 8.5, points[len(points)-1].AvgScore, 0.001,
+			"the average score must be over tenant A's register alone")
+	})
+
+	t.Run("mitigation_metrics", func(t *testing.T) {
+		m, err := svc.GetMitigationMetrics(ctx, crtA)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), m.TotalMitigations,
+			"tenant A owns exactly one mitigation; tenant B's three must be absent")
+		require.Equal(t, int64(0), m.CompletedMitigations,
+			"tenant B's completed mitigations must not be counted as tenant A's")
+
+		mB, err := svc.GetMitigationMetrics(ctx, crtB)
+		require.NoError(t, err)
+		require.Equal(t, int64(3), mB.TotalMitigations)
+		require.Equal(t, int64(3), mB.CompletedMitigations)
+		require.Equal(t, int64(0), mB.PendingMitigations,
+			"tenant A's in-progress mitigation must not be counted as tenant B's")
+	})
+
+	t.Run("frameworks", func(t *testing.T) {
+		fa, err := svc.GetFrameworkAnalytics(ctx, crtA)
+		require.NoError(t, err)
+		var total int64
+		for _, f := range fa {
+			total += f.AssociatedRisks
+		}
+		require.Equal(t, int64(1), total,
+			"framework coverage is a count of the tenant's own risks")
+	})
+
+	t.Run("dashboard_snapshot_and_export", func(t *testing.T) {
+		// GET /analytics/dashboard and GET /analytics/export return the same
+		// object: the export handler calls GetDashboardSnapshot and re-encodes it.
+		snap, err := svc.GetDashboardSnapshot(ctx, crtA)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), snap.RiskMetrics.TotalRisks)
+		require.Equal(t, int64(1), snap.MitigationMetrics.TotalMitigations)
+	})
+
+	t.Run("no_tenant_returns_nothing", func(t *testing.T) {
+		// uuid.Nil is what the handler's context helper yields when no tenant
+		// resolves. It must read as an empty tenant, never as "all tenants".
+		m, err := svc.GetRiskMetrics(ctx, uuid.Nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), m.TotalRisks)
+		mm, err := svc.GetMitigationMetrics(ctx, uuid.Nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), mm.TotalMitigations)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// DashboardDataService — /dashboard/metrics, /dashboard/risk-trends,
+// /dashboard/mitigation-status, /dashboard/top-risks,
+// /dashboard/mitigation-progress, /dashboard/complete
+// ---------------------------------------------------------------------------
+
+func TestDashboardCollections_NeverCrossTenants(t *testing.T) {
+	db := newCollectionDB(t)
+	seedTwoTenants(t, db)
+	svc := NewDashboardDataService(db, nil)
+	ctx := context.Background()
+
+	t.Run("metrics", func(t *testing.T) {
+		m, err := svc.GetDashboardMetrics(ctx, crtA)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), m.TotalRisks,
+			"tenant B's three risks must not be counted in tenant A's KPI tiles")
+	})
+
+	t.Run("risk_trends", func(t *testing.T) {
+		points, err := svc.GetRiskTrends(ctx, crtA)
+		require.NoError(t, err)
+		require.NotEmpty(t, points)
+		require.Equal(t, int64(1), points[len(points)-1].Count,
+			"tenant B's risks must not appear in tenant A's trend")
+	})
+
+	t.Run("mitigation_status", func(t *testing.T) {
+		s, err := svc.GetMitigationStatus(ctx, crtA)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), s.Completed,
+			"tenant B's three completed mitigations must not surface as tenant A's")
+		require.Equal(t, int64(1), s.InProgress)
+
+		sb, err := svc.GetMitigationStatus(ctx, crtB)
+		require.NoError(t, err)
+		require.Equal(t, int64(3), sb.Completed)
+		require.Equal(t, int64(0), sb.InProgress,
+			"tenant A's in-progress mitigation must not surface as tenant B's")
+	})
+
+	// GET /dashboard/top-risks and GET /dashboard/complete are NOT asserted here,
+	// and deliberately so. GetTopRisks calls Preload("Team") on domain.Risk,
+	// which declares no Team relation, so GORM refuses the query before it runs
+	// and both endpoints answer 500 on every request in every tenant. There is
+	// no observable result to make an isolation claim about. They stay Pending in
+	// the isolation registry with exactly that reason; the defect is filed
+	// separately. This test asserts the refusal so the two facts stay linked: if
+	// the relation is ever added, this fails and whoever fixes it is told to
+	// write the isolation assertion the route then needs.
+	t.Run("top_risks_cannot_execute", func(t *testing.T) {
+		_, err := svc.GetTopRisks(ctx, crtA, 10)
+		require.Error(t, err, "GetTopRisks preloads a relation domain.Risk does not declare")
+		require.Contains(t, err.Error(), "Team")
+	})
+
+	t.Run("mitigation_progress", func(t *testing.T) {
+		prog, err := svc.GetMitigationProgress(ctx, crtA, 20)
+		require.NoError(t, err)
+		require.Len(t, prog, 1)
+		require.Equal(t, "A-only mitigation", prog[0].Name)
+	})
+
+	t.Run("complete_cannot_execute", func(t *testing.T) {
+		// GET /dashboard/complete composes the widgets above, GetTopRisks
+		// included, so it inherits that refusal wholesale.
+		_, err := svc.GetCompleteDashboardData(ctx, crtA)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Team")
+	})
+
+	t.Run("no_tenant_returns_nothing", func(t *testing.T) {
+		m, err := svc.GetDashboardMetrics(ctx, uuid.Nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), m.TotalRisks)
+		st, err := svc.GetMitigationStatus(ctx, uuid.Nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), st.InProgress)
+		prog, err := svc.GetMitigationProgress(ctx, uuid.Nil, 20)
+		require.NoError(t, err)
+		require.Empty(t, prog)
+	})
+}


### PR DESCRIPTION
Closes #421

Every collection route in the product carried one shared string:
`"not assessed — collection route made visible by #412 criterion 9"`. #412 made
the surface countable; it did not judge it. This is the judging.

**Of the 97: 49 `Covered`, 12 `PublicByDesign`, 5 `SelfScoped`, 31 `Pending`.**
Each of the 31 states what is unresolved and what would settle it.

## One route was leaking

`GET /api/v1/audit-logs` returns the authentication and authorization log of
every tenant in the deployment. `domain.AuditLog` carries **no `tenant_id`
column**, so there is no predicate for the query to have lost —
`internal/service/audit_service.go:209`:

```go
query := database.DB.Where("timestamp BETWEEN ? AND ?", startTime, endTime).
	Order("timestamp DESC").Limit(limit).Offset(offset)
```

Its two siblings are the same (`user_id` alone, `action` alone). The `adminRole`
guard asks whether the caller is an admin of their **own** organisation — which
every customer's admin is. It gates who may call, not whose rows come back.

Same shape as `/timeline/recent` (`docs/JOURNAL.md` item 36), same underlying
cause: a journal table with no tenant column. Filed as **#532 (P0)** with the
quoted queries and acceptance criteria, per criterion 5. It is recorded as
leaking in the registry rather than quietly fixed here — the fix needs a
migration and a decision about pre-authentication events, which is its own issue.

## What is here

Five test files, each validated by sabotage — the tenant predicate removed from
the query under test, the test confirmed to fail, the change reverted. A
cross-tenant test that passes against an unscoped query is worse than no test,
because it reads as coverage.

Every test has one shape: seed the same qualifying rows in two tenants, read as
one, assert the other's rows are absent. Asserting that a tenant sees its own
rows is not enough — a query with no predicate passes that.

Plus two gate additions: `TestNoRouteCarriesTheGenericEvidenceString` (the
placeholder cannot come back) and `TestCollectionGapsAreVisible` (the residual
prints on every run, so the honest number stays in front of whoever runs the
suite).

## Reviewer note — one thing outside the scope

`Lookup`'s tie-break is changed. A wildcard also matches its own bare prefix, and
it is the longer string, so length-only comparison gave `GET /api/v1/risks` to
`/api/v1/risks/*` and discarded the exact entry written for it: a route
assessed, given its own entry, and still reporting as unassessed. Exact now beats
wildcard; length breaks ties only between patterns of the same kind, pinned by
`TestLookup_ExactPatternBeatsAWildcardOverTheSamePath` against the live registry.

#421 scopes the gate mechanism out as #412's. **This is included because
criterion 1 cannot be met without it, and it wants #412's owner's eyes.**

## Verification

```
$ go test ./internal/security/isolation/ -v
--- PASS: TestEveryParameterisedRouteHasAnIsolationDecision (0.01s)
--- PASS: TestEveryDecisionCarriesEvidence (0.00s)
--- PASS: TestNoStaleDecisions (0.02s)
--- PASS: TestPendingGapsAreVisible (0.01s)
--- PASS: TestIsolationGate_DemandsADecisionForCollectionRoutes (0.01s)
--- PASS: TestIsolationGate_TimelineAndCatalogueAreDecidedByName (0.00s)
--- PASS: TestIsolationGate_LegacyRecentTimelineIsRetired (0.01s)
--- PASS: TestNoRouteCarriesTheGenericEvidenceString (0.00s)
--- PASS: TestCollectionGapsAreVisible (0.01s)
--- PASS: TestLookup_ExactPatternBeatsAWildcardOverTheSamePath (0.00s)
PASS
ok  	github.com/opendefender/openrisk/internal/security/isolation	0.066s

$ go test ./internal/service/ ./internal/infrastructure/repository/ ./internal/handler/
ok  	github.com/opendefender/openrisk/internal/service	0.108s
ok  	github.com/opendefender/openrisk/internal/infrastructure/repository	0.583s
ok  	github.com/opendefender/openrisk/internal/handler	12.144s

$ go build ./... && go vet ./internal/... && gofmt -l <files touched>
(clean)
```

Sabotage, abridged — full list in the issue comment:

```
# scoped() stripped of its predicate (analytics_service.go, dashboard_data_service.go)
--- FAIL: TestAnalyticsCollections_NeverCrossTenants   (5/5 subtests)
--- FAIL: TestDashboardCollections_NeverCrossTenants   (5/5 assertable subtests)

# tenant_id removed (stats_handler.go, export_handler.go)
--- FAIL: TestStatsCollections_NeverCrossTenants
--- FAIL: TestStatsCollections_NoTenantReadsAsEmptyNotGlobal

# tenant_id removed (gorm_governance_repository.go, gorm_audit_chain_repository.go)
--- FAIL: TestGovernanceCollections_NeverCrossTenants  (6/6 assertable subtests)

# tenant_id removed (gorm_automation_repository.go)
--- FAIL: TestAutomationCollections_NeverCrossTenants  (4/4 assertable subtests)

# tenant_id removed (notification_repository.go)
--- FAIL: TestNotificationRepository_UnreadCountAndPreferences_AreTenantScoped
```

## Honest remainders

- **31 of 97 remain `Pending`** — criterion 6. One of them (`/audit-logs`) is the
  leak, pointing at #532. The other 30 are routes whose predicate I read and
  found present but which no test pins. Reading a predicate is not proving it
  holds, so I recorded the reading and refused to call it coverage. Full list and
  a suggested order in the issue comment; the four I would take first are
  `/organization/export`, `/search`, `/billing`, and `/score` with
  `scope=risk|asset`.
- **Three of the 31 are not "needs a test".** `/dashboard/top-risks` and
  `/dashboard/complete` preload a `Team` relation `domain.Risk` does not declare,
  so both answer **500 in every tenant on every request** — there is no
  observable result to make an isolation claim about
  (`TestDashboardCollections_NeverCrossTenants/top_risks_cannot_execute` pins the
  refusal). `/realtime/stats` discloses deployment-wide connection counters, not
  tenant rows. `/telemetry` is instance-level and hands the deployment's
  `instance_id` to any authenticated user while its `PUT` sibling is admin-only.
- **Two functional defects found and deliberately not fixed** (out of scope, no
  issue filed yet — happy to file): the `Team` preload above, and the
  `/dashboard` and `/analytics` mitigation counters matching lowercase status
  strings (`'completed'`, `'in_progress'`) that the domain vocabulary (`DONE`,
  `IN_PROGRESS`) never produces, so those tiles read zero in production.
  `/dashboard/severity-distribution` and `/analytics/frameworks` have the same
  shape against columns `domain.Risk` does not declare (`severity`, singular
  `framework`). Recorded in the registry entries and in the test comments.
- **Parameterised routes and body-addressed writes untouched**, as scoped.
- **`internal/domain` has one failing test on this branch**
  (`TestBusinessRolesReferenceOnlyCatalogPermissions` — an `events:read`
  permission missing from the catalogue). Verified pre-existing by stashing this
  work and re-running. Not introduced here and not fixed here.

## Skipped stages

`tech-lead` (no structural change — one tie-break fix, argued in the diff) and
`devsecops` (this PR *is* the security audit; its finding is #532).
