### PR TITLE
docs(roadmap): record what W1-05 delivered and what still blocks it (#235)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -457,6 +457,32 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
 11. **Billing & Plans (17.2)** + conversion (Partie C) + **Onboarding (17.6)** + **Super Admin (17.4)**.
 
 **Bloc W1 — Wave 1, fondations produit**
+- [ ] **W1-05 — Tableaux d'entreprise, vues enregistrées et actions en masse gouvernées**
+  (épique #235, enfants #580 / #581 / #582, tous **fermés par merge**).
+  Le composant de tableau, la virtualisation, le tri et la pagination serveur, les facettes
+  dans l'URL, la sélection page-vs-N-résultats, l'export CSV et la navigation clavier ont été
+  livrés en août (`frontend/src/shared/datatable/`, 2374 lignes, `docs/JOURNAL.md:119-129`).
+  Wave 1 a livré les trois manques qui restaient : les vues enregistrées côté serveur (W1-05a),
+  les actions en masse transactionnelles et auditées sur les risques (W1-05b), et le mécanisme
+  partagé d'aperçu + application gouvernée, appliqué aux vulnérabilités et aux actifs (W1-05c).
+  **Reste ouvert — l'épique n'est pas close.** Trois choses, dont une bloquante :
+  - **Le registre des risques n'utilise pas l'endpoint gouverné qu'il possède** (#598).
+    `POST /api/v1/risks/bulk` est transactionnel, audité et monté
+    (`cmd/server/main.go:1365`), mais `RiskRegisterPage.tsx:489-506` supprime toujours **une
+    requête par ligne** (`await Promise.all(ids.map((id) => deleteRisk(id)))`), et la mutation
+    `useRisks.ts:131` qui appelle l'endpoint n'a **aucun appelant**. Côté serveur la garantie
+    existe ; depuis le siège de l'utilisateur elle n'est pas atteignable. Tant que #598 n'est
+    pas livré, « actions en masse gouvernées sur le registre des risques » ne peut pas être
+    déclaré livré (RÈGLE ABSOLUE 12).
+  - **Quatre registres sur sept n'ont pas d'actions en masse** : mitigations et incidents (C2),
+    jetons d'API (C3), et la piste d'audit de gouvernance **abandonnée avec motif** — elle est
+    immuable et chaînée par tenant (`internal/domain/governance.go:96`), y écrire en masse
+    casserait la chaîne. C2 et C3 n'ont pas encore d'issue.
+  - **`docs/MARKETING_CLAIM_MATRIX.md` n'est pas à jour** pour les trois enfants : statut
+    `VERIFIED` réservé à `product-verifier` via `/verify-claims`.
+  Le reste de la dette de vérification de l'épique (Gap 3, `docs/JOURNAL.md:129`) a été
+  **apurée le 2026-09-08** par #583 : chaîne Go passée, suite E2E exécutée pour la première
+  fois (270 cas, 197 verts), 62 échecs déposés en #587 → #596.
 - [x] **W1-05a — Vues de tableau enregistrées : persistées côté serveur et partageables** (#580,
   enfant A de l'épique #235, indépendant des deux autres).
   Une vue enregistrée vivait dans le `localStorage` du navigateur de son auteur

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -457,6 +457,47 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
 11. **Billing & Plans (17.2)** + conversion (Partie C) + **Onboarding (17.6)** + **Super Admin (17.4)**.
 
 **Bloc W1 — Wave 1, fondations produit**
+- [x] **W1-05a — Vues de tableau enregistrées : persistées côté serveur et partageables** (#580,
+  enfant A de l'épique #235, indépendant des deux autres).
+  Une vue enregistrée vivait dans le `localStorage` du navigateur de son auteur
+  (`useTableState.ts:228,237` avant correction) : un responsable des risques qui avait construit
+  la bonne vue du registre pour son comité ne pouvait la donner à personne, et
+  `grep -rni "saved_view|savedview|table_view|column_pref"` sur `backend/` ne renvoyait **rien** —
+  ni table, ni API, ni partage. Le type `SavedView` était une forme cliente et rien d'autre.
+  **Livré** : `internal/domain/saved_view.go` (entité + `SavedViewVisibility` `personal`/`shared`),
+  quatre cas d'usage un fichier chacun dans `internal/application/savedview/`
+  (`create_`, `list_`, `update_`, `delete_saved_view.go`),
+  `internal/infrastructure/repository/gorm_saved_view_repository.go` et
+  `internal/handler/saved_view_handler.go`, montés en
+  `GET`/`POST /api/v1/saved-views` et `PATCH`/`DELETE /api/v1/saved-views/:id`
+  (`cmd/server/main.go:1779-1782`).
+  **Isolation (RÈGLE ABSOLUE 2)** : `tenant_id` est dans le `WHERE` de **chacune** des requêtes du
+  dépôt, y compris la garde d'unicité `(tenant_id, user_id, table_id, name)` ; le fichier le dit
+  en tête et le prouve ligne à ligne. Le partage est **intra-tenant uniquement**, conformément au
+  Scope OUT de l'épique. Une vue `shared` est lisible par le tenant, modifiable par son
+  propriétaire ou un admin du tenant, et attribuée à son auteur dans l'interface.
+  **Front** : `src/services/savedViewService.ts` (schéma Zod côté client, RÈGLE 11) et la
+  migration unique `localStorage` → serveur dans `useTableState.ts:266` — la copie locale n'est
+  effacée qu'**après** que toutes les vues ont été acceptées par le serveur ; un échec n'est pas
+  fatal, les vues restent locales et la migration est retentée.
+  **Tests** : `internal/application/savedview/saved_view_test.go` (9), 
+  `internal/infrastructure/repository/gorm_saved_view_repository_test.go` (7, SQLite réel) et
+  `frontend/src/shared/datatable/__tests__/savedViews.test.tsx` (15 — dont la migration locale,
+  la charge locale corrompue ignorée, le refus d'un nom sans lettre ni chiffre, le refus au-delà
+  de 120 caractères, la vue partagée d'un collègue en lecture seule, et trois passes axe-core
+  sans violation serious/critical). Vérifiés le 2026-09-08 dans la suite front complète :
+  47 fichiers, 516 tests, tous verts.
+  **Reste à faire**
+  - **Aucune migration SQL versionnée.** La table `saved_views` est créée par l'`AutoMigrate` de
+    GORM (`cmd/server/main.go:378`) et non par un fichier de `migrations/`. C'est le mécanisme
+    déjà en place pour les autres entités, mais cela signifie qu'il n'existe pas de `down` et que
+    la table n'apparaît pas dans l'historique `golang-migrate`.
+  - **La disposition des colonnes reste locale, par choix.** `ColumnPrefs` continue de vivre dans
+    le `localStorage` (`useTableState.ts:15`, `ColumnsMenu.tsx:4`) : c'est une préférence par
+    utilisateur **et par navigateur**, pas un artefact partageable. Le Gap 1 de #235 est donc
+    clos pour les vues, ouvert par décision pour les colonnes.
+  - Ligne dans `docs/MARKETING_CLAIM_MATRIX.md` : **non ajoutée**, statut `VERIFIED` réservé à
+    `product-verifier` via `/verify-claims`.
 - [x] **W1-05b — Actions en masse du registre : transactionnelles, auditées, complètes** (#581,
   enfant B de l'épique #235, débloqué par **D-036**).
   `POST /api/v1/risks/bulk` appliquait ce qu'il pouvait, item par item, sans transaction, et

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -477,7 +477,12 @@ financière + un plan de traitement suggéré ». Une branche par phase, commits
   - **Quatre registres sur sept n'ont pas d'actions en masse** : mitigations et incidents (C2),
     jetons d'API (C3), et la piste d'audit de gouvernance **abandonnée avec motif** — elle est
     immuable et chaînée par tenant (`internal/domain/governance.go:96`), y écrire en masse
-    casserait la chaîne. C2 et C3 n'ont pas encore d'issue.
+    casserait la chaîne. C2 et C3 sont désormais déposés en **#600**.
+  - **Le registre des risques n'a pas d'aperçu d'impact** (#599). `/risks/bulk` est une route
+    unique dont l'action vient du **corps** de la requête, alors que #582 a délibérément
+    abandonné cette forme (un porteur de `risks:update` pouvait poster une action `delete`) ;
+    vulnérabilités et actifs ont `capabilities`, `preview`, et une route par action derrière sa
+    propre permission. L'aperçu est ce que #582 appelle « la moitié qui manquait à #581 ».
   - **`docs/MARKETING_CLAIM_MATRIX.md` n'est pas à jour** pour les trois enfants : statut
     `VERIFIED` réservé à `product-verifier` via `/verify-claims`.
   Le reste de la dette de vérification de l'épique (Gap 3, `docs/JOURNAL.md:129`) a été


### PR DESCRIPTION
Refs #235 — the epic's own closing work. **This PR does not close the epic**, deliberately:
see the blocking remainder below.

#235 is an epic that ships no code of its own. Its three children are all closed by merge
(#580 → #584, #581 → #585, #582 → #586), which leaves the epic's own acceptance criteria 2
and 3 — the Gap 2 audit and the ROADMAP lines. This PR is those, and nothing else. **No
production code changed.**

Three atomic commits, all to `ROADMAP.md`:

| Commit | What |
|---|---|
| `e5e06f8` | **W1-05a** (#580) — the Wave 1 block had lines for #581 and #582 but none for #580 |
| `62153cf` | the epic-level **W1-05** line — what the three children shipped, and what still blocks it |
| `3078310` | names #599 and #600 against the Gap 2 rows that had no issue |

## Verification

Every Gap 2 row was re-checked against the code on `master` at `1a2fd14`, not against the
children's ROADMAP prose. Four rows moved to ✅ (transaction, audit records, `remove_tags`,
the missing test file), two are closed by decision (async progress, undo — both Scope OUT of
the epic), and two are partial and now carry named issues (#599, #600). The full table is in
the [audit comment on #235](https://github.com/opendefender/OpenRisk/issues/235#issuecomment-5582482115).

The audit found something the prose did not:

```
$ grep -rn "bulkAction" frontend/src/features/risks/*.tsx
frontend/src/features/risks/RiskRegisterPage.tsx:489:  const bulkActions: BulkAction<UiRisk>[] = useMemo(
frontend/src/features/risks/RiskRegisterPage.tsx:598:          bulkActions={bulkActions}
```

Both hits are the unrelated array passed to `<DataTable>`. `POST /api/v1/risks/bulk` — made
transactional and audited by #581, mounted at `cmd/server/main.go:1365` — **has no caller**.
The register still deletes one request per row:

```tsx
// frontend/src/features/risks/RiskRegisterPage.tsx:499-503
run: async ({ ids }) => {
  await Promise.all(ids.map((id) => deleteRisk(id)));
  …
```

Server-side the guarantee exists; from a user's seat it does not. Filed as **#598**.

## Issues filed

- **#598** — the risk register still deletes row by row; the governed endpoint has no caller
- **#599** — `/risks/bulk` has no impact preview, and takes its action from the request body
- **#600** — governed bulk for mitigations, incidents and API tokens (C2 + C3)

## Honest remainders

- **The epic stays open, and its W1-05 line is `[ ]` not `[x]`.** Ticking it would record a
  governance capability that is not reachable by a user, which is the ABSOLUTE RULE 12
  failure the epic's own Risk section warns about. #598 must merge first.
- **`docs/MARKETING_CLAIM_MATRIX.md` is untouched.** All three children left the same
  remainder for the same reason: `VERIFIED` is reserved to `product-verifier` via
  `/verify-claims`. Writing those rows by hand is precisely the failure mode the rule exists
  to prevent. That DoD box stays unticked.
- **The `status:needs-refinement` label was stale** and I changed it. The body satisfies every
  clause of the Ready definition and its criterion 1 was already marked ✅. Flagging in case
  you disagree with the call.
- **Four of seven registers still have no bulk actions** (mitigations, incidents, API tokens
  — #600). The governance audit trail is declined with its reason, not deferred: it is
  immutable and hash-chained per tenant (`internal/domain/governance.go:96`).
- **Nothing here was executed against a running stack.** These are documentation and
  verification changes; the code claims they describe were checked by reading and grepping
  the tree, and by the children's own test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL34uvJbLVBho3TnfNXUJs
