### PR TITLE
fix(risks): delete a selection in one governed request, not one per row (#598)

### DIFF
--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -77,6 +77,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useRiskStore, type RiskPhase } from '../../hooks/useRiskStore';
 import { useFocusParam } from '../../shared/useFocusParam';
 import { useAuthStore } from '../../hooks/useAuthStore';
+import { isMissingRows } from '../../services/bulkService';
 import { mapRisk, relTime, type UiRisk } from './riskMap';
 import { EditRiskModal } from './components/EditRiskModal';
 import { CreateMitigationModal } from '../mitigations/CreateMitigationModal';
@@ -145,6 +146,7 @@ export function RiskRegisterPage() {
   const loadError = useRiskStore((s) => s.error);
   const fetchRisks = useRiskStore((s) => s.fetchRisks);
   const deleteRisk = useRiskStore((s) => s.deleteRisk);
+  const bulkDelete = useRiskStore((s) => s.bulkDelete);
   const canUpdate = useAuthStore((s) => s.hasPermission('risks:update'));
   const { data: categories } = useRiskCategories();
   const canDelete = useAuthStore((s) => s.hasPermission('risks:delete'));
@@ -494,16 +496,38 @@ export function RiskRegisterPage() {
         icon: Trash2,
         danger: true,
         hidden: !canDelete,
-        // Per-id API: refuse to pretend we can delete "all N results" in one go.
+        // The governed endpoint takes explicit ids and caps a batch at 100, so it
+        // cannot address "all N results" — the largest page is exactly 100. This
+        // is a property of the API, not a UI limitation we could lift here.
         selectionOnly: true,
+        // ONE request (#598). `POST /risks/bulk` is transactional and audited:
+        // every named risk is deleted or none is, and each deletion is recorded
+        // against the actor. The bar shows its own error state on rejection; the
+        // toast is what says *why*, because under all-or-nothing the fact that
+        // nothing was deleted is the part the user has to know.
         run: async ({ ids }) => {
-          await Promise.all(ids.map((id) => deleteRisk(id)));
+          try {
+            await bulkDelete(ids);
+          } catch (err) {
+            toast.error(
+              isMissingRows(err)
+                ? tr(
+                    'Aucun risque supprimé : la sélection a changé. Rechargez et réessayez.',
+                    'No risk deleted: the selection has changed. Reload and try again.',
+                  )
+                : tr(
+                    `Aucun risque supprimé (${ids.length} sélectionné(s)).`,
+                    `No risk deleted (${ids.length} selected).`,
+                  ),
+            );
+            throw err;
+          }
           toast.success(tr(`${ids.length} risque(s) supprimé(s)`, `${ids.length} risk(s) deleted`));
           reload();
         },
       },
     ],
-    [L, canDelete, deleteRisk, reload],
+    [L, canDelete, bulkDelete, reload],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   const critCount = ui.filter((r) => r.crit === 'critical').length;

--- a/frontend/src/hooks/__tests__/useRiskStore.test.ts
+++ b/frontend/src/hooks/__tests__/useRiskStore.test.ts
@@ -89,3 +89,80 @@ describe('useRiskStore', () => {
     expect(state.total).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Governed bulk delete (#598).
+//
+// The register used to fan out one DELETE per row. These pin the two properties
+// that fan-out could not have: exactly one request reaches the transactional
+// endpoint, and a refusal leaves the store exactly as it was — which is the only
+// correct restore under all-or-nothing (D-036), because a refusal means nothing
+// was written.
+// ---------------------------------------------------------------------------
+
+describe('useRiskStore.bulkDelete — governed, one request', () => {
+  const seed = (): Risk[] =>
+    [
+      { id: 'r1', title: 'A' },
+      { id: 'r2', title: 'B' },
+      { id: 'r3', title: 'C' },
+    ] as unknown as Risk[];
+
+  beforeEach(() => {
+    useRiskStore.setState({ risks: seed(), total: 3, selectedIds: ['r1', 'r2'] });
+    vi.restoreAllMocks();
+  });
+
+  it('sends ONE request to the bulk endpoint, never one DELETE per row', async () => {
+    const post = vi.spyOn(api, 'post').mockResolvedValueOnce({
+      data: { total: 2, applied: 2, risk_ids: ['r1', 'r2'], audited: 2 },
+    });
+    const del = vi.spyOn(api, 'delete');
+
+    await useRiskStore.getState().bulkDelete(['r1', 'r2']);
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/risks/bulk', {
+      type: 'delete',
+      risk_ids: ['r1', 'r2'],
+    });
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('removes the rows optimistically and clears the selection on success', async () => {
+    vi.spyOn(api, 'post').mockResolvedValueOnce({
+      data: { total: 2, applied: 2, risk_ids: ['r1', 'r2'], audited: 2 },
+    });
+
+    await useRiskStore.getState().bulkDelete(['r1', 'r2']);
+
+    const s = useRiskStore.getState();
+    expect(s.risks.map((r) => r.id)).toEqual(['r3']);
+    expect(s.total).toBe(1);
+    expect(s.selectedIds).toEqual([]);
+  });
+
+  it('restores rows, total AND selection byte-for-byte when the server refuses', async () => {
+    const before = useRiskStore.getState();
+    const rowsBefore = before.risks;
+    const totalBefore = before.total;
+    const selectionBefore = before.selectedIds;
+
+    vi.spyOn(api, 'post').mockRejectedValueOnce({ response: { status: 404 } });
+
+    await expect(useRiskStore.getState().bulkDelete(['r1', 'r2'])).rejects.toBeDefined();
+
+    const after = useRiskStore.getState();
+    expect(after.risks).toEqual(rowsBefore);
+    expect(after.total).toBe(totalBefore);
+    // The selection survives a refusal: nothing was deleted, so the user's
+    // selection is still meaningful and they can retry without re-picking.
+    expect(after.selectedIds).toEqual(selectionBefore);
+    expect(after.isLoading).toBe(false);
+  });
+
+  it('rethrows so the bulk bar can show its own error state', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new Error('boom'));
+    await expect(useRiskStore.getState().bulkDelete(['r1'])).rejects.toThrow('boom');
+  });
+});

--- a/frontend/src/hooks/useRiskStore.ts
+++ b/frontend/src/hooks/useRiskStore.ts
@@ -6,6 +6,7 @@
 import { create } from 'zustand';
 import { registerTenantStore } from '../lib/sessionScope';
 import { api } from '../lib/api';
+import { riskService } from '../services/riskService';
 import type { Asset } from './useAssetStore';
 import type { RiskControlMapping } from '../services/taxonomyService';
 import type { RiskState } from '../features/risks/useLifecycle';
@@ -145,8 +146,12 @@ interface RiskStore {
   clearSelection: () => void;
 
   // bulk operations
+  /**
+   * Delete a selection in one governed request. Rejects — leaving the store
+   * untouched — when the server refuses the batch; there is no partial outcome
+   * to report, by design (D-036).
+   */
   bulkDelete: (ids: string[]) => Promise<void>;
-  bulkUpdate: (ids: string[], payload: Partial<Risk>) => Promise<void>;
 
   // import / export helpers
   importRisks: (file: File) => Promise<void>;
@@ -317,40 +322,30 @@ export const useRiskStore = create<RiskStore>((set, get) => ({
   clearSelection: () => set({ selectedIds: [] }),
 
   // bulk operations
+  //
+  // ONE request, not one per row (#598). `POST /risks/bulk` is transactional and
+  // audited (#581): the batch either applies to every id or to none, and each
+  // deleted risk gets an audit entry naming the actor. The previous
+  // implementation fanned out `DELETE /risks/:id` through `Promise.all` under a
+  // comment claiming "backend may not provide bulk delete endpoint" — it does,
+  // and the fan-out produced N unattributable mutations that a rejection partway
+  // through left half-applied.
   bulkDelete: async (ids) => {
     set({ isLoading: true });
     const prev = get().risks;
     const prevTotal = get().total;
+    const prevSelection = get().selectedIds;
+    // Optimistic (ABSOLUTE RULE 10); restored byte-for-byte below if the server
+    // refuses, because under all-or-nothing a refusal means nothing was written.
     set((state) => ({
       risks: state.risks.filter((r) => !ids.includes(r.id)),
       total: Math.max(0, state.total - ids.length),
+      selectedIds: [],
     }));
     try {
-      // backend may not provide bulk delete endpoint; call per-id
-      await Promise.all(ids.map((id) => api.delete(`/risks/${id}`)));
-      // clear selection
-      set({ selectedIds: [] });
+      await riskService.bulkAction({ type: 'delete', risk_ids: ids });
     } catch (err) {
-      set({ risks: prev, total: prevTotal });
-      console.error('bulkDelete failed', err);
-      throw err;
-    } finally {
-      set({ isLoading: false });
-    }
-  },
-
-  bulkUpdate: async (ids, payload) => {
-    set({ isLoading: true });
-    const prev = get().risks;
-    // optimistic update
-    set((state) => ({
-      risks: state.risks.map((r) => (ids.includes(r.id) ? { ...r, ...payload } : r)),
-    }));
-    try {
-      await Promise.all(ids.map((id) => api.patch(`/risks/${id}`, payload)));
-    } catch (err) {
-      set({ risks: prev });
-      console.error('bulkUpdate failed', err);
+      set({ risks: prev, total: prevTotal, selectedIds: prevSelection });
       throw err;
     } finally {
       set({ isLoading: false });


### PR DESCRIPTION
Closes #598

The risk register deleted a selection with one `DELETE /risks/:id` per row, while
`POST /api/v1/risks/bulk` — transactional and audited since #581, mounted at
`cmd/server/main.go:1365` — had no caller. Server-side the guarantee existed; from a user's
seat it did not. Selecting forty risks and deleting them produced forty independent,
unattributable mutations, and a rejection partway through left the earlier ones applied.

Frontend only. `POST /risks/bulk` is untouched, as this issue's Scope OUT requires.

| Commit | What |
|---|---|
| `238b067` | `useRiskStore.bulkDelete` sends one governed request; dead `bulkUpdate` removed |
| `c7c9f6d` | the register calls it, and says *why* when the server refuses |
| `ec06e9b` | four tests |

`bulkDelete` restores the optimistic removal on refusal **with the total and the selection**:
under all-or-nothing a refusal means nothing was written, so the selection is still meaningful
and the user retries without re-picking. `bulkUpdate` is removed — no caller, no atomic
backend equivalent for an arbitrary `Partial<Risk>`, and the same per-row `Promise.all` shape
this PR exists to eliminate.

## Verification

```
$ npx vitest run src/hooks/__tests__/useRiskStore.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ npx vitest run
 Test Files  48 passed (48)
      Tests  540 passed (540)

$ go test ./internal/application/risk/ -run Bulk -count=1
ok  	github.com/opendefender/openrisk/internal/application/risk	0.015s

$ grep -n "Promise.all" frontend/src/features/risks/RiskRegisterPage.tsx
(no match)
```

`eslint` on the two changed files: **12 errors, 8 warnings — byte-identical to the same
command on `master` with these changes stashed.** All pre-existing; this PR adds none.

Criteria **1, 2, 3 and 5 met**. **Criterion 4 is not** — see below.

## Honest remainders

- **Criterion 4 (the 409 fingerprint refusal) is blocked on #599** and cannot be met here.
  It needs a preview to fingerprint, and `/risks/bulk/preview` does not exist — vulnerabilities
  and assets have it (`main.go:1835`, `:1847`), risks is a single route taking its action from
  the request body. `bulkService.ts` types its register as `'vulnerabilities' | 'assets'`
  because the shared client assumes #582's route shape, so `useGovernedBulk` and
  `<BulkPreviewDialog>` cannot be reused for risks until #599 lands. **The register's bulk
  delete is still one click with no confirmation step** — unchanged from before this PR, not a
  regression it introduces, and #599 is what fixes it.
- **The issue's premise about `useRisks.ts` was wrong, so that file is untouched.** #598 said
  its `bulkAction` was the uncalled client. It is uncalled — but so is the entire file; it has
  zero consumers anywhere in `frontend/src`. The register uses the Zustand store, not React
  Query, which is why nothing called it. Deleting one mutation from a wholly dead file is
  arbitrary, and deleting the file is an architecture call. **Needs the owner's direction**, so
  that DoD box is unticked.
- **`tsc -b --noEmit` is red, and was already.** Three errors, all in
  `savedViewService.ts`: the saved-view schemas are missing from `docs/openapi.yaml`. Verified
  pre-existing by stashing this branch and re-running. Filed as **#602**, not fixed here.
- **Nothing was run against a live stack.** The store test asserts the request shape rather
  than observing it on the wire. E2E is where the real proof belongs, and it cannot gate this:
  it has never run in CI (#587), and 31 of its 62 failures are the product's own credential
  throttle (#588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WL34uvJbLVBho3TnfNXUJs
