### PR TITLE
feat(i18n): a locale registry, CLDR pluralization and locale-aware formatting (#315)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,7 +5,38 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-None. Every entry in this register is resolved as of 2026-09-07.
+### D-037 — English date order: `en-US` everywhere, or `en-GB`? · raised 2026-09-08
+**Context** — #315 gave every locale exactly one BCP-47 tag in
+`frontend/src/i18n/locales.ts`. Before it, English dates were formatted as
+`en-GB` on fifteen screens and `en-US` on nine, so the same product showed
+`12/03/2026` and `03/12/2026` for the same day depending on which page you were
+on. Centralizing forces one answer.
+**Chosen while waiting** — `en` → `en-US`. It matches the majority of the
+existing sites and the USA is a named market in CLAUDE.md. The change is live on
+the #315 branch.
+**Cost of the alternative** — `en-GB` is the day-first order Belgium, Canada,
+the Maghreb and Sub-Saharan Africa read, and it matches French, so a bilingual
+user switching languages would not see the digits reorder. Switching is a
+one-character edit to `LOCALES.en.tag` plus the two assertions in
+`frontend/src/i18n/__tests__/format.test.ts`.
+**Cost of delay** — near zero now, real once customers have screenshots and
+exported reports in circulation.
+**Recommendation** — keep `en-US` unless a launch customer is UK/Commonwealth.
+
+### D-038 — should a first visit follow the browser's language? · raised 2026-09-08
+**Context** — the registry gained `negotiateLocale()`, which picks the best
+offered language out of an `Accept-Language`-shaped list, with q-weights. It is
+implemented and tested. Wiring it to `navigator.languages` was **reverted** on
+#315 before commit: it changed the first-visit default from French to English on
+any English-configured machine, which is a product decision, not a refactor.
+**Chosen while waiting** — first visit stays French, as designed. A stored
+preference always wins.
+**Options** — (A) keep French always; (B) negotiate from the browser and fall
+back to French; (C) negotiate only when the tenant has no declared default.
+**Cost of delay** — none. The function is already there; wiring it is three
+lines in `frontend/src/store/uiStore.ts`.
+**Recommendation** — (A) until the marketing site reports meaningful non-French
+first-touch traffic; the current default is right for the primary market.
 
 ## Resolved
 

--- a/docs/adr/0002-i18n-locale-registry-and-formatting.md
+++ b/docs/adr/0002-i18n-locale-registry-and-formatting.md
@@ -1,0 +1,123 @@
+# 0002 — Locale registry, CLDR pluralization and centralized formatting
+
+Status: proposed
+Proposed: 2026-09-08, on #315 (W1-06)
+Implemented by: #315
+
+## Context
+
+OpenRisk targets France, Belgium, the Maghreb, Canada, the USA and Sub-Saharan
+Africa. Before this change the frontend could express exactly two languages, and
+it expressed them by writing `'fr' | 'en'` into 38 type annotations across 25
+files. Measured on `master` at 2026-09-08:
+
+| Symptom | Count |
+|---|---|
+| Inline `lang === 'fr' ? … : …` in components | 287 across 117 of 292 `.tsx` files |
+| `'fr' \| 'en'` unions outside any registry | 38 in 25 files |
+| Ad-hoc pluralization written as `n > 1 ? 's' : ''` | 17 sites |
+| `toLocale*` call sites | 77 |
+| …of which pinned a tag (`'fr-FR'`, `'en-US'`, `'en-GB'`) regardless of the user's language | 10 |
+| Central formatting module | none |
+| `Intl.PluralRules` / `Intl.RelativeTimeFormat` / `Intl.ListFormat` usage | none |
+| Writing-direction concept (`<html dir>`) | none |
+| Competing dictionaries | 2 (`locales/*.json`, 348 keys; `shared/uiStrings.ts`, flat) |
+
+Two of these were not merely inelegant, they were wrong:
+
+* `` `${n} result${n > 1 ? 's' : ''}` `` printed **"0 result"** in English.
+  English takes the plural at zero; French does not. One rule cannot serve both,
+  and no rule of that shape can serve Arabic, which has six plural categories.
+* Ten call sites formatted in French for English users, and English date order
+  was inconsistent between `en-GB` and `en-US` from screen to screen.
+
+## Decision
+
+### D1 — One registry owns the set of languages
+
+`src/i18n/locales.ts` declares every locale: BCP-47 tag, writing direction,
+endonym, default currency and an `enabled` flag. `LocaleCode` is derived from
+that object with `keyof typeof LOCALES`, and `store/uiStore.ts` re-exports it as
+`Lang`. Adding a language therefore *widens a type*, which makes every place
+that still assumes two languages a compile error rather than a silent fallback.
+
+That is exactly what happened when Arabic was registered: 129 type errors in 37
+files, all of them latent bugs. They are fixed in #315.
+
+### D2 — `enabled` separates *registered* from *offered*
+
+Arabic is registered (`ar-MA`, RTL, six plural categories) and **disabled**. Its
+direction and plural rules are exercised by the test suite; it has no catalogue,
+so `resolveLocale()` refuses to make it active however it arrives — a stale
+`localStorage` value, a deep link, or a switcher from an older build.
+
+This is what lets RTL be *proved* rather than asserted, without claiming the
+product ships Arabic. Enabling a language is one line, once its catalogue exists.
+
+### D3 — Pluralization is `Intl.PluralRules`, never a `> 1` test
+
+A catalogue value is either a string or a `PluralForms` object whose `other` key
+is **required by the type** — `other` is the one CLDR category every language
+defines, so a translator cannot physically ship a plural with no fallback.
+`exact` overrides a literal count where the copy reads better ("Aucun résultat"
+rather than "0 résultat").
+
+### D4 — One formatting module, always bound to the active locale
+
+`src/i18n/format.ts` is the only place the product turns a number, a date or an
+amount into text: number, compact, percent, currency, date, date-time, time,
+relative time, list. Every formatter takes a `LocaleCode` and resolves its tag
+through the registry. `Intl` instances are memoized because these run in table
+cells.
+
+Money is left to `Intl` rather than special-cased: it already knows XAF has no
+minor unit and prints "1 234 567 FCFA" in French, "FCFA 1,234,567" in English.
+
+### D5 — Missing keys fall back, and are visible
+
+`translate()` resolves active locale → default locale (`fr`) → `defaultValue` →
+the key text. An empty string in a catalogue is treated as a hole, not a
+translation. Nothing ever renders blank, and a gap reads as a dotted key in
+review.
+
+### D6 — The debt is ratcheted, not declared finished
+
+#315 delivers the framework and migrates the shared layer. 260 inline bilingual
+ternaries remain. `src/i18n/__tests__/ratchet.test.ts` freezes the counts and
+fails when they rise, so the tree stops accumulating what the framework replaces
+while the sweep is done screen by screen.
+
+## Consequences
+
+* Adding a language is: one `LOCALES` entry, one catalogue in `catalog.ts`,
+  `enabled: true`. No component changes.
+* **English dates are now consistent.** Fifteen sites previously formatted
+  English as `en-GB`; the registry maps `en` to `en-US`, so bare dates move from
+  `DD/MM/YYYY` to `MM/DD/YYYY` for English users. Logged for the owner as D-037.
+* First-visit language stays French. `negotiateLocale()` exists and is tested but
+  is deliberately **not** wired to `navigator.languages` — see D-038.
+* Three `'fr' | 'en'` unions survive on purpose: `features/ai/Locale`,
+  `types/report/ReportLocale`, `types/board/BoardLocale`. They describe what the
+  **server** can render, not what the UI can display. Widening them would claim
+  OpenRisk generates Arabic reports. They change when the backend gains a
+  language.
+* The backend still negotiates language with
+  `strings.HasPrefix(c.Get("Accept-Language"), "en")` in at least four handlers.
+  Out of scope here; tracked separately.
+* `shared/uiStrings.ts` is untouched. It has its own accessor and no plural or
+  format needs; folding it into the catalogue is a mechanical follow-up, not a
+  prerequisite.
+
+## Alternatives rejected
+
+* **react-i18next / FormatJS.** Both solve this well and both are a new runtime
+  dependency plus a bundle cost, which CLAUDE.md puts on the escalation list. The
+  parts actually needed — plural rules, number/date/list/relative formatting —
+  are `Intl`, already in every target browser and in Node. The framework here is
+  seven files and no dependency. If the catalogue ever needs full ICU MessageFormat
+  (select, selectordinal, nested arguments), that is the moment to escalate for
+  FormatJS rather than grow the interpolator.
+* **Widening `ReportLocale` / `BoardLocale` to `LocaleCode`.** Rejected under
+  "invent nothing": it would type a capability the server does not have.
+* **Extracting all 287 ternaries in this change.** Rejected as unreviewable. The
+  ratchet makes the incremental path safe instead.

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -39,6 +39,9 @@ import {
 } from '../../features/notifications/useNotifications';
 import { EmptyState } from '../../shared/EmptyState';
 import { Btn, SkeletonRows } from '../../shared/ui';
+import type { LocaleCode } from '../../i18n/locales';
+import { pickLocalized } from '../../i18n/locales';
+import { ENABLED_LOCALES, localeDefinition } from '../../i18n/locales';
 
 interface AppHeaderProps {
   onOpenMobileNav: () => void;
@@ -56,6 +59,15 @@ export const AppHeader = ({ onOpenMobileNav }: AppHeaderProps) => {
   const theme = useUIStore((s) => s.theme);
   const lang = useUIStore((s) => s.lang);
   const L = useUIStrings();
+  // The switcher names the language it will switch *to*, in that language's own
+  // words, and reads the list from the registry — so enabling a third locale
+  // needs no edit here.
+  const nextLocaleLabel = (() => {
+    const offered = ENABLED_LOCALES;
+    const next = offered[(offered.indexOf(lang) + 1) % offered.length];
+    return `${localeDefinition(next).nativeName} — ${localeDefinition(lang).nativeName}`;
+  })();
+
   const densityMeta = {
     comfort: { Icon: Rows3, label: lang === 'fr' ? 'Densité : Confort' : 'Density: Comfort' },
     compact: { Icon: Rows4, label: lang === 'fr' ? 'Densité : Compact' : 'Density: Compact' },
@@ -115,8 +127,8 @@ export const AppHeader = ({ onOpenMobileNav }: AppHeaderProps) => {
         <button
           onClick={toggleLang}
           className={iconBtn}
-          title="Language"
-          aria-label="Toggle language"
+          title={nextLocaleLabel}
+          aria-label={nextLocaleLabel}
         >
           <span className="mono text-[11px] font-semibold">{lang.toUpperCase()}</span>
         </button>
@@ -254,7 +266,7 @@ function NotifPanel({ onClose }: { onClose: () => void }) {
           <div className="flex gap-1.5 px-[15px] py-2.5 border-b border-border overflow-x-auto">
             {cats.map((c) => {
               const active = filter === c;
-              const label = c === 'all' ? tr('Tout', 'All') : categoryMeta(c).label[lang];
+              const label = c === 'all' ? tr('Tout', 'All') : pickLocalized(lang, categoryMeta(c).label);
               return (
                 <button
                   key={c}
@@ -346,7 +358,7 @@ function NotifPanel({ onClose }: { onClose: () => void }) {
                           background: `color-mix(in srgb, ${categoryMeta(it.category).color} 14%, transparent)`,
                         }}
                       >
-                        {categoryMeta(it.category).label[lang]}
+                        {pickLocalized(lang, categoryMeta(it.category).label)}
                       </span>
                     </div>
                   </div>
@@ -379,7 +391,7 @@ function NotifPanel({ onClose }: { onClose: () => void }) {
 // the dot reports whether live updates are actually arriving — which is the
 // difference between a screen that refreshes itself and one the user has to
 // reload, and the user is entitled to know which they are looking at.
-function ConnectionDot({ lang }: { lang: 'fr' | 'en' }) {
+function ConnectionDot({ lang }: { lang: LocaleCode }) {
   const status = useSyncExternalStore(
     subscribeConnection,
     getConnectionStatus,
@@ -486,7 +498,7 @@ function ConnectionDot({ lang }: { lang: 'fr' | 'en' }) {
 }
 
 /** Compact relative time ("il y a 8 min"), no dependency on a date library. */
-function relativeTime(iso: string, lang: 'fr' | 'en'): string {
+function relativeTime(iso: string, lang: LocaleCode): string {
   const then = new Date(iso).getTime();
   if (!Number.isFinite(then)) return '';
   const mins = Math.max(0, Math.floor((Date.now() - then) / 60000));

--- a/frontend/src/components/shared/AutoDetectedBadge.tsx
+++ b/frontend/src/components/shared/AutoDetectedBadge.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { useFormat } from '../../hooks/useI18n';
 import { motion } from 'framer-motion';
 import { Zap } from 'lucide-react';
 import { clsx, type ClassValue } from 'clsx';
@@ -25,6 +26,7 @@ export const AutoDetectedBadge = ({
   size = 'md',
   className,
 }: AutoDetectedBadgeProps) => {
+  const fmt = useFormat();
   const sizeClasses = {
     sm: 'px-2 py-1 text-xs gap-1',
     md: 'px-3 py-1.5 text-sm gap-1.5',
@@ -38,7 +40,7 @@ export const AutoDetectedBadge = ({
   const formatTime = (isoString?: string) => {
     if (!isoString) return '';
     const date = new Date(isoString);
-    return date.toLocaleString('fr-FR', {
+    return fmt.dateTime(date, {
       day: '2-digit',
       month: '2-digit',
       hour: '2-digit',

--- a/frontend/src/features/action-center/dueDate.ts
+++ b/frontend/src/features/action-center/dueDate.ts
@@ -7,12 +7,14 @@
 // that exports both a component and a helper breaks Vite's fast refresh, which
 // the react-refresh lint rule enforces at error level.
 
+import { localeTag, type LocaleCode } from '../../i18n/locales';
+
 /** Formats a due date in the active locale, or null when the category has none. */
-export function formatDue(dueAt: string | null | undefined, locale: string): string | null {
+export function formatDue(dueAt: string | null | undefined, locale: LocaleCode): string | null {
   if (!dueAt) return null;
   const date = new Date(dueAt);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(locale === 'fr' ? 'fr-FR' : 'en-GB', {
+  return date.toLocaleDateString(localeTag(locale), {
     day: '2-digit',
     month: 'short',
     year: 'numeric',

--- a/frontend/src/features/analytics/ExecutiveDashboard.tsx
+++ b/frontend/src/features/analytics/ExecutiveDashboard.tsx
@@ -10,6 +10,7 @@
 // severity (with labels/legend), one hue for magnitude, ink tokens for text, and
 // they render in light + dark.
 
+import { localeTag, type LocaleCode } from '../../i18n/locales';
 import { useMemo } from 'react';
 import { toast } from 'sonner';
 import { CartesianChart, RadarChart } from '../../shared/ds/charts';
@@ -52,10 +53,10 @@ const SEV_COLOR: Record<string, string> = {
   ok: 'var(--low)',
 };
 
-function fmtInt(n: number, lang: string): string {
-  return Math.round(n).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US');
+function fmtInt(n: number, lang: LocaleCode): string {
+  return Math.round(n).toLocaleString(localeTag(lang));
 }
-function fmtCompactFCFA(n: number, lang: string): string {
+function fmtCompactFCFA(n: number, lang: LocaleCode): string {
   const abs = Math.abs(n);
   const u = lang === 'fr' ? { b: ' Md', m: ' M', k: ' k' } : { b: 'B', m: 'M', k: 'K' };
   const f = (v: number) => (lang === 'fr' ? v.toFixed(1).replace('.', ',') : v.toFixed(1));
@@ -117,7 +118,7 @@ export function ExecutiveDashboard() {
     );
   }
 
-  const gen = new Date(data.generated_at).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+  const gen = new Date(data.generated_at).toLocaleString(localeTag(lang), {
     dateStyle: 'medium',
     timeStyle: 'short',
   });
@@ -253,7 +254,7 @@ function FinancialCard({
   tr,
 }: {
   data: ExecData;
-  lang: string;
+  lang: LocaleCode;
   tr: (f: string, e: string) => string;
 }) {
   const f = data.financial;
@@ -299,7 +300,7 @@ const KRI_ICON: Record<string, LucideIcon> = {
   avg_mttr_days: TrendingUp,
   compliance_coverage: ShieldCheck,
 };
-function KriStrip({ kris, lang }: { kris: KRI[]; lang: string }) {
+function KriStrip({ kris, lang }: { kris: KRI[]; lang: LocaleCode }) {
   if (kris.length === 0) return null;
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-3">
@@ -310,7 +311,7 @@ function KriStrip({ kris, lang }: { kris: KRI[]; lang: string }) {
           k.unit === '%'
             ? `${fmtInt(k.value, lang)} %`
             : k.unit === 'days'
-              ? `${k.value.toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US', { maximumFractionDigits: 1 })} ${lang === 'fr' ? 'j' : 'd'}`
+              ? `${k.value.toLocaleString(localeTag(lang), { maximumFractionDigits: 1 })} ${lang === 'fr' ? 'j' : 'd'}`
               : fmtInt(k.value, lang);
         return (
           <Card key={k.key} style={{ padding: '13px 15px' }}>
@@ -374,7 +375,7 @@ function RiskDistributionCard({
   tr,
 }: {
   slices: DistributionSlice[];
-  lang: string;
+  lang: LocaleCode;
   tr: (f: string, e: string) => string;
 }) {
   const data: PieRow[] = slices
@@ -441,7 +442,7 @@ function TopRisksCard({
   tr,
 }: {
   risks: ExecRisk[];
-  lang: string;
+  lang: LocaleCode;
   tr: (f: string, e: string) => string;
 }) {
   return (

--- a/frontend/src/features/assets/InventoryPage.tsx
+++ b/frontend/src/features/assets/InventoryPage.tsx
@@ -51,6 +51,7 @@ import { AttributeSearchBar } from '../attackSurface/AttributeSearchBar';
 import { CATEGORY_LABELS, type AssetCategory } from '../attackSurface/schemaTypes';
 import type { Asset } from '../../types/asset';
 import { BulkPreviewDialog, useGovernedBulk, type BulkChangeInput } from '../../shared/bulk';
+import type { LocaleCode } from '../../i18n/locales';
 
 const TYPE_ICON: Record<string, LucideIcon> = {
   Server: Server,
@@ -102,7 +103,7 @@ function isAssetList(cached: unknown): cached is Asset[] {
   return Array.isArray(cached) && cached.every((a) => typeof a === 'object' && a !== null && 'id' in a);
 }
 
-const t = (lang: 'fr' | 'en', fr: string, en: string) => (lang === 'fr' ? fr : en);
+const t = (lang: LocaleCode, fr: string, en: string) => (lang === 'fr' ? fr : en);
 
 export function InventoryPage() {
   const L = useUIStrings();

--- a/frontend/src/features/attackSurface/AssetSchemaSettings.tsx
+++ b/frontend/src/features/attackSurface/AssetSchemaSettings.tsx
@@ -9,6 +9,7 @@ import { useToast } from '../../hooks/useToast';
 import { useAuthStore } from '../../hooks/useAuthStore';
 import { apiErrorMessage } from '../../lib/apiError';
 import { useAssetSchemas } from './useAssetSchemas';
+import { useI18n } from '../../hooks/useI18n';
 import {
   ASSET_CATEGORIES,
   ATTRIBUTE_TYPES,
@@ -35,6 +36,7 @@ const inputSty = {
  * is validated against, so it is admin-gated and saved as a whole.
  */
 export default function AssetSchemaSettings() {
+  const { t } = useI18n();
   const toast = useToast();
   const isAdmin = useAuthStore((s) => s.hasPermission('*'));
   const { schemas, isLoading, isError, refetch, updateSchema, resetSchema } = useAssetSchemas();
@@ -166,7 +168,7 @@ export default function AssetSchemaSettings() {
           </div>
           <div className="flex items-center gap-2">
             <span className="text-xs" style={{ color: 'var(--fg-muted)' }}>
-              {draft.length} attribut{draft.length > 1 ? 's' : ''}
+              {t('common.attributes', { count: draft.length })}
               {current?.customized ? ' · personnalisé' : ' · par défaut'}
               {current?.version ? ` · v${current.version}` : ''}
             </span>

--- a/frontend/src/features/attackSurface/AttributeSearchBar.tsx
+++ b/frontend/src/features/attackSurface/AttributeSearchBar.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react';
 import { Filter, X } from 'lucide-react';
 import { useAssetSchemas } from './useAssetSchemas';
 import { ASSET_CATEGORIES, CATEGORY_LABELS, type AssetCategory } from './schemaTypes';
+import { useI18n } from '../../hooks/useI18n';
 
 /**
  * Search the inventory by typed attribute.
@@ -29,6 +30,7 @@ export function AttributeSearchBar({
   onChange,
   resultCount,
 }: AttributeSearchBarProps) {
+  const { t } = useI18n();
   const { defsFor } = useAssetSchemas();
   const defs = defsFor(category);
   const [pendingKey, setPendingKey] = useState('');
@@ -165,7 +167,7 @@ export function AttributeSearchBar({
 
         {typeof resultCount === 'number' && (category || activeTerms.length) ? (
           <span className="ml-auto text-[12px]" style={{ color: 'var(--fg-muted)' }}>
-            {resultCount} actif{resultCount > 1 ? 's' : ''}
+            {t('common.assets', { count: resultCount })}
           </span>
         ) : null}
       </div>

--- a/frontend/src/features/auth/MFAEnrollmentBanner.tsx
+++ b/frontend/src/features/auth/MFAEnrollmentBanner.tsx
@@ -21,6 +21,7 @@ import { useMFAStatus } from './useMfa';
 import { daysUntilDeadline, type MFAStatus } from './mfaPolicyService';
 import { MFAEnrollmentDialog } from './MFAEnrollmentDialog';
 import { useUIStore } from '../../store/uiStore';
+import { catalogs, translate, DEFAULT_LOCALE, type LocaleCode } from '../../i18n';
 
 /**
  * Session-scoped dismissal for the soft prompt.
@@ -49,8 +50,16 @@ interface Copy {
  * implementations of "are they required?" is how the banner and the guard end
  * up disagreeing, and the one the user believes is the wrong one.
  */
-export function copyFor(status: MFAStatus, tr: (fr: string, en: string) => string): Copy | null {
+export function copyFor(
+  status: MFAStatus,
+  tr: (fr: string, en: string) => string,
+  /** Locale for the day count's plural form. Optional so existing callers hold. */
+  locale: LocaleCode = DEFAULT_LOCALE,
+): Copy | null {
   const days = daysUntilDeadline(status);
+  // "1 jour" / "2 jours" / "0 days" — the plural rule belongs to the language,
+  // not to a `days > 1` written into a French sentence.
+  const dayCount = (n: number) => translate(catalogs, locale, 'common.days', { params: { count: n } });
 
   switch (status.state) {
     case 'configured':
@@ -80,8 +89,8 @@ export function copyFor(status: MFAStatus, tr: (fr: string, en: string) => strin
                 'Your role grants access to sensitive data and settings, so two-factor authentication is required.',
               )
             : tr(
-                `Votre rôle donne accès à des données sensibles. Il vous reste ${days} jour${days > 1 ? 's' : ''} pour activer le MFA.`,
-                `Your role grants access to sensitive data. You have ${days} day${days === 1 ? '' : 's'} left to enable MFA.`,
+                `Votre rôle donne accès à des données sensibles. Il vous reste ${dayCount(days)} pour activer le MFA.`,
+                `Your role grants access to sensitive data. You have ${dayCount(days)} left to enable MFA.`,
               ),
         cta: tr('Activer le MFA', 'Enable MFA'),
       };
@@ -98,8 +107,8 @@ export function copyFor(status: MFAStatus, tr: (fr: string, en: string) => strin
                 'Access to OpenRisk will be blocked shortly until MFA is enabled.',
               )
             : tr(
-                `Il vous reste ${days} jour${days > 1 ? 's' : ''}. Passé ce délai, l'accès sera bloqué jusqu'à l'activation du MFA.`,
-                `You have ${days} day${days === 1 ? '' : 's'} left. After that, access is blocked until MFA is enabled.`,
+                `Il vous reste ${dayCount(days)}. Passé ce délai, l'accès sera bloqué jusqu'à l'activation du MFA.`,
+                `You have ${dayCount(days)} left. After that, access is blocked until MFA is enabled.`,
               ),
         cta: tr('Activer le MFA', 'Enable MFA'),
       };
@@ -180,7 +189,7 @@ export function MFAEnrollmentBanner() {
 
   if (!status) return null;
 
-  const copy = copyFor(status, tr);
+  const copy = copyFor(status, tr, lang);
   if (!copy) return null;
   if (copy.dismissible && dismissed) return null;
 

--- a/frontend/src/features/auth/SessionsPanel.tsx
+++ b/frontend/src/features/auth/SessionsPanel.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 
 import { useUIStore } from '../../store/uiStore';
 import { DangerConfirm } from '../../shared/DangerConfirm';
+import { localeTag, type LocaleCode } from '../../i18n/locales';
 import {
   listSessions,
   revokeOtherSessions,
@@ -20,7 +21,7 @@ import {
   type SessionRecord,
 } from './authService';
 
-const copyFor = (lang: 'fr' | 'en') =>
+const copyFor = (lang: LocaleCode) =>
   lang === 'en'
     ? {
         title: 'Active sessions',
@@ -76,11 +77,11 @@ const copyFor = (lang: 'fr' | 'en') =>
         unknown: 'inconnue',
       };
 
-function formatWhen(iso: string | undefined, lang: 'fr' | 'en', fallback: string): string {
+function formatWhen(iso: string | undefined, lang: LocaleCode, fallback: string): string {
   if (!iso) return fallback;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return fallback;
-  return d.toLocaleString(lang === 'en' ? 'en-GB' : 'fr-FR', {
+  return d.toLocaleString(localeTag(lang), {
     dateStyle: 'medium',
     timeStyle: 'short',
   });

--- a/frontend/src/features/auth/authStrings.ts
+++ b/frontend/src/features/auth/authStrings.ts
@@ -460,11 +460,12 @@ const en: AuthCopy = {
     `This address already signs in with ${existing}. Use ${existing} or your password.`,
 };
 
-const BUNDLES: Record<Lang, AuthCopy> = { fr, en };
+// Partial: a registered language without auth copy falls back in `authCopy`.
+const BUNDLES: Partial<Record<Lang, AuthCopy>> = { fr, en };
 
 /** The auth copy for a language. */
 export function authCopy(lang: Lang): AuthCopy {
-  return BUNDLES[lang] ?? BUNDLES.fr;
+  return BUNDLES[lang] ?? fr;
 }
 
 /** Human label for a zxcvbn score, 0..4. */

--- a/frontend/src/features/automation/automationMeta.ts
+++ b/frontend/src/features/automation/automationMeta.ts
@@ -1,3 +1,4 @@
+import type { LocaleCode } from '../../i18n/locales';
 // Copyright (c) 2026 OpenDefender Contributors
 // SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
@@ -28,7 +29,7 @@ import type {
   SLAStatus,
 } from './automationService';
 
-type Lang = 'fr' | 'en';
+type Lang = LocaleCode;
 export const pick = (m: { fr: string; en: string }, lang: Lang) => (lang === 'fr' ? m.fr : m.en);
 
 export const TRIGGER_META: Record<

--- a/frontend/src/features/billing/BillingPanel.tsx
+++ b/frontend/src/features/billing/BillingPanel.tsx
@@ -6,6 +6,8 @@
 // cancellation, invoices — plus the opt-in telemetry consent. Reads the real
 // entitlements/billing endpoints; the backend enforces every gate.
 
+import { type BoundFormatters } from '../../i18n';
+import { useFormat } from '../../hooks/useI18n';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { Check, Sparkles } from 'lucide-react';
@@ -58,12 +60,12 @@ const PLAN_HIGHLIGHTS: Record<PlanKey, string[]> = {
   ],
 };
 
-function formatPrice(p: Price | undefined): string {
+function formatPrice(p: Price | undefined, fmt: BoundFormatters): string {
   if (!p) return '—';
   if (p.custom) return 'Sur devis';
   if (p.amount === 0) return 'Gratuit';
   if (p.currency === 'EUR') return `${p.amount} € / mois`;
-  return `${p.amount.toLocaleString('fr-FR')} ${p.currency} / mois`;
+  return `${fmt.currency(p.amount, { currency: p.currency })} / mois`;
 }
 
 const LIMIT_LABEL: Record<string, string> = {
@@ -74,6 +76,7 @@ const LIMIT_LABEL: Record<string, string> = {
 };
 
 export function BillingPanel() {
+  const fmt = useFormat();
   const { data: ent, isLoading } = useEntitlements();
   const { data: billing } = useBilling();
   const startTrial = useStartTrial();
@@ -248,7 +251,7 @@ export function BillingPanel() {
                 {plan === 'pro' && <Sparkles size={14} className="text-accent" />}
               </div>
               <div className="text-[12px] text-ink-soft mb-2">{PLAN_PITCH[plan]}</div>
-              <div className="disp text-[20px] font-bold text-ink mb-3">{formatPrice(price)}</div>
+              <div className="disp text-[20px] font-bold text-ink mb-3">{formatPrice(price, fmt)}</div>
               <ul className="space-y-1.5 mb-4 flex-1">
                 {PLAN_HIGHLIGHTS[plan].map((h) => (
                   <li key={h} className="flex items-start gap-1.5 text-[12.5px] text-ink-soft">
@@ -293,11 +296,11 @@ export function BillingPanel() {
               <div key={inv.id} className="flex items-center justify-between text-[12.5px]">
                 <span className="text-ink-soft">
                   {inv.number || inv.id.slice(0, 8)} ·{' '}
-                  {new Date(inv.created_at).toLocaleDateString('fr-FR')}
+                  {fmt.date(inv.created_at)}
                 </span>
                 <span className="flex items-center gap-3">
                   <span className="font-semibold text-ink">
-                    {(inv.amount_cents / 100).toLocaleString('fr-FR')} {inv.currency}
+                    {fmt.currency(inv.amount_cents / 100, { currency: inv.currency })}
                   </span>
                   {inv.hosted_url && (
                     <a

--- a/frontend/src/features/billing/DangerZonePanel.tsx
+++ b/frontend/src/features/billing/DangerZonePanel.tsx
@@ -6,6 +6,7 @@
 // code (for enrolled admins), and shows the 30-day cancelable grace window with a
 // running countdown. Nothing is destroyed synchronously.
 
+import { useFormat } from '../../hooks/useI18n';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { AlertTriangle, Download } from 'lucide-react';
@@ -14,6 +15,7 @@ import { orgDeletionService } from '../../services/entitlementService';
 import { useOrgDeletion, useRequestOrgDeletion, useCancelOrgDeletion } from './useEntitlements';
 
 export function DangerZonePanel() {
+  const fmt = useFormat();
   const user = useAuthStore((s) => s.user);
   const orgName = user?.org_name ?? '';
   const { data: state } = useOrgDeletion();
@@ -74,7 +76,7 @@ export function DangerZonePanel() {
           L'organisation <strong>{orgName}</strong> sera définitivement supprimée le{' '}
           <strong>
             {state.scheduled_purge_at
-              ? new Date(state.scheduled_purge_at).toLocaleDateString('fr-FR')
+              ? fmt.date(state.scheduled_purge_at)
               : ''}
           </strong>
           .

--- a/frontend/src/features/compliance/AuditDetailPage.tsx
+++ b/frontend/src/features/compliance/AuditDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 } from './complianceMeta';
 import { useState } from 'react';
 import type { AuditStatus } from '../../types/compliance';
+import { pickLocalized } from '../../i18n/locales';
 
 export function AuditDetailPage() {
   const { auditId } = useParams<{ auditId: string }>();
@@ -87,10 +88,10 @@ export function AuditDetailPage() {
                 background: `color-mix(in srgb, ${status.color} 14%, transparent)`,
               }}
             >
-              {status[lang]}
+              {pickLocalized(lang, status)}
             </span>
             <span className="text-ink-muted">
-              {AUDIT_TYPE_LABEL[audit.type]?.[lang] ?? audit.type}
+              {pickLocalized(lang, AUDIT_TYPE_LABEL[audit.type]) ?? audit.type}
             </span>
             {framework && (
               // Cross-link to the framework, which is a sibling branch of the
@@ -171,7 +172,7 @@ export function AuditDetailPage() {
                           : `color-mix(in srgb, ${m.color} 12%, transparent)`,
                       }}
                     >
-                      {m[lang]}
+                      {pickLocalized(lang, m)}
                     </button>
                   );
                 })}
@@ -211,7 +212,7 @@ export function AuditDetailPage() {
             'The audit and its history are removed. Remediation plans already generated are kept.',
           )}
           impact={[
-            { label: tr('Statut', 'Status'), value: status?.[lang] ?? audit.status },
+            { label: tr('Statut', 'Status'), value: pickLocalized(lang, status) ?? audit.status },
             {
               label: tr('Référentiel', 'Framework'),
               value: framework?.name ?? tr('Programme entier', 'Programme-wide'),

--- a/frontend/src/features/compliance/AuditsPage.tsx
+++ b/frontend/src/features/compliance/AuditsPage.tsx
@@ -5,6 +5,7 @@
 // GET/POST/PATCH/DELETE /compliance/audits. Schedule an audit, move it through
 // its lifecycle (planned → in progress → completed), and keep the history.
 
+import { localeTag } from '../../i18n/locales';
 import { useMemo, useState } from 'react';
 import { CalendarClock, Plus, Trash2, Wand2, ArrowLeft } from 'lucide-react';
 import { useNavigate, Link } from 'react-router';
@@ -62,7 +63,7 @@ export function AuditsPage() {
       : tr('Programme entier', 'Whole program');
   const fmtDate = (d: string | null) =>
     d
-      ? new Date(d).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+      ? new Date(d).toLocaleDateString(localeTag(lang), {
           day: '2-digit',
           month: 'short',
           year: 'numeric',

--- a/frontend/src/features/compliance/ComplianceScreen.tsx
+++ b/frontend/src/features/compliance/ComplianceScreen.tsx
@@ -42,8 +42,10 @@ import { useFrameworks } from './useCompliance';
 import { useGenerateReport } from '../reports/useReportJobs';
 import { CreateFrameworkDialog, ImportFrameworkDialog } from './ComplianceModals';
 import { ImpactDialog } from '../../shared/ImpactDialog';
+import { useI18n } from '../../hooks/useI18n';
 
 export function ComplianceScreen() {
+  const { t } = useI18n();
   const L = useUIStrings();
   const lang = useUIStore((s) => s.lang);
   const navigate = useNavigate();
@@ -171,8 +173,8 @@ export function ComplianceScreen() {
                 </div>
                 <div className="text-[13.5px] text-ink-soft leading-relaxed mb-3.5 max-w-[520px]">
                   {tr(
-                    `${totalControls} contrôles suivis sur ${fws.length} référentiel${fws.length > 1 ? 's' : ''}. ${gaps} contrôle${gaps > 1 ? 's' : ''} requièrent une action.`,
-                    `${totalControls} controls tracked across ${fws.length} framework${fws.length > 1 ? 's' : ''}. ${gaps} control${gaps > 1 ? 's' : ''} need action.`,
+                    `${totalControls} contrôles suivis sur ${t('common.frameworks', { count: fws.length })}. ${t('common.controls', { count: gaps })} requièrent une action.`,
+                    `${totalControls} controls tracked across ${t('common.frameworks', { count: fws.length })}. ${t('common.controls', { count: gaps })} need action.`,
                   )}
                 </div>
                 <div className="flex gap-2.5 flex-wrap">

--- a/frontend/src/features/compliance/RemediationDetailPage.tsx
+++ b/frontend/src/features/compliance/RemediationDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   formatDate,
 } from './complianceMeta';
 import type { RemediationStatus } from '../../types/compliance';
+import { pickLocalized } from '../../i18n/locales';
 
 export function RemediationDetailPage() {
   const { planId } = useParams<{ planId: string }>();
@@ -75,7 +76,7 @@ export function RemediationDetailPage() {
                 background: `color-mix(in srgb, ${status.color} 14%, transparent)`,
               }}
             >
-              {status[lang]}
+              {pickLocalized(lang, status)}
             </span>
             <span
               className="text-[11.5px] font-semibold px-2 py-[3px] rounded-md"
@@ -84,7 +85,7 @@ export function RemediationDetailPage() {
                 background: `color-mix(in srgb, ${priority.color} 14%, transparent)`,
               }}
             >
-              {priority[lang]}
+              {pickLocalized(lang, priority)}
             </span>
             {overdue && (
               <span
@@ -166,7 +167,7 @@ export function RemediationDetailPage() {
                           : `color-mix(in srgb, ${m.color} 12%, transparent)`,
                       }}
                     >
-                      {m[lang]}
+                      {pickLocalized(lang, m)}
                     </button>
                   );
                 })}
@@ -197,8 +198,8 @@ export function RemediationDetailPage() {
             'The gap it addresses stays open in the gap analysis.',
           )}
           impact={[
-            { label: tr('Statut', 'Status'), value: status?.[lang] ?? plan.status },
-            { label: tr('Priorité', 'Priority'), value: priority?.[lang] ?? plan.priority },
+            { label: tr('Statut', 'Status'), value: pickLocalized(lang, status) ?? plan.status },
+            { label: tr('Priorité', 'Priority'), value: pickLocalized(lang, priority) ?? plan.priority },
             { label: tr('Échéance', 'Due date'), value: formatDate(plan.due_date, lang) },
           ]}
           confirmLabel={tr('Supprimer', 'Delete')}

--- a/frontend/src/features/compliance/RemediationPage.tsx
+++ b/frontend/src/features/compliance/RemediationPage.tsx
@@ -6,6 +6,7 @@
 // and track status (open → in progress → completed). Plans link back to the
 // compliance control they remediate.
 
+import { localeTag } from '../../i18n/locales';
 import { useMemo, useState } from 'react';
 import { Wrench, Plus, Trash2, AlertCircle, ArrowLeft } from 'lucide-react';
 import { useNavigate, Link } from 'react-router';
@@ -59,7 +60,7 @@ export function RemediationPage() {
 
   const fmtDate = (d: string | null) =>
     d
-      ? new Date(d).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+      ? new Date(d).toLocaleDateString(localeTag(lang), {
           day: '2-digit',
           month: 'short',
           year: 'numeric',

--- a/frontend/src/features/compliance/complianceMeta.ts
+++ b/frontend/src/features/compliance/complianceMeta.ts
@@ -8,7 +8,9 @@
 // "En cours" beside a detail showing "In progress" is the kind of drift nobody
 // notices until a screenshot goes to a regulator.
 
+import { localeTag } from '../../i18n/locales';
 import type { AuditStatus, RemediationPriority, RemediationStatus } from '../../types/compliance';
+import type { LocaleCode } from '../../i18n/locales';
 
 export interface Meta {
   color: string;
@@ -59,11 +61,11 @@ export const REMEDIATION_STATUS_ORDER: RemediationStatus[] = [
 ];
 
 /** Formats an ISO date for display, or an em dash when absent. */
-export function formatDate(iso: string | null | undefined, lang: 'fr' | 'en'): string {
+export function formatDate(iso: string | null | undefined, lang: LocaleCode): string {
   if (!iso) return '—';
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '—';
-  return d.toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+  return d.toLocaleDateString(localeTag(lang), {
     day: '2-digit',
     month: 'short',
     year: 'numeric',

--- a/frontend/src/features/cti/CveDetailDrawer.tsx
+++ b/frontend/src/features/cti/CveDetailDrawer.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { localeTag, type LocaleCode } from '../../i18n/locales';
 import { useQuery } from '@tanstack/react-query';
 import { ExternalLink, ShieldAlert, X } from 'lucide-react';
 import { SkeletonRows } from '../../shared/ui';
@@ -142,7 +143,7 @@ export function CveDetailDrawer({
                 <Section title={tr('Échéance CISA', 'CISA due date')}>
                   <p className="text-[13px]" style={{ color: 'var(--critical)' }}>
                     {new Date(v.cisa_due_date).toLocaleDateString(
-                      lang === 'fr' ? 'fr-FR' : 'en-GB',
+                      localeTag(lang),
                     )}
                   </p>
                 </Section>
@@ -226,8 +227,8 @@ function Row({ label, value }: { label: string; value: string }) {
   );
 }
 
-function fmtDate(iso: string | undefined, lang: string): string {
+function fmtDate(iso: string | undefined, lang: LocaleCode): string {
   if (!iso) return '—';
   const d = new Date(iso);
-  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-GB');
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString(localeTag(lang));
 }

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -11,6 +11,7 @@
 //
 // See docs/W0-06_SECURITY_COMMAND_CENTER.md for the contract inventory.
 
+import { localeTag } from '../../i18n/locales';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import {
@@ -57,6 +58,7 @@ import { AuditDashboard } from './AuditDashboard';
 import { EstateDashboard } from './EstateDashboard';
 import { ViewerDashboard } from './ViewerDashboard';
 import { ExecutiveDashboard } from '../analytics/ExecutiveDashboard';
+import type { LocaleCode } from '../../i18n/locales';
 
 const Card = ({
   children,
@@ -181,7 +183,7 @@ function PostureDashboard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [risks]);
 
-  const fmt = (n: number) => Math.round(n).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US');
+  const fmt = (n: number) => Math.round(n).toLocaleString(localeTag(lang));
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -315,7 +317,7 @@ function KpiGrid({
 }: {
   values: { total: number; critical: number; mitig: number; resolved: number };
   fmt: (n: number) => string;
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   query: StatsQuery;
   openedInPeriod: number;
   selection: PeriodSelection;

--- a/frontend/src/features/dashboard/ExecDashboard.tsx
+++ b/frontend/src/features/dashboard/ExecDashboard.tsx
@@ -14,6 +14,7 @@
 // Nothing is rendered now until it has been read. A failure says so, and offers
 // a retry; a genuine zero is still a zero, and is now distinguishable from one.
 
+import { localeTag } from '../../i18n/locales';
 import { useNavigate } from 'react-router';
 import { Coins, AlertTriangle, ShieldAlert, CheckCircle2 } from 'lucide-react';
 import { useUIStore } from '../../store/uiStore';
@@ -41,7 +42,7 @@ export function ExecDashboard() {
   const kris = data?.kris ?? [];
 
   const money = (n: number) =>
-    new Intl.NumberFormat(lang === 'fr' ? 'fr-FR' : 'en-US', {
+    new Intl.NumberFormat(localeTag(lang), {
       notation: n >= 1_000_000 ? 'compact' : 'standard',
       maximumFractionDigits: 1,
     }).format(n) + ' FCFA';
@@ -147,7 +148,7 @@ export function ExecDashboard() {
                   className="mono text-[22px] font-bold leading-none"
                   style={{ color: KRI_COL[k.severity] ?? 'var(--fg-primary)' }}
                 >
-                  {new Intl.NumberFormat(lang === 'fr' ? 'fr-FR' : 'en-US', {
+                  {new Intl.NumberFormat(localeTag(lang), {
                     maximumFractionDigits: 1,
                   }).format(k.value)}
                   {kriUnit(k.unit)}

--- a/frontend/src/features/dashboard/PeriodControl.tsx
+++ b/frontend/src/features/dashboard/PeriodControl.tsx
@@ -22,6 +22,7 @@ import { useId, useState } from 'react';
 import { CalendarRange, Check } from 'lucide-react';
 
 import { PERIOD_PRESETS, periodLabel, type PeriodSelection, type PeriodPreset } from './period';
+import type { LocaleCode } from '../../i18n/locales';
 
 export function PeriodControl({
   selection,
@@ -35,7 +36,7 @@ export function PeriodControl({
 }: {
   selection: PeriodSelection;
   onChange: (next: PeriodSelection) => void;
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   scopeNote: string;
 }) {
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);

--- a/frontend/src/features/dashboard/WidgetState.tsx
+++ b/frontend/src/features/dashboard/WidgetState.tsx
@@ -31,9 +31,10 @@ import { AlertTriangle, CalendarX, Lock, type LucideIcon } from 'lucide-react';
 import { EmptyState } from '../../shared/EmptyState';
 import { Btn, Skeleton } from '../../shared/ui';
 import { isPermissionError } from './widgetError';
+import type { LocaleCode } from '../../i18n/locales';
 
 export interface WidgetStateProps {
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   isLoading: boolean;
   error: unknown;
   /** True when the fetch succeeded and returned nothing to draw. */

--- a/frontend/src/features/dashboard/period.ts
+++ b/frontend/src/features/dashboard/period.ts
@@ -20,6 +20,8 @@
 
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
+import type { LocaleCode } from '../../i18n/locales';
+import { pickLocalized } from '../../i18n/locales';
 
 /** The presets the server accepts. Anything else is a 400, by design. */
 export const PERIOD_PRESETS = ['all', '7d', '30d', '90d'] as const;
@@ -108,7 +110,7 @@ export function periodToSearchParams(
 }
 
 /** Human label, FR/EN. Kept beside the values so a new preset cannot ship unlabelled. */
-export function periodLabel(sel: PeriodSelection, lang: 'fr' | 'en'): string {
+export function periodLabel(sel: PeriodSelection, lang: LocaleCode): string {
   if (sel.kind === 'custom') return `${sel.from} → ${sel.to}`;
   const labels: Record<PeriodPreset, { fr: string; en: string }> = {
     all: { fr: 'Tout', en: 'All time' },
@@ -116,7 +118,7 @@ export function periodLabel(sel: PeriodSelection, lang: 'fr' | 'en'): string {
     '30d': { fr: '30 jours', en: '30 days' },
     '90d': { fr: '90 jours', en: '90 days' },
   };
-  return labels[sel.preset][lang];
+  return pickLocalized(lang, labels[sel.preset]) ?? sel.preset;
 }
 
 /**

--- a/frontend/src/features/dashboard/shared.tsx
+++ b/frontend/src/features/dashboard/shared.tsx
@@ -6,6 +6,7 @@
 // card shell and the persona header. Keeps the personas thin — each just wires its
 // own real data into these.
 
+import { localeTag, type LocaleCode } from '../../i18n/locales';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { FileText, type LucideIcon } from 'lucide-react';
 import { InfoHint } from '../../shared/InfoHint';
@@ -64,8 +65,8 @@ export const Card = ({
 );
 
 /** Locale number formatter shared by every persona. */
-export const numFmt = (lang: string) => (n: number) =>
-  Math.round(n).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US');
+export const numFmt = (lang: LocaleCode) => (n: number) =>
+  Math.round(n).toLocaleString(localeTag(lang));
 
 /* ---------------- persona header ---------------- */
 

--- a/frontend/src/features/evidence/EvidenceDrawer.tsx
+++ b/frontend/src/features/evidence/EvidenceDrawer.tsx
@@ -16,6 +16,7 @@ import {
   useUpdateEvidence,
 } from './useEvidence';
 import { EVIDENCE_STATUS_META, EVIDENCE_TYPE_META, expiryLabel } from './evidenceMeta';
+import { localeTag } from '../../i18n/locales';
 
 export function EvidenceDrawer({
   evidenceId,
@@ -94,7 +95,7 @@ export function EvidenceDrawer({
                 </dt>
                 <dd className="text-ink mt-0.5">
                   {new Date(evidence.collected_at).toLocaleDateString(
-                    lang === 'fr' ? 'fr-FR' : 'en-GB',
+                    localeTag(lang),
                   )}
                 </dd>
               </div>
@@ -105,7 +106,7 @@ export function EvidenceDrawer({
                 <dd className="text-ink mt-0.5">
                   {evidence.valid_until
                     ? new Date(evidence.valid_until).toLocaleDateString(
-                        lang === 'fr' ? 'fr-FR' : 'en-GB',
+                        localeTag(lang),
                       )
                     : tr("N'expire pas", 'Never expires')}
                   {evidence.days_until_expiry !== undefined ? (

--- a/frontend/src/features/evidence/EvidenceLibraryPage.tsx
+++ b/frontend/src/features/evidence/EvidenceLibraryPage.tsx
@@ -41,6 +41,7 @@ import { EvidenceDrawer } from './EvidenceDrawer';
 import { CreateEvidenceModal } from './CreateEvidenceModal';
 import { evidenceService } from '../../services/evidenceService';
 import type { Evidence, EvidenceStatus, EvidenceType } from '../../types/evidence';
+import { localeTag } from '../../i18n/locales';
 
 const TYPE_ICON: Record<EvidenceType, typeof FileText> = {
   document: FileText,
@@ -262,7 +263,7 @@ export function EvidenceLibraryPage() {
                       </td>
                       <td className="px-4 py-3 text-ink-muted whitespace-nowrap">
                         {new Date(e.collected_at).toLocaleDateString(
-                          lang === 'fr' ? 'fr-FR' : 'en-GB',
+                          localeTag(lang),
                         )}
                       </td>
                       <td className="px-4 py-3">

--- a/frontend/src/features/evidence/MissingEvidencePage.tsx
+++ b/frontend/src/features/evidence/MissingEvidencePage.tsx
@@ -32,6 +32,7 @@ import { useMissingEvidence, useCreateEvidence } from './useEvidence';
 import { MISSING_KIND_META } from './evidenceMeta';
 import { CreateEvidenceModal } from './CreateEvidenceModal';
 import type { MissingControl, MissingKind } from '../../types/evidence';
+import { localeTag } from '../../i18n/locales';
 
 const FILTERS: { key: 'all' | MissingKind; fr: string; en: string }[] = [
   { key: 'all', fr: 'Tout', en: 'All' },
@@ -217,7 +218,7 @@ export function MissingEvidencePage() {
                                     {' '}
                                     · {tr('échéance', 'due')}{' '}
                                     {new Date(m.nearest_expiry).toLocaleDateString(
-                                      lang === 'fr' ? 'fr-FR' : 'en-GB',
+                                      localeTag(lang),
                                     )}
                                   </span>
                                 ) : null}

--- a/frontend/src/features/infrastructure/scannerMeta.ts
+++ b/frontend/src/features/infrastructure/scannerMeta.ts
@@ -1,3 +1,4 @@
+import type { LocaleCode } from '../../i18n/locales';
 // Copyright (c) 2026 OpenDefender Contributors
 // SPDX-License-Identifier: LicenseRef-OpenRisk-Commercial
 //
@@ -297,7 +298,7 @@ export function criticalityFromFactor(f: number): AssetCriticality {
   return 'LOW';
 }
 
-export function scheduleLabel(minutes: number, lang: 'fr' | 'en'): string {
+export function scheduleLabel(minutes: number, lang: LocaleCode): string {
   switch (minutes) {
     case 60:
       return lang === 'fr' ? 'Horaire' : 'Hourly';
@@ -312,7 +313,7 @@ export function scheduleLabel(minutes: number, lang: 'fr' | 'en'): string {
   }
 }
 
-export function timeAgo(iso: string | null | undefined, lang: 'fr' | 'en'): string {
+export function timeAgo(iso: string | null | undefined, lang: LocaleCode): string {
   if (!iso) return '—';
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '—';

--- a/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
+++ b/frontend/src/features/mitigations/MitigationDetailDrawer.tsx
@@ -44,7 +44,7 @@ export const MitigationDetailDrawer = ({
 }: MitigationDetailDrawerProps) => {
   // Esc closes this overlay (spec §2).
   useEscapeToClose(isOpen, onClose);
-  const { t } = useI18n();
+  const { t, fmt } = useI18n();
   const [activeTab, setActiveTab] = useState<
     'overview' | 'sub-actions' | 'evidence' | 'timeline' | 'ai'
   >('overview');
@@ -172,11 +172,7 @@ export const MitigationDetailDrawer = ({
                   <div>
                     <p className="text-xs text-fg-muted mb-1">Échéance</p>
                     <p className="text-sm text-fg-primary">
-                      {new Date(mitigation.due_date).toLocaleDateString('fr-FR', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
+                      {fmt.date(mitigation.due_date, { year: 'numeric', month: 'long', day: 'numeric' })}
                     </p>
                   </div>
 

--- a/frontend/src/features/mitigations/MitigationGanttView.tsx
+++ b/frontend/src/features/mitigations/MitigationGanttView.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { useFormat } from '../../hooks/useI18n';
 import { useMemo, memo, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import type { Mitigation } from '../../types/mitigation';
@@ -19,6 +20,7 @@ export const MitigationGanttView = memo(function MitigationGanttView({
   isLoading = false,
   onRowClick,
 }: MitigationGanttViewProps) {
+  const fmt = useFormat();
   const containerRef = useRef<HTMLDivElement>(null);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -99,7 +101,7 @@ export const MitigationGanttView = memo(function MitigationGanttView({
                     )}
                   >
                     {i % 7 === 0 &&
-                      date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short' })}
+                      fmt.date(date, { day: 'numeric', month: 'short' })}
                   </div>
                 );
               })}

--- a/frontend/src/features/mitigations/MitigationTableView.tsx
+++ b/frontend/src/features/mitigations/MitigationTableView.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { useFormat } from '../../hooks/useI18n';
 import { useState, useMemo, memo } from 'react';
 import { motion } from 'framer-motion';
 import { ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
@@ -25,6 +26,7 @@ export const MitigationTableView = memo(function MitigationTableView({
   isLoading = false,
   onRowClick,
 }: MitigationTableViewProps) {
+  const fmt = useFormat();
   const [sortField, setSortField] = useState<SortField>('due_date');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
@@ -172,7 +174,7 @@ export const MitigationTableView = memo(function MitigationTableView({
               </td>
               <td className="px-4 py-3 text-fg-secondary">{mitigation.progress_percentage}%</td>
               <td className="px-4 py-3 text-fg-secondary">
-                {new Date(mitigation.due_date).toLocaleDateString('fr-FR')}
+                {fmt.date(mitigation.due_date)}
               </td>
               <td className="px-4 py-3">
                 {mitigation.assigned_to_user ? (

--- a/frontend/src/features/mitigations/MitigationsBoard.tsx
+++ b/frontend/src/features/mitigations/MitigationsBoard.tsx
@@ -6,6 +6,7 @@
 // Table, and a Gantt timeline positioned by real start/due dates. Loading skeleton
 // + empty state on all three.
 
+import { localeTag } from '../../i18n/locales';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
@@ -560,7 +561,7 @@ function GanttView({
       const t = min + (range * k) / 4;
       ticks.push({
         pct: (k / 4) * 100,
-        label: new Date(t).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+        label: new Date(t).toLocaleDateString(localeTag(lang), {
           day: '2-digit',
           month: 'short',
         }),

--- a/frontend/src/features/mitigations/useMitigations.ts
+++ b/frontend/src/features/mitigations/useMitigations.ts
@@ -3,6 +3,8 @@
 //
 // Real /mitigations list shaped into the dc.html Kanban columns.
 
+import { DEFAULT_LOCALE, formatDate, type LocaleCode } from '../../i18n';
+import { useUIStore } from '../../store/uiStore';
 import { useQuery } from '@tanstack/react-query';
 import { mitigationService } from '../../services/mitigationService';
 import type { Mitigation } from '../../types/mitigation';
@@ -44,15 +46,17 @@ const CRIT: Record<string, Criticality> = {
   low: 'low',
 };
 
-function fmtDate(iso?: string): string {
+function fmtDate(iso: string | undefined, locale: LocaleCode): string {
   if (!iso) return '—';
-  const d = new Date(iso);
-  return Number.isNaN(d.getTime())
-    ? '—'
-    : d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' });
+  return formatDate(locale, iso, { day: '2-digit', month: 'short' });
 }
 
-export function mapMitigation(m: Mitigation): UiMiti {
+/**
+ * `locale` is explicit rather than read from the store: this mapper runs inside
+ * a query function, where a hook cannot. The caller passes the active language
+ * and the query key carries it, so switching language refetches the labels.
+ */
+export function mapMitigation(m: Mitigation, locale: LocaleCode = DEFAULT_LOCALE): UiMiti {
   const mm = m as Mitigation & {
     assignee?: string;
     risk_title?: string;
@@ -66,7 +70,7 @@ export function mapMitigation(m: Mitigation): UiMiti {
     title: m.title,
     risk: mm.risk_title || (m.risk_id ? `#${m.risk_id.slice(0, 8)}` : '—'),
     owner: initialsOf(mm.assignee),
-    deadline: fmtDate(m.due_date),
+    deadline: fmtDate(m.due_date, locale),
     // Backend serialises the field as `progress`; keep the legacy fallback.
     progress: mm.progress ?? m.progress_percentage ?? 0,
     crit: CRIT[(m.priority ?? 'low').toLowerCase()] ?? 'low',
@@ -80,11 +84,14 @@ export function mapMitigation(m: Mitigation): UiMiti {
 }
 
 export function useMitigations() {
+  const locale = useUIStore((s) => s.lang);
   const query = useQuery({
-    queryKey: ['mitigations', 'board'],
+    // The locale is part of the key: the mapper bakes formatted dates into the
+    // rows, so a language switch has to produce a different cache entry.
+    queryKey: ['mitigations', 'board', locale],
     queryFn: async () => {
       const res = await mitigationService.listMitigations({ page: 1, per_page: 200 });
-      return (res.items ?? []).map(mapMitigation);
+      return (res.items ?? []).map((m) => mapMitigation(m, locale));
     },
   });
   const items = query.data ?? [];

--- a/frontend/src/features/notifications/NotificationCategoryPrefs.tsx
+++ b/frontend/src/features/notifications/NotificationCategoryPrefs.tsx
@@ -9,6 +9,7 @@
 
 import { useState } from 'react';
 import { useUIStore } from '../../store/uiStore';
+import { pickLocalized } from '../../i18n/locales';
 import {
   NOTIF_CATEGORIES,
   loadNotifPrefs,
@@ -93,21 +94,21 @@ export function NotificationCategoryPrefs() {
               <Icon size={16} strokeWidth={1.8} />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="text-[13.5px] font-medium text-ink">{c.label[lang]}</div>
-              <div className="text-[11.5px] text-ink-muted leading-snug">{c.desc[lang]}</div>
+              <div className="text-[13.5px] font-medium text-ink">{pickLocalized(lang, c.label)}</div>
+              <div className="text-[11.5px] text-ink-muted leading-snug">{pickLocalized(lang, c.desc)}</div>
             </div>
             <div className="w-[52px] flex justify-center">
               <Switch
                 on={p.inApp}
                 onClick={() => toggle(c.key, 'inApp')}
-                label={`${c.label[lang]} in-app`}
+                label={`${pickLocalized(lang, c.label) ?? ''} in-app`}
               />
             </div>
             <div className="w-[52px] flex justify-center">
               <Switch
                 on={p.email}
                 onClick={() => toggle(c.key, 'email')}
-                label={`${c.label[lang]} email`}
+                label={`${pickLocalized(lang, c.label) ?? ''} email`}
               />
             </div>
           </div>

--- a/frontend/src/features/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/features/onboarding/OnboardingChecklist.tsx
@@ -20,6 +20,7 @@ import { Check, ArrowRight, Sparkles, Loader2, LifeBuoy } from 'lucide-react';
 import { useUIStore } from '../../store/uiStore';
 import { i18n, type ActivationStep } from '../../services/activationService';
 import { useActivationState, useCelebrateActivation } from './useActivation';
+import type { LocaleCode } from '../../i18n/locales';
 
 export function OnboardingChecklist() {
   const navigate = useNavigate();
@@ -164,7 +165,7 @@ function StepRow({
   nowLabel,
 }: {
   step: ActivationStep;
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   isCurrent: boolean;
   onGo: () => void;
   ctaLabel: string;

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -25,6 +25,7 @@ import {
 } from '../useActivation';
 import { useCatalogs, useImportCatalogAsFramework } from '../../compliance/useCompliance';
 import { WIZARD_STEPS, stepPath } from './OnboardingWizard';
+import type { LocaleCode } from '../../../i18n/locales';
 
 // ---------------------------------------------------------------------------
 // Shared primitives
@@ -345,7 +346,7 @@ export function ProfileStep() {
   const [fullName, setFullName] = useState('');
   const [jobTitle, setJobTitle] = useState('');
   const [avatarUrl, setAvatarUrl] = useState('');
-  const [language, setLanguage] = useState<'fr' | 'en'>(lang);
+  const [language, setLanguage] = useState<LocaleCode>(lang);
   const [notifyInApp, setNotifyInApp] = useState(true);
   const [notifyEmail, setNotifyEmail] = useState(true);
 
@@ -418,7 +419,7 @@ export function ProfileStep() {
             className={inputCls}
             style={inputStyle}
             value={language}
-            onChange={(e) => setLanguage(e.target.value as 'fr' | 'en')}
+            onChange={(e) => setLanguage(e.target.value as LocaleCode)}
           >
             <option value="fr">Français</option>
             <option value="en">English</option>

--- a/frontend/src/features/organization/AcceptInvitationPage.tsx
+++ b/frontend/src/features/organization/AcceptInvitationPage.tsx
@@ -12,6 +12,7 @@
 // each get their own words. "Invalid token" tells someone holding a legitimate
 // link nothing they can act on.
 
+import { localeTag } from '../../i18n/locales';
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
@@ -373,7 +374,7 @@ export function AcceptInvitationPage() {
               <p className="text-[11.5px] text-ink-muted mt-4 text-center leading-snug">
                 {tr('Ce lien expire le ', 'This link expires on ')}
                 {new Date(preview.expires_at).toLocaleDateString(
-                  lang === 'fr' ? 'fr-FR' : 'en-GB',
+                  localeTag(lang),
                   {
                     day: 'numeric',
                     month: 'long',

--- a/frontend/src/features/organization/MembersView.tsx
+++ b/frontend/src/features/organization/MembersView.tsx
@@ -12,6 +12,7 @@
 // functional that is not: an action the API would refuse is disabled here for
 // the same reason, read from the same fields.
 
+import { localeTag } from '../../i18n/locales';
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { toast } from 'sonner';
@@ -39,6 +40,7 @@ import { usePermissions } from '../../hooks/usePermissions';
 import { useAuthStore } from '../../hooks/useAuthStore';
 import { useEscapeToClose } from '../../shared/useBackTo';
 import { useRbacCatalog } from '../rbac/useRbac';
+import type { LocaleCode } from '../../i18n/locales';
 import {
   useMembers,
   useInvitations,
@@ -78,11 +80,11 @@ const INVITE_STATUS_STYLE: Record<string, { color: string; fr: string; en: strin
 
 const ADMIN_OPTION = '__admin__';
 
-function fmtDate(iso: string | undefined, lang: 'fr' | 'en'): string {
+function fmtDate(iso: string | undefined, lang: LocaleCode): string {
   if (!iso) return '—';
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '—';
-  return d.toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-GB', {
+  return d.toLocaleDateString(localeTag(lang), {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
@@ -240,7 +242,7 @@ export function MembersView() {
 
 /* ------------------------------------------------------------------- members */
 
-function MembersTable({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
+function MembersTable({ tr, lang }: { tr: Tr; lang: LocaleCode }) {
   const { can } = usePermissions();
   const canUpdate = can('organization:members:update');
   const canDeactivate = can('organization:members:deactivate');
@@ -610,7 +612,7 @@ function MembersTable({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
 
 /* --------------------------------------------------------------- invitations */
 
-function InvitationsTable({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
+function InvitationsTable({ tr, lang }: { tr: Tr; lang: LocaleCode }) {
   const { can } = usePermissions();
   const canInvite = can('organization:members:invite');
   const { data, isLoading, isError, refetch } = useInvitations();
@@ -828,7 +830,7 @@ function InvitationsTable({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
 
 /* ------------------------------------------------------------------- history */
 
-function AccessHistory({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
+function AccessHistory({ tr, lang }: { tr: Tr; lang: LocaleCode }) {
   const { data, isLoading, isError, refetch } = useMembershipAudit(100);
 
   if (isLoading) return <SkeletonRows rows={6} />;
@@ -886,7 +888,7 @@ function AccessHistory({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
                     attributing it to somebody would not be. */}
                 {e.actor_email || (e.actor_id ? e.actor_id.slice(0, 8) : tr('Système', 'System'))}
                 {' · '}
-                {new Date(e.at).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-GB')}
+                {new Date(e.at).toLocaleString(localeTag(lang))}
                 {e.ip_address ? ` · ${e.ip_address}` : ''}
               </div>
             </div>

--- a/frontend/src/features/reports/ReportJobPage.tsx
+++ b/frontend/src/features/reports/ReportJobPage.tsx
@@ -8,6 +8,7 @@
 // to Compliance: a closed loop that never produced a document. The request now
 // terminates here, on the artifact, with a download and a way back.
 
+import { localeTag } from '../../i18n/locales';
 import { useParams, Link } from 'react-router';
 import { Download, RefreshCw, FileText, CheckCircle2, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
@@ -16,8 +17,9 @@ import { Btn, Card } from '../../shared/ui';
 import { useUIStore } from '../../store/uiStore';
 import { useReportJob } from './useReportJobs';
 import { reportJobService } from './reportJobService';
+import type { LocaleCode } from '../../i18n/locales';
 
-function formatBytes(n: number | undefined, lang: 'fr' | 'en'): string {
+function formatBytes(n: number | undefined, lang: LocaleCode): string {
   if (!n) return '—';
   const kb = n / 1024;
   if (kb < 1024) return `${kb.toFixed(0)} ${lang === 'fr' ? 'Ko' : 'KB'}`;
@@ -53,7 +55,7 @@ export function ReportJobPage() {
       subtitle={
         job ? (
           <span className="text-ink-muted">
-            {new Date(job.created_at).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US')}
+            {new Date(job.created_at).toLocaleString(localeTag(lang))}
           </span>
         ) : null
       }
@@ -135,7 +137,7 @@ export function ReportJobPage() {
             </DetailField>
             <DetailField label={tr('Généré le', 'Generated at')}>
               {job.completed_at
-                ? new Date(job.completed_at).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-US')
+                ? new Date(job.completed_at).toLocaleString(localeTag(lang))
                 : '—'}
             </DetailField>
           </Card>

--- a/frontend/src/features/reports/ReportsLibraryPage.tsx
+++ b/frontend/src/features/reports/ReportsLibraryPage.tsx
@@ -7,6 +7,7 @@
 // Every row is a real document with a real hash. Nothing here is a tile that
 // navigates somewhere else to do the work.
 
+import { localeTag } from '../../i18n/locales';
 import { useState } from 'react';
 import {
   FileText,
@@ -184,7 +185,7 @@ export function ReportsLibraryPage() {
 
                     <div className="text-[12px] text-ink-muted mt-1 flex items-center gap-2 flex-wrap">
                       <span>
-                        {new Date(r.created_at).toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-GB')}
+                        {new Date(r.created_at).toLocaleString(localeTag(lang))}
                       </span>
                       {r.requested_by_email ? <span>· {r.requested_by_email}</span> : null}
                       <span>

--- a/frontend/src/features/reports/ReportsScreen.tsx
+++ b/frontend/src/features/reports/ReportsScreen.tsx
@@ -5,6 +5,7 @@
 // destinations/exports (Board report, Compliance PDFs, risk-register CSV export…),
 // plus a recent-reports list.
 
+import { localeTag } from '../../i18n/locales';
 import {
   TrendingUp,
   FileText,
@@ -260,7 +261,7 @@ export function ReportsScreen() {
                 <div className="text-[13.5px] font-medium text-ink truncate">{r.title}</div>
                 <div className="text-[11.5px] text-ink-muted mt-0.5">
                   {r.period_label} ·{' '}
-                  {new Date(r.created_at).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+                  {new Date(r.created_at).toLocaleDateString(localeTag(lang), {
                     day: '2-digit',
                     month: 'short',
                     year: 'numeric',

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -27,6 +27,7 @@ import { ScoreExplainerButton } from '../../shared/ScoreExplainer';
 import { useUIStore } from '../../store/uiStore';
 import { useInvalidateActivation, useOnboardingSuggestions } from '../onboarding/useActivation';
 import type { RiskSuggestion } from '../../services/activationService';
+import type { LocaleCode } from '../../i18n/locales';
 
 const createRiskSchema = z.object({
   title: z.string().min(5, 'Le nom doit comporter au moins 5 caractères').max(100),
@@ -509,7 +510,7 @@ function SuggestionPicker({
 }: {
   suggestions: RiskSuggestion[];
   visible: boolean;
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   onPick: (s: RiskSuggestion) => void;
 }) {
   if (!visible || suggestions.length === 0) return null;

--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -12,6 +12,8 @@
 // view. The right-side drawer (Details / Lifecycle / Score / Financial / …)
 // is unchanged.
 
+import { useFormat } from '../../hooks/useI18n';
+import { localeTag } from '../../i18n/locales';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
@@ -97,6 +99,7 @@ import { ownershipPatch, type OwnershipRole } from '../../services/ownershipServ
 import { mappingHref, mappingLabel } from '../../services/taxonomyService';
 import { ctiService } from '../cti/ctiService';
 import { useQueryClient } from '@tanstack/react-query';
+import type { LocaleCode } from '../../i18n/locales';
 
 /* -------------------------------------------------------------- CSV export */
 
@@ -1083,7 +1086,7 @@ function DrawerCTI({ r }: { r: UiRisk }) {
       {data.cisa_known && data.cisa_due_date && (
         <Fact
           label={tr('Échéance CISA', 'CISA due date')}
-          value={new Date(data.cisa_due_date).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-GB')}
+          value={new Date(data.cisa_due_date).toLocaleDateString(localeTag(lang))}
         />
       )}
       {!!data.mitre_tactics?.length && (
@@ -1710,7 +1713,7 @@ function DrawerSmart({ r }: { r: UiRisk }) {
 // renders GET /risks/:id/transitions verbatim, blockers included.
 
 /** State pill for the register row, from the single canonical lifecycle. */
-function PhasePill({ phase, lang }: { phase: RiskPhase; lang: 'fr' | 'en' }) {
+function PhasePill({ phase, lang }: { phase: RiskPhase; lang: LocaleCode }) {
   const closed = phase === 'closed';
   const col = closed ? 'var(--fg-secondary)' : 'var(--accent)';
   const labels: Record<RiskPhase, [string, string]> = {
@@ -1776,11 +1779,14 @@ function DrawerFinancial({ r }: { r: UiRisk }) {
     raw.mitigation_effectiveness != null ? Number(raw.mitigation_effectiveness) : 0,
   );
   const [busy, setBusy] = useState(false);
+  const fmt = useFormat();
 
+  // Money goes through `Intl` in the reader's locale: XAF prints "FCFA" with no
+  // minor unit and USD prints "$" with cents suppressed, in both languages.
   const fmtXAF = (v?: number) =>
-    v == null ? '—' : `${Math.round(v).toLocaleString('fr-FR')} FCFA`;
+    v == null ? '—' : fmt.currency(Math.round(v), { currency: 'XAF' });
   const fmtUSD = (v?: number) =>
-    v == null ? '—' : `$${v.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+    v == null ? '—' : fmt.currency(v, { currency: 'USD', fractionDigits: 0 });
   const fmtPct = (ratio: number) => `${ratio >= 0 ? '+' : ''}${Math.round(ratio * 100)}%`;
   const num = (v: string) => (v.trim() === '' ? null : Number(v));
 

--- a/frontend/src/features/risks/components/SmartRiskRadar.tsx
+++ b/frontend/src/features/risks/components/SmartRiskRadar.tsx
@@ -10,6 +10,7 @@
 import { RadarChart } from '../../../shared/ds/charts';
 import type { FactorKey, SmartRiskScore } from '../smartScoreService';
 import { critColor } from '../../../shared/riskColors';
+import type { LocaleCode } from '../../../i18n/locales';
 
 // Bilingual short labels for the radar spokes, keyed by the stable FactorKey.
 const FACTOR_LABELS: Record<FactorKey, [string, string]> = {
@@ -23,7 +24,7 @@ const FACTOR_LABELS: Record<FactorKey, [string, string]> = {
   threat_intel: ['Menaces actives', 'Active threats'],
 };
 
-function factorLabel(key: FactorKey, lang: 'fr' | 'en'): string {
+function factorLabel(key: FactorKey, lang: LocaleCode): string {
   const l = FACTOR_LABELS[key];
   return l ? l[lang === 'fr' ? 0 : 1] : key;
 }
@@ -36,7 +37,7 @@ function smartColor(criticality: SmartRiskScore['criticality']): string {
   return critColor[criticality] ?? 'var(--fg-muted)';
 }
 
-export function SmartRiskRadar({ data, lang }: { data: SmartRiskScore; lang: 'fr' | 'en' }) {
+export function SmartRiskRadar({ data, lang }: { data: SmartRiskScore; lang: LocaleCode }) {
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   // Radar plots each factor's normalised risk contribution (0–100%).
   const radarData = data.factors.map((f) => ({

--- a/frontend/src/features/risks/riskMap.ts
+++ b/frontend/src/features/risks/riskMap.ts
@@ -5,11 +5,13 @@
 // drawer render. Normalizes the two live status vocabularies (DRAFT/ACTIVE/… and
 // open/in_progress/…) and the criticality/level fields into the design's tokens.
 
+import { localeTag } from '../../i18n/locales';
 import type { Risk, RiskPhase } from '../../hooks/useRiskStore';
 import type { RiskControlMapping } from '../../services/taxonomyService';
 import { mappingHref, mappingLabel } from '../../services/taxonomyService';
 import type { Criticality } from '../../shared/riskColors';
 import type { RiskStatus } from '../../shared/ui';
+import type { LocaleCode } from '../../i18n/locales';
 
 export interface UiRisk {
   id: string;
@@ -67,7 +69,7 @@ export function initialsOf(name?: string, fallback = '—'): string {
 }
 
 /** Compact locale-aware relative time without pulling a heavy dep. */
-export function relTime(iso?: string, lang: 'fr' | 'en' = 'fr'): string {
+export function relTime(iso?: string, lang: LocaleCode = 'fr'): string {
   if (!iso) return '—';
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '—';
@@ -83,10 +85,10 @@ export function relTime(iso?: string, lang: 'fr' | 'en' = 'fr'): string {
   if (d < 7) return fr ? `il y a ${d} j` : `${d} d ago`;
   const w = Math.floor(d / 7);
   if (w < 5) return fr ? `il y a ${w} sem.` : `${w} w ago`;
-  return new Date(iso).toLocaleDateString(fr ? 'fr-FR' : 'en-US');
+  return new Date(iso).toLocaleDateString(localeTag(lang));
 }
 
-export function mapRisk(r: Risk, lang: 'fr' | 'en'): UiRisk {
+export function mapRisk(r: Risk, lang: LocaleCode): UiRisk {
   const rr = r as Risk & { name?: string; owner?: string; asset_id?: string; updated_at?: string };
   // The owner is now a real user id resolved server-side; the legacy free-text
   // fields are only a fallback for rows written before migration 0044.

--- a/frontend/src/features/score/ScorePage.tsx
+++ b/frontend/src/features/score/ScorePage.tsx
@@ -17,6 +17,7 @@ import { ScoreGauge } from '../../shared/ScoreGauge';
 import { ScoreExplainer } from '../../shared/ScoreExplainer';
 import { bandColor, bandLabel } from '../../services/scoreService';
 import { ErrorState, SkeletonRows } from '../../shared/ui';
+import type { LocaleCode } from '../../i18n/locales';
 
 export function ScorePage() {
   const navigate = useNavigate();
@@ -162,7 +163,7 @@ function Metric({
   hint: string;
   value: number;
   band: Parameters<typeof bandColor>[0];
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
 }) {
   const color = bandColor(band);
   return (

--- a/frontend/src/features/settings/MFAPolicyPanel.tsx
+++ b/frontend/src/features/settings/MFAPolicyPanel.tsx
@@ -20,10 +20,13 @@ import { useUIStore } from '../../store/uiStore';
 import { useAuthStore } from '../../hooks/useAuthStore';
 import { useMFAPolicy, useSaveMFAPolicy, useMFAStatus } from '../auth/useMfa';
 import { MFAEnrollmentDialog } from '../auth/MFAEnrollmentDialog';
+import { useI18n } from '../../hooks/useI18n';
 
 export function MFAPolicyPanel() {
   const lang = useUIStore((s) => s.lang);
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
+  const { t } = useI18n();
+  const dayCount = (n: number) => t('common.days', { count: n });
   const hasPermission = useAuthStore((s) => s.hasPermission);
   const canEdit = hasPermission('*');
 
@@ -164,8 +167,8 @@ export function MFAPolicyPanel() {
                     '0 days: MFA is required from the first sign-in for affected accounts.',
                   )
                 : tr(
-                    `Après ${policy.grace_days} jour${policy.grace_days > 1 ? 's' : ''}, les comptes concernés doivent activer le MFA avant de continuer.`,
-                    `After ${policy.grace_days} day${policy.grace_days === 1 ? '' : 's'}, affected accounts must enable MFA before continuing.`,
+                    `Après ${dayCount(policy.grace_days)}, les comptes concernés doivent activer le MFA avant de continuer.`,
+                    `After ${dayCount(policy.grace_days)}, affected accounts must enable MFA before continuing.`,
                   )}
             </div>
             {roles.length > 0 && (

--- a/frontend/src/features/settings/SettingsScreen.tsx
+++ b/frontend/src/features/settings/SettingsScreen.tsx
@@ -67,6 +67,9 @@ import { BillingPanel } from '../billing/BillingPanel';
 import { DangerZonePanel } from '../billing/DangerZonePanel';
 import { useOrganization } from '../organization/useOrganization';
 import { MFAPolicyPanel, MFAAccountPanel } from './MFAPolicyPanel';
+import type { LocaleCode } from '../../i18n/locales';
+import { useI18n } from '../../hooks/useI18n';
+import { localeTag } from '../../i18n/locales';
 
 type TabKey =
   | 'general'
@@ -371,7 +374,7 @@ function copyPrefix(prefix: string, tr: Tr) {
     .catch(() => toast.error(tr('Copie impossible', 'Could not copy')));
 }
 
-function TokensTab({ tr, lang }: { tr: Tr; lang: 'fr' | 'en' }) {
+function TokensTab({ tr, lang }: { tr: Tr; lang: LocaleCode }) {
   const { tokens, isLoading, isError, refetch, create, revoke } = useTokens();
   const [name, setName] = useState('');
   // Revoking a token breaks any integration using it → impact-radiography confirm.
@@ -716,7 +719,7 @@ function GeneralTab({ tr }: { tr: Tr }) {
     .slice(0, 2)
     .join('')
     .toUpperCase();
-  const created = new Date(org.created_at).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-GB', {
+  const created = new Date(org.created_at).toLocaleDateString(localeTag(lang), {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
@@ -902,6 +905,7 @@ function CountTile({ label, value, color }: { label: string; value: number; colo
  * UI can say "configured" without ever handling a webhook URL.
  */
 function IntegrationsTab({ tr }: { tr: Tr }) {
+  const { t } = useI18n();
   const navigate = useNavigate();
   const channels = useChannelConfig();
   const scanners = useVulnIntegrations();
@@ -1053,10 +1057,7 @@ function IntegrationsTab({ tr }: { tr: Tr }) {
               {scanners.isError
                 ? tr('État indisponible.', 'State unavailable.')
                 : scannersConfigured > 0
-                  ? tr(
-                      `${scannersConfigured} source${scannersConfigured > 1 ? 's' : ''} configurée${scannersConfigured > 1 ? 's' : ''} (Nessus, Qualys, Defender…).`,
-                      `${scannersConfigured} source${scannersConfigured > 1 ? 's' : ''} configured (Nessus, Qualys, Defender…).`,
-                    )
+                  ? `${t('common.sources', { count: scannersConfigured })} (Nessus, Qualys, Defender…).`
                   : tr(
                       'Aucune source connectée. Connectez un scanner pour ingérer des vulnérabilités.',
                       'No source connected. Connect a scanner to start ingesting vulnerabilities.',

--- a/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
+++ b/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
@@ -61,13 +61,14 @@ import {
 import { IngestModal } from './IngestModal';
 import { IntegrationsPanel } from './IntegrationsPanel';
 import { safeExternalUrl } from '../../shared/safeUrl';
+import type { LocaleCode } from '../../i18n/locales';
 import {
   BulkPreviewDialog,
   useGovernedBulk,
   type BulkChangeInput,
 } from '../../shared/bulk';
 
-const t = (lang: 'fr' | 'en', fr: string, en: string) => (lang === 'fr' ? fr : en);
+const t = (lang: LocaleCode, fr: string, en: string) => (lang === 'fr' ? fr : en);
 
 // CVSS, NOT the OpenRisk score. CVSS is an external 0–10 scale defined by FIRST
 // and its severity cuts (9/7/4) are part of that standard, not ours. Kept local
@@ -516,7 +517,7 @@ export function VulnerabilitiesPage() {
   );
 }
 
-function SevBadge({ sev, lang }: { sev: Vulnerability['severity']; lang: 'fr' | 'en' }) {
+function SevBadge({ sev, lang }: { sev: Vulnerability['severity']; lang: LocaleCode }) {
   const m = SEVERITY_META[sev] ?? SEVERITY_META.info;
   return (
     <span
@@ -587,7 +588,7 @@ function InlineVulnStatus({ v }: { v: Vulnerability }) {
   );
 }
 
-function StatusChip({ status, lang }: { status: VulnStatus; lang: 'fr' | 'en' }) {
+function StatusChip({ status, lang }: { status: VulnStatus; lang: LocaleCode }) {
   const m = STATUS_META[status];
   return (
     <span

--- a/frontend/src/features/vulnerabilities/vulnMeta.ts
+++ b/frontend/src/features/vulnerabilities/vulnMeta.ts
@@ -5,6 +5,7 @@
 // ingest modal. Kept in one place so the vocabulary stays consistent.
 
 import type { VulnSeverity, VulnStatus, VulnSource } from './vulnerabilityService';
+import type { LocaleCode } from '../../i18n/locales';
 
 export const SEVERITY_META: Record<VulnSeverity, { label: [string, string]; color: string }> = {
   critical: { label: ['Critique', 'Critical'], color: 'var(--critical)' },
@@ -51,4 +52,4 @@ export const SOURCE_LABEL: Record<VulnSource, string> = {
   manual: 'Manuel',
 };
 
-export const pick = <T>(v: [T, T], lang: 'fr' | 'en'): T => (lang === 'fr' ? v[0] : v[1]);
+export const pick = <T>(v: [T, T], lang: LocaleCode): T => (lang === 'fr' ? v[0] : v[1]);

--- a/frontend/src/hooks/useI18n.ts
+++ b/frontend/src/hooks/useI18n.ts
@@ -3,60 +3,77 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
-import { useCallback } from 'react';
-import frLocale from '../locales/fr.json';
-import enLocale from '../locales/en.json';
-import { useUIStore, type Lang } from '../store/uiStore';
-
-type Locale = Lang;
-
-interface UseI18nReturn {
-  t: (key: string, defaultValue?: string) => string;
-  locale: Locale;
-  setLocale: (locale: Locale) => void;
-}
-
-const locales: Record<Locale, Record<string, any>> = {
-  fr: frLocale,
-  en: enLocale,
-};
+import { useCallback, useMemo } from 'react';
+import {
+  boundFormatters,
+  catalogs,
+  translate,
+  type BoundFormatters,
+  type LocaleCode,
+  type TranslateParams,
+} from '../i18n';
+import { useUIStore } from '../store/uiStore';
 
 /**
- * Simple i18n hook for translations. Language now lives in the central UI store
- * (see store/uiStore.ts), so the header FR/EN toggle re-renders every consumer
- * reactively. Supports nested keys like "risks.title".
+ * The component-facing i18n hook.
+ *
+ * The language lives in the central UI store, so the header language toggle
+ * re-renders every consumer reactively. Everything below it — key lookup,
+ * fallback, pluralization, formatting — is the pure core in `src/i18n`, which is
+ * why it is testable without React.
+ *
+ * The second argument of `t` accepts both shapes on purpose. Roughly 200 call
+ * sites already pass a default string, and rewriting them was not the job of
+ * this change; passing an object opts into interpolation and plurals:
+ *
+ *   t('risks.title')
+ *   t('risks.title', 'Risk register')                 // legacy default value
+ *   t('common.results', { count: rows.length })        // plural + grouping
  */
-export function useI18n(): UseI18nReturn {
-  // Subscribe to the store so components re-render when the language changes.
-  const locale = useUIStore((s) => s.lang);
-  const setLang = useUIStore((s) => s.setLang);
+export interface UseI18nReturn {
+  /** Translate a dotted key. Falls back to the default locale, then the key. */
+  t: (key: string, defaultOrParams?: string | TranslateParams) => string;
+  /** The active language. */
+  locale: LocaleCode;
+  setLocale: (locale: LocaleCode) => void;
+  /** Formatters already bound to the active locale. */
+  fmt: BoundFormatters;
+}
 
-  const getNestedValue = useCallback((obj: any, path: string): string => {
-    const keys = path.split('.');
-    let value = obj;
-    for (const key of keys) {
-      value = value?.[key];
-      if (value === undefined) return path;
-    }
-    return value ?? path;
-  }, []);
+export function useI18n(): UseI18nReturn {
+  const locale = useUIStore((s) => s.lang);
+  const setLocale = useUIStore((s) => s.setLang);
 
   const t = useCallback(
-    (key: string, defaultValue?: string): string => {
-      const dict = locales[locale];
-      const translation = getNestedValue(dict, key);
-      return translation || defaultValue || key;
+    (key: string, defaultOrParams?: string | TranslateParams): string => {
+      if (typeof defaultOrParams === 'string') {
+        return translate(catalogs, locale, key, { defaultValue: defaultOrParams });
+      }
+      return translate(catalogs, locale, key, { params: defaultOrParams });
     },
-    [getNestedValue, locale],
+    [locale],
   );
 
-  return { t, locale, setLocale: setLang };
+  const fmt = useMemo(() => boundFormatters(locale), [locale]);
+
+  return { t, locale, setLocale, fmt };
+}
+
+/** Formatters alone, for components that format but do not translate. */
+export function useFormat(): BoundFormatters {
+  const locale = useUIStore((s) => s.lang);
+  return useMemo(() => boundFormatters(locale), [locale]);
 }
 
 /**
- * Helper function to interpolate values in translation strings
- * Usage: interpolate(t('risks.selectedCount'), { count: 5 })
+ * Standalone interpolation, kept for the call sites that read a string first and
+ * substitute afterwards (`interpolate(t('actionCenter.range'), { … })`). New
+ * code should pass the params straight to `t` so plurals apply too.
  */
-export function interpolate(str: string, values: Record<string, any>): string {
-  return str.replace(/{(\w+)}/g, (_, key) => values[key] ?? `{${key}}`);
+export { interpolate as interpolateRaw } from '../i18n/translate';
+
+export function interpolate(str: string, values: Record<string, unknown>): string {
+  return str.replace(/\{(\w+)\}/g, (match, key: string) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? String(values[key] ?? '') : match,
+  );
 }

--- a/frontend/src/i18n/__tests__/direction.test.ts
+++ b/frontend/src/i18n/__tests__/direction.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// RTL readiness, proved rather than asserted.
+//
+// The product ships no RTL language today. What it ships is the plumbing: the
+// registry owns direction, `<html dir>` follows the active locale, and a
+// registered-but-disabled RTL locale can never sneak into the store. Those are
+// the three things that would otherwise be discovered broken on the day Arabic
+// is switched on.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LOCALES, localeDirection } from '../locales';
+import { useUIStore } from '../../store/uiStore';
+
+describe('writing direction', () => {
+  beforeEach(() => {
+    useUIStore.getState().setLang('fr');
+  });
+
+  it('puts both lang and dir on <html>', () => {
+    useUIStore.getState().setLang('en');
+    expect(document.documentElement.getAttribute('lang')).toBe('en');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+
+    useUIStore.getState().setLang('fr');
+    expect(document.documentElement.getAttribute('lang')).toBe('fr');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('reads direction from the registry, not from a list of RTL codes', () => {
+    expect(localeDirection(LOCALES.ar.code as 'ar')).toBe('rtl');
+  });
+
+  it('refuses to activate a registered locale that is not offered yet', () => {
+    // `ar` has direction and plural rules but no catalogue. Activating it would
+    // show a half-translated product, so the store rejects it and holds.
+    useUIStore.getState().setLang('ar' as 'fr');
+    expect(useUIStore.getState().lang).toBe('fr');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('cycles the toggle only through offered languages', () => {
+    useUIStore.getState().setLang('fr');
+    useUIStore.getState().toggleLang();
+    expect(useUIStore.getState().lang).toBe('en');
+    useUIStore.getState().toggleLang();
+    expect(useUIStore.getState().lang).toBe('fr');
+  });
+});

--- a/frontend/src/i18n/__tests__/format.test.ts
+++ b/frontend/src/i18n/__tests__/format.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import {
+  boundFormatters,
+  formatCompact,
+  formatCurrency,
+  formatDate,
+  formatList,
+  formatNumber,
+  formatPercent,
+  formatRelativeTime,
+} from '../format';
+
+/** Intl inserts narrow/non-breaking spaces; compare on the digits and marks. */
+const norm = (s: string) => s.replace(/[  ‎‏]/g, ' ');
+
+describe('locale-aware formatting', () => {
+  it('groups numbers in the reader’s conventions', () => {
+    expect(norm(formatNumber('fr', 1234567))).toBe('1 234 567');
+    expect(formatNumber('en', 1234567)).toBe('1,234,567');
+  });
+
+  it('formats XAF with its real symbol and no minor unit', () => {
+    // The CFA franc has no cents. Intl knows; a hand-rolled formatter would not.
+    expect(norm(formatCurrency('fr', 1234567, { currency: 'XAF' }))).toBe('1 234 567 FCFA');
+    expect(norm(formatCurrency('en', 1234567, { currency: 'XAF' }))).toBe('FCFA 1,234,567');
+  });
+
+  it('formats EUR and USD in each language', () => {
+    expect(norm(formatCurrency('fr', 1234.5, { currency: 'EUR' }))).toBe('1 234,50 €');
+    expect(formatCurrency('en', 1234.5, { currency: 'USD' })).toBe('$1,234.50');
+  });
+
+  it('uses the locale’s default currency when none is given', () => {
+    expect(norm(formatCurrency('fr', 1000))).toContain('FCFA');
+    expect(formatCurrency('en', 1000)).toContain('$');
+  });
+
+  it('degrades an unknown ISO code instead of blanking the cell', () => {
+    expect(norm(formatCurrency('fr', 1000, { currency: 'NOTACODE' }))).toBe('1 000 NOTACODE');
+  });
+
+  it('renders — rather than NaN for a missing figure', () => {
+    expect(formatNumber('fr', Number.NaN)).toBe('—');
+    expect(formatCurrency('fr', Number.NaN)).toBe('—');
+    expect(formatPercent('fr', Number.POSITIVE_INFINITY)).toBe('—');
+    expect(formatCompact('fr', Number.NaN)).toBe('—');
+    expect(formatDate('fr', 'not-a-date')).toBe('—');
+  });
+
+  it('treats a percent input as a ratio', () => {
+    expect(formatPercent('en', 0.42)).toBe('42%');
+    expect(formatPercent('en', 0.4235, 1)).toBe('42.4%');
+  });
+
+  it('formats dates and relative times per language', () => {
+    const iso = '2026-03-12T08:30:00Z';
+    expect(formatDate('fr', iso, { day: '2-digit', month: '2-digit', year: 'numeric' })).toBe(
+      '12/03/2026',
+    );
+    expect(formatDate('en', iso, { day: '2-digit', month: '2-digit', year: 'numeric' })).toBe(
+      '03/12/2026',
+    );
+    const now = new Date('2026-03-15T08:30:00Z');
+    expect(formatRelativeTime('fr', iso, now)).toBe('il y a 3 jours');
+    expect(formatRelativeTime('en', iso, now)).toBe('3 days ago');
+  });
+
+  it('joins a list with the language’s own conjunction', () => {
+    expect(formatList('fr', ['a', 'b', 'c'])).toBe('a, b et c');
+    expect(formatList('en', ['a', 'b', 'c'])).toBe('a, b, and c');
+    expect(formatList('fr', [])).toBe('');
+  });
+
+  it('binds every formatter to one locale', () => {
+    const fmt = boundFormatters('en');
+    expect(fmt.locale).toBe('en');
+    expect(fmt.number(1000)).toBe('1,000');
+    expect(fmt.percent(0.5)).toBe('50%');
+    expect(fmt.currency(10, { currency: 'USD' })).toBe('$10.00');
+  });
+});

--- a/frontend/src/i18n/__tests__/locales.test.ts
+++ b/frontend/src/i18n/__tests__/locales.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LOCALE,
+  ENABLED_LOCALES,
+  LOCALES,
+  LOCALE_CODES,
+  isEnabledLocale,
+  isLocaleCode,
+  localeDirection,
+  localeTag,
+  negotiateLocale,
+  pickLocalized,
+  resolveLocale,
+} from '../locales';
+
+describe('locale registry', () => {
+  it('declares a complete definition for every registered locale', () => {
+    for (const code of LOCALE_CODES) {
+      const def = LOCALES[code];
+      expect(def.code).toBe(code);
+      // A tag that Intl refuses is a locale that formats nothing.
+      expect(() => new Intl.NumberFormat(def.tag)).not.toThrow();
+      expect(['ltr', 'rtl']).toContain(def.dir);
+      expect(def.nativeName.length).toBeGreaterThan(0);
+      expect(['XAF', 'EUR', 'USD']).toContain(def.defaultCurrency);
+    }
+  });
+
+  it('offers only locales that are enabled', () => {
+    expect(ENABLED_LOCALES).toEqual(['fr', 'en']);
+    expect(isEnabledLocale('ar')).toBe(false);
+    expect(isLocaleCode('ar')).toBe(true);
+  });
+
+  it('registers an RTL locale so direction is exercised, not assumed', () => {
+    expect(localeDirection('ar')).toBe('rtl');
+    expect(localeDirection('fr')).toBe('ltr');
+    expect(localeDirection('en')).toBe('ltr');
+  });
+
+  it('resolves regional tags onto the offered language', () => {
+    expect(resolveLocale('fr-CM')).toBe('fr');
+    expect(resolveLocale('fr_CA')).toBe('fr');
+    expect(resolveLocale('EN-gb')).toBe('en');
+    // Registered but not offered: must not become the active language.
+    expect(resolveLocale('ar')).toBe(DEFAULT_LOCALE);
+    expect(resolveLocale('de')).toBe(DEFAULT_LOCALE);
+    expect(resolveLocale(undefined)).toBe(DEFAULT_LOCALE);
+    expect(resolveLocale('')).toBe(DEFAULT_LOCALE);
+  });
+
+  it('negotiates an Accept-Language list by q-weight', () => {
+    expect(negotiateLocale('de-DE,en-GB;q=0.8,fr;q=0.5')).toBe('en');
+    expect(negotiateLocale('en;q=0.2, fr-CM;q=0.9')).toBe('fr');
+    expect(negotiateLocale(['de', 'ar'])).toBe(DEFAULT_LOCALE);
+    expect(negotiateLocale('en;q=0')).toBe(DEFAULT_LOCALE);
+    expect(negotiateLocale(undefined)).toBe(DEFAULT_LOCALE);
+  });
+
+  it('maps a locale to the BCP-47 tag Intl needs, not to its own code', () => {
+    expect(localeTag('fr')).toBe('fr-FR');
+    expect(localeTag('en')).toBe('en-US');
+    expect(localeTag('ar')).toBe('ar-MA');
+  });
+
+  it('falls an inline {fr,en} literal back to the default language', () => {
+    const label = { fr: 'Actif', en: 'Asset' };
+    expect(pickLocalized('en', label)).toBe('Asset');
+    // The whole point: a newly registered locale reads French, never undefined.
+    expect(pickLocalized('ar', label)).toBe('Actif');
+    expect(pickLocalized('fr', undefined)).toBeUndefined();
+    expect(pickLocalized('fr', null)).toBeUndefined();
+  });
+});

--- a/frontend/src/i18n/__tests__/parity.test.ts
+++ b/frontend/src/i18n/__tests__/parity.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// FR/EN parity is a gate, not a convention.
+//
+// A key that exists in one catalogue and not the other does not fail loudly: it
+// silently falls back to the other language, so the screen reads half-French to
+// an English user and nobody notices until a customer does. This test is the
+// notice.
+
+import { describe, expect, it } from 'vitest';
+import enJson from '../../locales/en.json';
+import frJson from '../../locales/fr.json';
+import { runtimeMessages } from '../messages';
+import { isPluralForms } from '../plural';
+import type { Catalog } from '../translate';
+
+/** Every leaf path in a catalogue, dotted. Plural sets count as one leaf. */
+function keysOf(node: Catalog, prefix = ''): string[] {
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(node)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null && !isPluralForms(value)) {
+      out.push(...keysOf(value as Catalog, path));
+    } else {
+      out.push(path);
+    }
+  }
+  return out.sort();
+}
+
+const frKeys = keysOf(frJson as Catalog);
+const enKeys = keysOf(enJson as Catalog);
+
+describe('FR/EN catalogue parity', () => {
+  it('has no key present in French and missing in English', () => {
+    expect(frKeys.filter((k) => !enKeys.includes(k))).toEqual([]);
+  });
+
+  it('has no key present in English and missing in French', () => {
+    expect(enKeys.filter((k) => !frKeys.includes(k))).toEqual([]);
+  });
+
+  it('has no empty translation, which renders as a silent hole', () => {
+    const empty = (node: Catalog, prefix = ''): string[] => {
+      const out: string[] = [];
+      for (const [key, value] of Object.entries(node)) {
+        const path = prefix ? `${prefix}.${key}` : key;
+        if (typeof value === 'string') {
+          if (value.trim() === '') out.push(path);
+        } else if (value && !isPluralForms(value)) {
+          out.push(...empty(value as Catalog, path));
+        }
+      }
+      return out;
+    };
+    expect(empty(frJson as Catalog)).toEqual([]);
+    expect(empty(enJson as Catalog)).toEqual([]);
+  });
+
+  it('keeps the TypeScript plural overlay in parity too', () => {
+    const fr = keysOf(runtimeMessages.fr ?? {});
+    const en = keysOf(runtimeMessages.en ?? {});
+    expect(fr).toEqual(en);
+  });
+
+  it('defines `other` on every plural set — the one universal category', () => {
+    const check = (node: Catalog, prefix = ''): void => {
+      for (const [key, value] of Object.entries(node)) {
+        const path = prefix ? `${prefix}.${key}` : key;
+        if (isPluralForms(value)) {
+          expect(typeof value.other, `${path} must define "other"`).toBe('string');
+        } else if (typeof value === 'object' && value !== null) {
+          check(value as Catalog, path);
+        }
+      }
+    };
+    check(runtimeMessages.fr ?? {});
+    check(runtimeMessages.en ?? {});
+  });
+});

--- a/frontend/src/i18n/__tests__/plural.test.ts
+++ b/frontend/src/i18n/__tests__/plural.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { pluralCategory, resolveMessage, selectPlural, type PluralForms } from '../plural';
+
+const results: PluralForms = {
+  exact: { 0: 'Aucun résultat' },
+  one: '{count} résultat',
+  other: '{count} résultats',
+};
+
+describe('pluralization', () => {
+  it('uses the language’s own CLDR categories, not an English rule', () => {
+    // French counts 0 as singular; English does not. This is the exact pair the
+    // old `n > 1 ? 's' : ''` got wrong.
+    expect(pluralCategory('fr', 0)).toBe('one');
+    expect(pluralCategory('en', 0)).toBe('other');
+    expect(pluralCategory('fr', 1)).toBe('one');
+    expect(pluralCategory('en', 1)).toBe('one');
+    expect(pluralCategory('fr', 2)).toBe('other');
+  });
+
+  it('exposes the six categories an RTL language actually needs', () => {
+    expect(pluralCategory('ar', 0)).toBe('zero');
+    expect(pluralCategory('ar', 1)).toBe('one');
+    expect(pluralCategory('ar', 2)).toBe('two');
+    expect(pluralCategory('ar', 3)).toBe('few');
+    expect(pluralCategory('ar', 11)).toBe('many');
+    expect(pluralCategory('ar', 100)).toBe('other');
+  });
+
+  it('supports ordinal rules as well as cardinal', () => {
+    expect(pluralCategory('en', 1, 'ordinal')).toBe('one');
+    expect(pluralCategory('en', 2, 'ordinal')).toBe('two');
+    expect(pluralCategory('en', 4, 'ordinal')).toBe('other');
+  });
+
+  it('prefers an exact override over the category', () => {
+    expect(selectPlural('fr', results, 0)).toBe('Aucun résultat');
+    expect(selectPlural('fr', results, 1)).toBe('{count} résultat');
+    expect(selectPlural('fr', results, 2)).toBe('{count} résultats');
+  });
+
+  it('falls back to `other` for a category the message does not define', () => {
+    // Arabic selects `many` at 11; the message has no `many`, so `other` holds.
+    expect(selectPlural('ar', results, 11)).toBe('{count} résultats');
+  });
+
+  it('never blows up on a non-finite count', () => {
+    expect(pluralCategory('fr', Number.NaN)).toBe('other');
+    expect(selectPlural('fr', results, Number.POSITIVE_INFINITY)).toBe('{count} résultats');
+  });
+
+  it('passes plain strings through and neutralises a countless plural', () => {
+    expect(resolveMessage('fr', 'Bonjour')).toBe('Bonjour');
+    expect(resolveMessage('fr', results)).toBe('{count} résultats');
+  });
+});

--- a/frontend/src/i18n/__tests__/ratchet.test.ts
+++ b/frontend/src/i18n/__tests__/ratchet.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The hardcoded-string ratchet.
+//
+// The framework in `src/i18n` is only worth having if the tree stops accumulating
+// the patterns it replaces. Extracting all of them at once was not this change's
+// job (#315 shipped the framework; the sweep is tracked separately), so instead
+// the counts are frozen here at their measured value and may only ever go DOWN.
+//
+// If this test fails on your branch you have either:
+//   * added a new inline `lang === 'fr' ? … : …` — use `t('some.key')` instead;
+//   * added a new raw `toLocale*` — use `fmt.date()` / `fmt.number()` from
+//     `useFormat()` or `useI18n()`;
+//   * removed some, in which case LOWER the number here. That is the point.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SRC = join(process.cwd(), 'src');
+
+/**
+ * Measured 2026-09-08 on branch 315. Every number here is a debt, not a target.
+ * THESE NUMBERS MAY ONLY EVER GO DOWN.
+ */
+const BASELINE = {
+  /** Inline bilingual ternaries that should be catalogue keys. */
+  frTernaries: 260,
+  /** Raw `toLocale*` calls that should go through `src/i18n/format.ts`. */
+  rawToLocale: 62,
+};
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      walk(path, out);
+    } else if (/\.tsx?$/.test(entry) && !/\.(test|spec)\.tsx?$/.test(entry)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Every source file except the i18n module itself, which is allowed to know. */
+const files = walk(SRC).filter((f) => !f.includes(`${join('src', 'i18n')}`));
+
+function countMatches(pattern: RegExp): number {
+  let total = 0;
+  for (const file of files) {
+    const matches = readFileSync(file, 'utf8').match(pattern);
+    total += matches ? matches.length : 0;
+  }
+  return total;
+}
+
+describe('hardcoded-string ratchet', () => {
+  it('adds no new inline bilingual ternary', () => {
+    const count = countMatches(/lang === 'fr'/g);
+    expect(
+      count,
+      `Inline \`lang === 'fr' ? …\` count is ${count}, baseline ${BASELINE.frTernaries}. ` +
+        'Use a catalogue key via `t()`. If you removed some, lower the baseline.',
+    ).toBeLessThanOrEqual(BASELINE.frTernaries);
+  });
+
+  it('adds no new raw toLocale* call', () => {
+    const count = countMatches(/toLocale(?:Date|Time)?String\(/g);
+    expect(
+      count,
+      `Raw \`toLocale*\` count is ${count}, baseline ${BASELINE.rawToLocale}. ` +
+        'Use `useFormat()` / `useI18n().fmt`. If you removed some, lower the baseline.',
+    ).toBeLessThanOrEqual(BASELINE.rawToLocale);
+  });
+
+  it('lets no BCP-47 tag be hardcoded outside the registry', () => {
+    // This one is already at zero and must stay there: the registry owns tags.
+    const count = countMatches(/'(?:fr-FR|en-US|en-GB|fr-CA|ar-MA)'/g);
+    expect(
+      count,
+      'A BCP-47 tag is hardcoded outside src/i18n/locales.ts. Use `localeTag(lang)`.',
+    ).toBe(0);
+  });
+
+  it('lets no new module redeclare the set of UI languages', () => {
+    // `Lang` is derived from LOCALES; a local `'fr' | 'en'` union re-freezes the
+    // product at two languages, and #315 removed 38 of them.
+    //
+    // Three survive on purpose, and they are not UI locales: `Locale`
+    // (features/ai), `ReportLocale` (types/report) and `BoardLocale`
+    // (types/board) each describe what the SERVER can render. Widening those to
+    // LocaleCode would claim OpenRisk generates Arabic reports, which it does
+    // not. They change when the backend gains a language — not when the UI does.
+    const count = countMatches(/'fr'\s*\|\s*'en'/g);
+    expect(
+      count,
+      "Declare UI languages in src/i18n/locales.ts, not as a `'fr' | 'en'` union.",
+    ).toBeLessThanOrEqual(3);
+  });
+});

--- a/frontend/src/i18n/__tests__/translate.test.ts
+++ b/frontend/src/i18n/__tests__/translate.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { catalogs } from '../catalog';
+import { lookup, translate, type Catalog } from '../translate';
+
+const fixture: Partial<Record<'fr' | 'en' | 'ar', Catalog>> = {
+  fr: {
+    risks: { title: 'Registre des risques', greet: 'Bonjour {name}', blank: '' },
+    common: { results: { exact: { 0: 'Aucun résultat' }, one: '{count, number} résultat', other: '{count, number} résultats' } },
+  },
+  en: {
+    risks: { title: 'Risk register' },
+    common: { results: { exact: { 0: 'No results' }, one: '{count, number} result', other: '{count, number} results' } },
+  },
+};
+
+const norm = (s: string) => s.replace(/[  ‎‏]/g, ' ');
+
+describe('translate', () => {
+  it('reads a dotted key', () => {
+    expect(translate(fixture, 'en', 'risks.title')).toBe('Risk register');
+    expect(lookup(fixture.fr, 'risks.title')).toBe('Registre des risques');
+    expect(lookup(fixture.fr, 'risks.missing')).toBeUndefined();
+    expect(lookup(undefined, 'risks.title')).toBeUndefined();
+  });
+
+  it('falls back to the default locale before giving up', () => {
+    // `risks.greet` exists only in French.
+    expect(translate(fixture, 'en', 'risks.greet', { params: { name: 'Awa' } })).toBe('Bonjour Awa');
+  });
+
+  it('shows the key rather than a blank when nothing matches', () => {
+    expect(translate(fixture, 'en', 'nope.at.all')).toBe('nope.at.all');
+    expect(translate(fixture, 'en', 'nope.at.all', { defaultValue: 'Fallback' })).toBe('Fallback');
+    // An empty catalogue entry is a hole, not a translation.
+    expect(translate(fixture, 'fr', 'risks.blank')).toBe('risks.blank');
+  });
+
+  it('pluralizes and formats the count together', () => {
+    expect(translate(fixture, 'en', 'common.results', { params: { count: 0 } })).toBe('No results');
+    expect(translate(fixture, 'en', 'common.results', { params: { count: 1 } })).toBe('1 result');
+    expect(translate(fixture, 'en', 'common.results', { params: { count: 4200 } })).toBe(
+      '4,200 results',
+    );
+    expect(norm(translate(fixture, 'fr', 'common.results', { params: { count: 4200 } }))).toBe(
+      '4 200 résultats',
+    );
+    // French is singular at 1 AND at 0 when no exact form overrides it.
+    expect(translate(fixture, 'fr', 'common.results', { params: { count: 0 } })).toBe(
+      'Aucun résultat',
+    );
+  });
+
+  it('runs interpolated values through the formatters', () => {
+    const c: Partial<Record<'fr' | 'en', Catalog>> = {
+      fr: {
+        money: 'Perte : {amount, currency, XAF}',
+        when: 'Le {day, date}',
+        share: '{ratio, percent}',
+        big: '{n, compact}',
+      },
+    };
+    expect(norm(translate(c, 'fr', 'money', { params: { amount: 1234567 } }))).toBe(
+      'Perte : 1 234 567 FCFA',
+    );
+    expect(norm(translate(c, 'fr', 'share', { params: { ratio: 0.42 } }))).toBe('42 %');
+    expect(translate(c, 'fr', 'when', { params: { day: '2026-03-12T00:00:00Z' } })).toContain('2026');
+    expect(norm(translate(c, 'fr', 'big', { params: { n: 1_200_000 } }))).toBe('1,2 M');
+  });
+
+  it('leaves an unknown placeholder visible instead of erasing it', () => {
+    const c: Partial<Record<'fr', Catalog>> = { fr: { hi: 'Bonjour {name} {surname}' } };
+    expect(translate(c, 'fr', 'hi', { params: { name: 'Awa' } })).toBe('Bonjour Awa {surname}');
+  });
+});
+
+describe('the real catalogues', () => {
+  it('are wired for every language that has words', () => {
+    expect(Object.keys(catalogs).sort()).toEqual(['en', 'fr']);
+  });
+
+  it('merge the TypeScript plural overlay over the JSON', () => {
+    expect(translate(catalogs, 'en', 'common.results', { params: { count: 0 } })).toBe('No results');
+    expect(translate(catalogs, 'en', 'common.results', { params: { count: 2 } })).toBe('2 results');
+    expect(translate(catalogs, 'fr', 'common.days', { params: { count: 1 } })).toBe('1 jour');
+    expect(translate(catalogs, 'fr', 'common.days', { params: { count: 3 } })).toBe('3 jours');
+  });
+
+  it('serve a registered-but-untranslated locale from the default language', () => {
+    // `ar` has no catalogue. It must read French, not the raw key.
+    expect(translate(catalogs, 'ar', 'common.days', { params: { count: 3 } })).toBe('3 jours');
+  });
+
+  it('keep the JSON keys the app already uses reachable', () => {
+    expect(translate(catalogs, 'fr', 'risks.title')).not.toBe('risks.title');
+    expect(translate(catalogs, 'en', 'risks.title')).not.toBe('risks.title');
+  });
+});

--- a/frontend/src/i18n/catalog.ts
+++ b/frontend/src/i18n/catalog.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * Where a language's words are wired in.
+ *
+ * Adding a language is two lines: an entry in `LOCALES` (src/i18n/locales.ts)
+ * and an entry here pointing at its catalogue. `ar` deliberately has no entry —
+ * it is registered for its direction and plural rules, and until someone writes
+ * `ar.json` it falls back to French through `translate()`. That is the whole
+ * point of the fallback chain: a partially translated language degrades to
+ * readable text instead of to blank cells.
+ *
+ * `runtimeMessages` is the extension seam for plural forms and messages that the
+ * legacy flat JSON files cannot express. Keys defined there win over the JSON,
+ * which lets a screen migrate to real pluralization one key at a time without a
+ * big-bang rewrite of `locales/fr.json`.
+ */
+
+import enJson from '../locales/en.json';
+import frJson from '../locales/fr.json';
+import { runtimeMessages } from './messages';
+import { LOCALE_CODES, type LocaleCode } from './locales';
+import { isPluralForms } from './plural';
+import type { Catalog } from './translate';
+
+/** A branch of the tree — as opposed to a leaf, which is a string or a plural set. */
+function isBranch(value: unknown): value is Catalog {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !isPluralForms(value);
+}
+
+/** Deep-merge two catalogues, with `overlay` winning at every leaf. */
+export function merge(base: Catalog, overlay: Catalog): Catalog {
+  const out: Catalog = { ...base };
+  for (const [key, value] of Object.entries(overlay)) {
+    const existing = out[key];
+    out[key] =
+      isBranch(existing) && isBranch(value) ? merge(existing, value) : (value as Catalog[string]);
+  }
+  return out;
+}
+
+/** The JSON catalogues, keyed by locale. One line per shipped language. */
+const jsonCatalogs: Partial<Record<LocaleCode, Catalog>> = {
+  fr: frJson as Catalog,
+  en: enJson as Catalog,
+};
+
+/**
+ * Built once at module load: every registered locale that has words, with its
+ * TypeScript overlay merged over its JSON. A registered locale with neither
+ * (today: `ar`) is simply absent, and `translate()` falls back for it.
+ */
+export const catalogs: Partial<Record<LocaleCode, Catalog>> = Object.fromEntries(
+  LOCALE_CODES.map((code) => [code, mergeFor(code)]).filter(([, catalog]) => catalog !== undefined),
+) as Partial<Record<LocaleCode, Catalog>>;
+
+function mergeFor(code: LocaleCode): Catalog | undefined {
+  const json = jsonCatalogs[code];
+  const overlay = runtimeMessages[code];
+  if (!json) return overlay;
+  return overlay ? merge(json, overlay) : json;
+}

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * Locale-aware formatting — the only place the product turns a number, a date
+ * or an amount into text.
+ *
+ * Before this module there were 77 `toLocale*` call sites, ten of which pinned
+ * `'fr-FR'` or `'en-US'` regardless of the language the user had selected, so an
+ * English user read French thousands separators. Every formatter here takes the
+ * active `LocaleCode` and resolves its BCP-47 tag through the registry, so a new
+ * language formats correctly the moment it is registered.
+ *
+ * `Intl` already knows the market's conventions: XAF prints as "1 234 567 FCFA"
+ * in French and "FCFA 1,234,567" in English, with zero decimals in both, because
+ * the CFA franc has no minor unit. Do not hand-roll that.
+ */
+
+import { localeTag, localeDefinition, type CurrencyCode, type LocaleCode } from './locales';
+
+/**
+ * `Intl` constructors are expensive relative to the formatting itself and these
+ * run inside table cells, so every configuration is built once and reused.
+ */
+function memoize<TOptions extends object, TFormatter>(
+  build: (tag: string, options: TOptions) => TFormatter,
+): (tag: string, options?: TOptions) => TFormatter {
+  const cache = new Map<string, TFormatter>();
+  return (tag: string, options?: TOptions) => {
+    const key = `${tag}|${options ? JSON.stringify(options) : ''}`;
+    let found = cache.get(key);
+    if (!found) {
+      found = build(tag, (options ?? {}) as TOptions);
+      cache.set(key, found);
+    }
+    return found;
+  };
+}
+
+const numberFormat = memoize<Intl.NumberFormatOptions, Intl.NumberFormat>(
+  (tag, options) => new Intl.NumberFormat(tag, options),
+);
+const dateFormat = memoize<Intl.DateTimeFormatOptions, Intl.DateTimeFormat>(
+  (tag, options) => new Intl.DateTimeFormat(tag, options),
+);
+const relativeFormat = memoize<Intl.RelativeTimeFormatOptions, Intl.RelativeTimeFormat>(
+  (tag, options) => new Intl.RelativeTimeFormat(tag, options),
+);
+const listFormat = memoize<Intl.ListFormatOptions, Intl.ListFormat>(
+  (tag, options) => new Intl.ListFormat(tag, options),
+);
+
+/* ------------------------------- numbers -------------------------------- */
+
+export function formatNumber(
+  locale: LocaleCode,
+  value: number,
+  options?: Intl.NumberFormatOptions,
+): string {
+  if (!Number.isFinite(value)) return '—';
+  return numberFormat(localeTag(locale), options).format(value);
+}
+
+/** "1,2 M" / "1.2M" — for dense tiles where the exact figure is not the point. */
+export function formatCompact(locale: LocaleCode, value: number, maximumFractionDigits = 1): string {
+  if (!Number.isFinite(value)) return '—';
+  return numberFormat(localeTag(locale), {
+    notation: 'compact',
+    compactDisplay: 'short',
+    maximumFractionDigits,
+  }).format(value);
+}
+
+/**
+ * `value` is the ratio, not the percentage: pass 0.42 for 42 %. French puts a
+ * non-breaking space before the sign and English does not; `Intl` handles that.
+ */
+export function formatPercent(locale: LocaleCode, value: number, fractionDigits = 0): string {
+  if (!Number.isFinite(value)) return '—';
+  return numberFormat(localeTag(locale), {
+    style: 'percent',
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(value);
+}
+
+/* ------------------------------ currency -------------------------------- */
+
+export interface CurrencyOptions {
+  /** ISO 4217. Defaults to the locale's own default currency. */
+  currency?: CurrencyCode | string;
+  /** Compact notation for dashboards: "1,2 M FCFA". */
+  compact?: boolean;
+  /** Force decimals. Omitted, the currency's own minor-unit rule applies. */
+  fractionDigits?: number;
+}
+
+/**
+ * Money in the reader's conventions. XAF carries no minor unit, so `Intl` gives
+ * it zero decimals and the "FCFA" symbol the target market actually reads —
+ * that is why this does not special-case XAF by hand.
+ */
+export function formatCurrency(
+  locale: LocaleCode,
+  value: number,
+  options: CurrencyOptions = {},
+): string {
+  if (!Number.isFinite(value)) return '—';
+  const currency = options.currency || localeDefinition(locale).defaultCurrency;
+  const intlOptions: Intl.NumberFormatOptions = { style: 'currency', currency };
+  if (options.compact) {
+    intlOptions.notation = 'compact';
+    intlOptions.compactDisplay = 'short';
+    intlOptions.maximumFractionDigits = options.fractionDigits ?? 1;
+  } else if (options.fractionDigits !== undefined) {
+    intlOptions.minimumFractionDigits = options.fractionDigits;
+    intlOptions.maximumFractionDigits = options.fractionDigits;
+  }
+  try {
+    return numberFormat(localeTag(locale), intlOptions).format(value);
+  } catch {
+    // An unknown ISO code must not blank a dashboard cell.
+    return `${formatNumber(locale, value)} ${currency}`;
+  }
+}
+
+/* -------------------------------- dates --------------------------------- */
+
+/** Anything the API or a component might hand us as a moment in time. */
+export type DateInput = Date | string | number;
+
+function toDate(value: DateInput): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatDate(
+  locale: LocaleCode,
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions = { dateStyle: 'medium' },
+): string {
+  const date = toDate(value);
+  if (!date) return '—';
+  return dateFormat(localeTag(locale), options).format(date);
+}
+
+export function formatDateTime(
+  locale: LocaleCode,
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' },
+): string {
+  return formatDate(locale, value, options);
+}
+
+export function formatTime(
+  locale: LocaleCode,
+  value: DateInput,
+  options: Intl.DateTimeFormatOptions = { timeStyle: 'short' },
+): string {
+  return formatDate(locale, value, options);
+}
+
+const RELATIVE_UNITS: ReadonlyArray<[Intl.RelativeTimeFormatUnit, number]> = [
+  ['year', 31_536_000_000],
+  ['month', 2_592_000_000],
+  ['week', 604_800_000],
+  ['day', 86_400_000],
+  ['hour', 3_600_000],
+  ['minute', 60_000],
+  ['second', 1000],
+];
+
+/**
+ * "il y a 3 jours" / "3 days ago". `numeric: 'auto'` is deliberate: it lets the
+ * language use "hier"/"yesterday" where it has a word for it.
+ */
+export function formatRelativeTime(
+  locale: LocaleCode,
+  value: DateInput,
+  now: DateInput = Date.now(),
+): string {
+  const date = toDate(value);
+  const base = toDate(now);
+  if (!date || !base) return '—';
+  const diff = date.getTime() - base.getTime();
+  const formatter = relativeFormat(localeTag(locale), { numeric: 'auto' });
+  for (const [unit, ms] of RELATIVE_UNITS) {
+    if (Math.abs(diff) >= ms) return formatter.format(Math.round(diff / ms), unit);
+  }
+  return formatter.format(0, 'second');
+}
+
+/* --------------------------------- lists -------------------------------- */
+
+/** "a, b et c" / "a, b, and c" — never a hand-joined ", " with a hardcoded word. */
+export function formatList(
+  locale: LocaleCode,
+  items: readonly string[],
+  type: Intl.ListFormatType = 'conjunction',
+): string {
+  if (items.length === 0) return '';
+  return listFormat(localeTag(locale), { style: 'long', type }).format(items);
+}
+
+/** Every formatter bound to one locale — what `useFormat()` hands a component. */
+export interface BoundFormatters {
+  readonly locale: LocaleCode;
+  number: (value: number, options?: Intl.NumberFormatOptions) => string;
+  compact: (value: number, maximumFractionDigits?: number) => string;
+  percent: (value: number, fractionDigits?: number) => string;
+  currency: (value: number, options?: CurrencyOptions) => string;
+  date: (value: DateInput, options?: Intl.DateTimeFormatOptions) => string;
+  dateTime: (value: DateInput, options?: Intl.DateTimeFormatOptions) => string;
+  time: (value: DateInput, options?: Intl.DateTimeFormatOptions) => string;
+  relative: (value: DateInput, now?: DateInput) => string;
+  list: (items: readonly string[], type?: Intl.ListFormatType) => string;
+}
+
+export function boundFormatters(locale: LocaleCode): BoundFormatters {
+  return {
+    locale,
+    number: (value, options) => formatNumber(locale, value, options),
+    compact: (value, digits) => formatCompact(locale, value, digits),
+    percent: (value, digits) => formatPercent(locale, value, digits),
+    currency: (value, options) => formatCurrency(locale, value, options),
+    date: (value, options) => formatDate(locale, value, options),
+    dateTime: (value, options) => formatDateTime(locale, value, options),
+    time: (value, options) => formatTime(locale, value, options),
+    relative: (value, now) => formatRelativeTime(locale, value, now),
+    list: (items, type) => formatList(locale, items, type),
+  };
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * The i18n public surface. Import from `@/i18n` (or a relative `../i18n`) —
+ * never reach into the individual modules from a feature.
+ *
+ * Typical use inside a component:
+ *
+ *   const { t, fmt } = useI18n();
+ *   t('common.results', { count: rows.length })   // "0 result" is never printed
+ *   fmt.currency(ale, { currency: 'XAF' })        // "1 234 567 FCFA"
+ *   fmt.relative(risk.updated_at)                 // "il y a 3 jours"
+ */
+
+export {
+  CURRENCIES,
+  DEFAULT_LOCALE,
+  ENABLED_LOCALES,
+  LOCALES,
+  LOCALE_CODES,
+  isEnabledLocale,
+  isLocaleCode,
+  localeDefinition,
+  localeDirection,
+  localeTag,
+  negotiateLocale,
+  resolveLocale,
+  type CurrencyCode,
+  type Direction,
+  type LocaleCode,
+  type LocaleDefinition,
+} from './locales';
+
+export {
+  PLURAL_CATEGORIES,
+  isPluralForms,
+  pluralCategory,
+  resolveMessage,
+  selectPlural,
+  type Message,
+  type PluralCategory,
+  type PluralForms,
+} from './plural';
+
+export {
+  boundFormatters,
+  formatCompact,
+  formatCurrency,
+  formatDate,
+  formatDateTime,
+  formatList,
+  formatNumber,
+  formatPercent,
+  formatRelativeTime,
+  formatTime,
+  type BoundFormatters,
+  type CurrencyOptions,
+  type DateInput,
+} from './format';
+
+export {
+  lookup,
+  translate,
+  type Catalog,
+  type TranslateOptions,
+  type TranslateParams,
+} from './translate';
+
+export { catalogs, merge } from './catalog';
+export { runtimeMessages } from './messages';

--- a/frontend/src/i18n/locales.ts
+++ b/frontend/src/i18n/locales.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * The locale registry — the single place a language is declared.
+ *
+ * Adding a language is one entry here plus one message catalogue in
+ * `src/i18n/catalog.ts`. Nothing else in the application names a language:
+ * `Lang` is derived from this object, so widening it widens the app.
+ *
+ * `enabled` is the honesty switch. A locale may be *registered* (its direction,
+ * currency and plural rules are live and tested) long before it is *offered* to
+ * users. Only enabled locales appear in the language switcher, and only they can
+ * be persisted, so a half-translated language can never leak into the product.
+ */
+
+/** ISO 4217 codes the product formats money in. XAF is the canonical currency. */
+export const CURRENCIES = ['XAF', 'EUR', 'USD'] as const;
+export type CurrencyCode = (typeof CURRENCIES)[number];
+
+/** Writing direction. Drives `<html dir>` and the logical-property CSS. */
+export type Direction = 'ltr' | 'rtl';
+
+export interface LocaleDefinition {
+  /** Internal key and the value persisted in localStorage. */
+  readonly code: string;
+  /** BCP-47 tag handed to every `Intl` constructor. Never assume it equals `code`. */
+  readonly tag: string;
+  readonly dir: Direction;
+  /** Endonym, shown in the switcher — a language names itself in its own words. */
+  readonly nativeName: string;
+  readonly englishName: string;
+  /** Currency used when a figure carries no explicit currency of its own. */
+  readonly defaultCurrency: CurrencyCode;
+  /** False = registered and testable, but not offered to users yet. */
+  readonly enabled: boolean;
+}
+
+export const LOCALES = {
+  fr: {
+    code: 'fr',
+    tag: 'fr-FR',
+    dir: 'ltr',
+    nativeName: 'Français',
+    englishName: 'French',
+    defaultCurrency: 'XAF',
+    enabled: true,
+  },
+  en: {
+    code: 'en',
+    tag: 'en-US',
+    dir: 'ltr',
+    nativeName: 'English',
+    englishName: 'English',
+    defaultCurrency: 'USD',
+    enabled: true,
+  },
+  /**
+   * Registered, not shipped. Arabic exists here so RTL is exercised by the test
+   * suite rather than asserted in a document: it proves the direction plumbing,
+   * the RTL plural categories (zero/one/two/few/many/other) and the Arabic
+   * numeral formatting all work before anyone writes a catalogue. It stays
+   * `enabled: false` until that catalogue exists — see the Maghreb line in
+   * ROADMAP.md.
+   */
+  ar: {
+    code: 'ar',
+    tag: 'ar-MA',
+    dir: 'rtl',
+    nativeName: 'العربية',
+    englishName: 'Arabic',
+    defaultCurrency: 'EUR',
+    enabled: false,
+  },
+} as const satisfies Record<string, LocaleDefinition>;
+
+/** Every registered language. Widens automatically when LOCALES grows. */
+export type LocaleCode = keyof typeof LOCALES;
+
+/** The fallback for a missing key, an unknown code, and a first visit. */
+export const DEFAULT_LOCALE: LocaleCode = 'fr';
+
+export const LOCALE_CODES = Object.keys(LOCALES) as LocaleCode[];
+
+/** The locales the switcher may offer and the store may persist. */
+export const ENABLED_LOCALES: LocaleCode[] = LOCALE_CODES.filter((c) => LOCALES[c].enabled);
+
+export function isLocaleCode(value: unknown): value is LocaleCode {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(LOCALES, value);
+}
+
+export function isEnabledLocale(value: unknown): value is LocaleCode {
+  return isLocaleCode(value) && LOCALES[value].enabled;
+}
+
+export function localeDefinition(code: LocaleCode): LocaleDefinition {
+  return LOCALES[code];
+}
+
+/** BCP-47 tag for `Intl`. Unknown codes resolve to the default rather than throw. */
+export function localeTag(code: LocaleCode): string {
+  return (LOCALES[code] ?? LOCALES[DEFAULT_LOCALE]).tag;
+}
+
+export function localeDirection(code: LocaleCode): Direction {
+  return (LOCALES[code] ?? LOCALES[DEFAULT_LOCALE]).dir;
+}
+
+/**
+ * Narrow anything — a localStorage string, an `Accept-Language` header, a URL
+ * param — onto a locale the product actually offers. Matches the exact code
+ * first, then the primary subtag ("fr-CM" and "fr_CA" both land on "fr").
+ */
+export function resolveLocale(value: unknown, fallback: LocaleCode = DEFAULT_LOCALE): LocaleCode {
+  if (typeof value !== 'string' || value === '') return fallback;
+  const normalized = value.trim().toLowerCase().replace('_', '-');
+  if (isEnabledLocale(normalized)) return normalized;
+  const primary = normalized.split('-')[0];
+  if (isEnabledLocale(primary)) return primary;
+  return fallback;
+}
+
+/**
+ * Pick the best offered locale out of an `Accept-Language`-shaped preference
+ * list, honouring q-weights. Used by the first-visit default and by anything
+ * that receives a browser language list.
+ */
+export function negotiateLocale(
+  accepted: readonly string[] | string | undefined,
+  fallback: LocaleCode = DEFAULT_LOCALE,
+): LocaleCode {
+  if (!accepted) return fallback;
+  const raw = Array.isArray(accepted) ? accepted : String(accepted).split(',');
+  const ranked = raw
+    .map((entry, index) => {
+      const [tag, ...params] = entry.split(';').map((part: string) => part.trim());
+      const q = params
+        .map((param: string) => /^q=([0-9.]+)$/i.exec(param))
+        .find(Boolean)?.[1];
+      return { tag, q: q === undefined ? 1 : Number(q), index };
+    })
+    .filter((e) => e.tag !== '' && Number.isFinite(e.q) && e.q > 0)
+    .sort((a, b) => b.q - a.q || a.index - b.index);
+
+  for (const entry of ranked) {
+    const match = resolveLocale(entry.tag, null as unknown as LocaleCode);
+    if (match) return match;
+  }
+  return fallback;
+}
+
+/**
+ * Read a value out of an inline `{ fr: …, en: … }` literal.
+ *
+ * Transitional by design: these literals are exactly the pattern this framework
+ * exists to replace, and 287 of them are still in the tree. Until each one is
+ * extracted into a catalogue, this resolves it through the same fallback chain
+ * `translate()` uses — so registering a new language turns those labels into the
+ * default language's words, never into `undefined` rendered as a blank cell.
+ */
+export function pickLocalized<T>(
+  locale: LocaleCode,
+  options: Partial<Record<LocaleCode, T>> | null | undefined,
+): T | undefined {
+  if (!options) return undefined;
+  return options[locale] ?? options[DEFAULT_LOCALE];
+}

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * Messages that JSON cannot express — plural sets, and copy that has to run a
+ * value through a formatter.
+ *
+ * These live in TypeScript so the `PluralForms` type enforces the one thing a
+ * translator cannot be trusted to remember: every plural must define `other`,
+ * the single category present in every language on earth.
+ *
+ * They are merged over `locales/*.json` at startup and win on collision, so a
+ * key moves here the day it needs a plural and no call site changes.
+ *
+ * FR/EN parity is a test, not a convention — see `__tests__/parity.test.ts`.
+ */
+
+import type { LocaleCode } from './locales';
+import type { Catalog } from './translate';
+
+const fr: Catalog = {
+  common: {
+    results: {
+      exact: { 0: 'Aucun résultat' },
+      one: '{count, number} résultat',
+      other: '{count, number} résultats',
+    },
+    selected: {
+      one: '{count, number} sélectionné',
+      other: '{count, number} sélectionnés',
+    },
+    assets: {
+      exact: { 0: 'Aucun actif' },
+      one: '{count, number} actif',
+      other: '{count, number} actifs',
+    },
+    days: {
+      one: '{count, number} jour',
+      other: '{count, number} jours',
+    },
+    controls: {
+      exact: { 0: 'Aucun contrôle' },
+      one: '{count, number} contrôle',
+      other: '{count, number} contrôles',
+    },
+    frameworks: {
+      one: '{count, number} référentiel',
+      other: '{count, number} référentiels',
+    },
+    sources: {
+      exact: { 0: 'Aucune source configurée' },
+      one: '{count, number} source configurée',
+      other: '{count, number} sources configurées',
+    },
+    attributes: {
+      one: '{count, number} attribut',
+      other: '{count, number} attributs',
+    },
+  },
+};
+
+const en: Catalog = {
+  common: {
+    results: {
+      exact: { 0: 'No results' },
+      one: '{count, number} result',
+      other: '{count, number} results',
+    },
+    selected: {
+      one: '{count, number} selected',
+      other: '{count, number} selected',
+    },
+    assets: {
+      exact: { 0: 'No assets' },
+      one: '{count, number} asset',
+      other: '{count, number} assets',
+    },
+    days: {
+      one: '{count, number} day',
+      other: '{count, number} days',
+    },
+    controls: {
+      exact: { 0: 'No controls' },
+      one: '{count, number} control',
+      other: '{count, number} controls',
+    },
+    frameworks: {
+      one: '{count, number} framework',
+      other: '{count, number} frameworks',
+    },
+    sources: {
+      exact: { 0: 'No source configured' },
+      one: '{count, number} source configured',
+      other: '{count, number} sources configured',
+    },
+    attributes: {
+      one: '{count, number} attribute',
+      other: '{count, number} attributes',
+    },
+  },
+};
+
+/** Partial by design: a locale with no overlay simply has none. */
+export const runtimeMessages: Partial<Record<LocaleCode, Catalog>> = { fr, en };

--- a/frontend/src/i18n/plural.ts
+++ b/frontend/src/i18n/plural.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * Pluralization through `Intl.PluralRules` and the real CLDR categories.
+ *
+ * The pattern this replaces is `${n} result${n > 1 ? 's' : ''}`, which is wrong
+ * in two directions at once: it prints "0 result" in English (English uses the
+ * plural at zero) and it cannot express Arabic, which has six categories, or
+ * Russian, which changes form again at 5. A category is a language fact, so the
+ * language table decides it — never the component.
+ */
+
+import { localeTag, type LocaleCode } from './locales';
+
+/** The six CLDR plural categories. No language uses all six; Arabic uses all six. */
+export const PLURAL_CATEGORIES = ['zero', 'one', 'two', 'few', 'many', 'other'] as const;
+export type PluralCategory = (typeof PLURAL_CATEGORIES)[number];
+
+/**
+ * A message that changes shape with a count. `other` is required because it is
+ * the only category every language defines — it is the guaranteed fallback.
+ * `exact` short-circuits the rules entirely for copy that reads better at a
+ * literal count ("no results" rather than "0 results").
+ */
+export type PluralForms = Partial<Record<PluralCategory, string>> & {
+  other: string;
+  exact?: Record<number, string>;
+};
+
+/** A catalogue value: a plain string, or a set of plural forms. */
+export type Message = string | PluralForms;
+
+export function isPluralForms(value: unknown): value is PluralForms {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as PluralForms).other === 'string'
+  );
+}
+
+// `Intl.PluralRules` construction is not free and these are hit inside render.
+const cardinalCache = new Map<string, Intl.PluralRules>();
+const ordinalCache = new Map<string, Intl.PluralRules>();
+
+function rules(tag: string, type: Intl.PluralRuleType): Intl.PluralRules {
+  const cache = type === 'ordinal' ? ordinalCache : cardinalCache;
+  let found = cache.get(tag);
+  if (!found) {
+    found = new Intl.PluralRules(tag, { type });
+    cache.set(tag, found);
+  }
+  return found;
+}
+
+/**
+ * The CLDR category for `count` in `locale`. Non-finite counts fall to `other`,
+ * which is the safe form: it is the one category guaranteed to be present.
+ */
+export function pluralCategory(
+  locale: LocaleCode,
+  count: number,
+  type: Intl.PluralRuleType = 'cardinal',
+): PluralCategory {
+  if (!Number.isFinite(count)) return 'other';
+  return rules(localeTag(locale), type).select(count) as PluralCategory;
+}
+
+/**
+ * Choose the form for `count`, preferring an exact override, then the CLDR
+ * category, then `other`. Never returns undefined — `other` is mandatory in the
+ * type, so a catalogue physically cannot leave a plural without a fallback.
+ */
+export function selectPlural(locale: LocaleCode, forms: PluralForms, count: number): string {
+  const exact = forms.exact?.[count];
+  if (exact !== undefined) return exact;
+  return forms[pluralCategory(locale, count)] ?? forms.other;
+}
+
+/**
+ * Resolve any catalogue value against a count. Plain strings pass through. A
+ * plural message used without a count is an authoring mistake; it renders
+ * `other`, the neutral form, rather than silently claiming a quantity of zero.
+ */
+export function resolveMessage(locale: LocaleCode, message: Message, count?: number): string {
+  if (typeof message === 'string') return message;
+  if (count === undefined) return message.other;
+  return selectPlural(locale, message, count);
+}

--- a/frontend/src/i18n/translate.ts
+++ b/frontend/src/i18n/translate.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+/**
+ * Key lookup, fallback and interpolation.
+ *
+ * Three rules the rest of the app depends on:
+ *   1. A missing key never renders blank. It falls back to the default locale
+ *      and then to the key text, so a gap is visible in review, not invisible
+ *      in production.
+ *   2. Values are interpolated *through the formatters*, so `{count, number}`
+ *      is grouped in the reader's conventions rather than pasted raw.
+ *   3. A count selects the plural form before interpolation runs, so a message
+ *      can say `{count, number} risques` and still be singular at one.
+ */
+
+import {
+  boundFormatters,
+  type CurrencyOptions,
+  type DateInput,
+} from './format';
+import { DEFAULT_LOCALE, type LocaleCode } from './locales';
+import { isPluralForms, resolveMessage, type Message } from './plural';
+
+/** A catalogue is a tree of messages. Leaves are strings or plural forms. */
+export interface Catalog {
+  [key: string]: Message | Catalog;
+}
+
+/** What a component may interpolate. `count` additionally drives pluralization. */
+export type TranslateParams = Record<
+  string,
+  string | number | boolean | Date | null | undefined
+>;
+
+function isCatalog(value: unknown): value is Catalog {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Read `a.b.c` out of a catalogue. Returns undefined — not the key — so the
+ * caller can tell "absent here" from "the translation is literally this text"
+ * and move on to the next locale in the chain.
+ */
+export function lookup(catalog: Catalog | undefined, key: string): Message | undefined {
+  if (!catalog) return undefined;
+  let node: Message | Catalog | undefined = catalog;
+  for (const part of key.split('.')) {
+    if (!isCatalog(node) || isPluralForms(node)) return undefined;
+    node = node[part];
+    if (node === undefined) return undefined;
+  }
+  if (typeof node === 'string' || isPluralForms(node)) return node;
+  return undefined;
+}
+
+/**
+ * `{name}`, `{count, number}`, `{amount, currency, EUR}`.
+ * The optional third field is the format's argument — a currency code for
+ * `currency`, a fraction-digit count for `percent` and `compact`.
+ */
+const PLACEHOLDER = /\{(\w+)(?:\s*,\s*(\w+))?(?:\s*,\s*([^}]+))?\}/g;
+
+function applyFormat(
+  locale: LocaleCode,
+  value: string | number | boolean | Date | null | undefined,
+  format: string | undefined,
+  arg: string | undefined,
+): string {
+  if (value === null || value === undefined) return '';
+  const f = boundFormatters(locale);
+  switch (format) {
+    case undefined:
+      return String(value);
+    case 'number':
+      return f.number(Number(value));
+    case 'compact':
+      return f.compact(Number(value), arg === undefined ? undefined : Number(arg));
+    case 'percent':
+      return f.percent(Number(value), arg === undefined ? undefined : Number(arg));
+    case 'currency':
+      return f.currency(Number(value), { currency: arg } as CurrencyOptions);
+    case 'date':
+      return f.date(value as DateInput);
+    case 'datetime':
+      return f.dateTime(value as DateInput);
+    case 'time':
+      return f.time(value as DateInput);
+    case 'relative':
+      return f.relative(value as DateInput);
+    default:
+      // An unknown format is an authoring mistake, not a reason to blank the UI.
+      return String(value);
+  }
+}
+
+/** Substitute `{…}` placeholders. An unknown name is left visible, not erased. */
+export function interpolate(
+  template: string,
+  params: TranslateParams | undefined,
+  locale: LocaleCode = DEFAULT_LOCALE,
+): string {
+  if (!params) return template;
+  return template.replace(PLACEHOLDER, (match, name: string, format?: string, arg?: string) => {
+    if (!Object.prototype.hasOwnProperty.call(params, name)) return match;
+    return applyFormat(locale, params[name], format, arg?.trim());
+  });
+}
+
+export interface TranslateOptions {
+  /** Text to show when the key is absent from every locale in the chain. */
+  defaultValue?: string;
+  params?: TranslateParams;
+}
+
+/**
+ * Resolve `key` for `locale`, falling back to the default locale and finally to
+ * `defaultValue` or the key text itself.
+ *
+ * `catalogs` is passed in rather than imported so the pure core stays testable
+ * with a two-key fixture and the app wires the real catalogues in `catalog.ts`.
+ */
+export function translate(
+  catalogs: Partial<Record<LocaleCode, Catalog>>,
+  locale: LocaleCode,
+  key: string,
+  options: TranslateOptions = {},
+): string {
+  const { defaultValue, params } = options;
+  const message = lookup(catalogs[locale], key) ?? lookup(catalogs[DEFAULT_LOCALE], key);
+  if (message === undefined) return defaultValue ?? key;
+
+  const count = typeof params?.count === 'number' ? params.count : undefined;
+  const resolved = resolveMessage(locale, message, count);
+  // An empty string in a catalogue is a hole, not a translation.
+  if (resolved === '') return defaultValue ?? key;
+  return interpolate(resolved, params, locale);
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { useFormat } from '../hooks/useI18n';
 import React, { useState, useEffect } from 'react';
 import { CartesianChart, PieChart } from '../shared/ds/charts';
 import { Download, RefreshCw, TrendingUp, TrendingDown } from 'lucide-react';
@@ -55,6 +56,7 @@ interface DashboardSnapshot {
 }
 
 export default function Analytics() {
+  const fmt = useFormat();
   const [dashboard, setDashboard] = useState<DashboardSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -264,7 +266,7 @@ export default function Analytics() {
             { type: 'line', key: 'new_risks', label: 'New Risks' },
           ]}
           formatCategory={(d) =>
-            new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+            fmt.date(d, { month: 'short', day: 'numeric' })
           }
           ariaLabel="Total risks, average score and new risks over the last 30 days"
         />

--- a/frontend/src/pages/TokenManagement.tsx
+++ b/frontend/src/pages/TokenManagement.tsx
@@ -3,6 +3,7 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
+import { useFormat } from '../hooks/useI18n';
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Key, Trash2, Lock, Copy, Plus, Search, Calendar, ChevronDown } from 'lucide-react';
@@ -32,6 +33,7 @@ interface CreateTokenRequest {
 }
 
 export const TokenManagement = () => {
+  const fmt = useFormat();
   const [tokens, setTokens] = useState<APIToken[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
@@ -149,11 +151,7 @@ export const TokenManagement = () => {
 
   const formatDate = (dateString?: string) => {
     if (!dateString) return 'Never';
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return fmt.date(dateString, { month: 'short', day: 'numeric', year: 'numeric' });
   };
 
   const isExpiringSoon = (expiresAt?: string) => {

--- a/frontend/src/services/activationService.ts
+++ b/frontend/src/services/activationService.ts
@@ -10,9 +10,10 @@
 // through. The client asks; the server answers.
 
 import { api } from '../lib/api';
+import type { LocaleCode } from '../i18n/locales';
 
 /** Language keys the server ships copy in. */
-export type Lang = 'fr' | 'en';
+export type Lang = LocaleCode;
 
 export interface ActivationStep {
   key: string;

--- a/frontend/src/services/scoreService.ts
+++ b/frontend/src/services/scoreService.ts
@@ -15,6 +15,8 @@
 // durable fix is that the client never derives a label at all.
 
 import { api } from '../lib/api';
+import type { LocaleCode } from '../i18n/locales';
+import { pickLocalized } from '../i18n/locales';
 
 export type ScoreScope = 'tenant' | 'risk' | 'asset';
 
@@ -148,7 +150,7 @@ export function bandTextColor(band: ScoreBand | undefined): string {
 }
 
 /** FR/EN label for a band, keyed by the server's i18n key. */
-export function bandLabel(band: ScoreBand | undefined, lang: 'fr' | 'en'): string {
+export function bandLabel(band: ScoreBand | undefined, lang: LocaleCode): string {
   const labels: Record<ScoreBand, { fr: string; en: string }> = {
     low: { fr: 'Faible', en: 'Low' },
     medium: { fr: 'Moyen', en: 'Medium' },
@@ -156,11 +158,11 @@ export function bandLabel(band: ScoreBand | undefined, lang: 'fr' | 'en'): strin
     critical: { fr: 'Critique', en: 'Critical' },
   };
   if (!band || !(band in labels)) return lang === 'fr' ? 'Non mesuré' : 'Not measured';
-  return labels[band][lang];
+  return pickLocalized(lang, labels[band]) ?? band;
 }
 
 /** FR/EN label for a factor, keyed by the server's factor key. */
-export function factorLabel(factor: string, lang: 'fr' | 'en'): string {
+export function factorLabel(factor: string, lang: LocaleCode): string {
   const labels: Record<string, { fr: string; en: string }> = {
     risk_exposure: { fr: 'Exposition aux risques', en: 'Risk exposure' },
     control_gaps: { fr: 'Écarts de conformité', en: 'Control gaps' },
@@ -173,5 +175,5 @@ export function factorLabel(factor: string, lang: 'fr' | 'en'): string {
     linked_risk_exposure: { fr: 'Risques liés', en: 'Linked risks' },
     internet_exposure: { fr: 'Exposition Internet', en: 'Internet exposure' },
   };
-  return labels[factor]?.[lang] ?? factor;
+  return pickLocalized(lang, labels[factor]) ?? factor;
 }

--- a/frontend/src/shared/Breadcrumbs.tsx
+++ b/frontend/src/shared/Breadcrumbs.tsx
@@ -20,6 +20,7 @@ import { routeTrail } from './routeModel';
 import { useUIStrings } from './uiStrings';
 import { useUIStore } from '../store/uiStore';
 import { useCrumbLabels } from './crumbLabels';
+import { pickLocalized } from '../i18n/locales';
 
 export function Breadcrumbs() {
   const { pathname } = useLocation();
@@ -46,7 +47,7 @@ export function Breadcrumbs() {
         const isLast = i === trail.length - 1;
         const label =
           (step.node.dynamic ? labels[step.href] : undefined) ??
-          (step.node.labelKey ? L[step.node.labelKey] : step.node.label?.[lang]) ??
+          (step.node.labelKey ? L[step.node.labelKey] : pickLocalized(lang, step.node.label)) ??
           '';
         return (
           <span key={step.href} className="flex items-center gap-1.5 min-w-0">

--- a/frontend/src/shared/FieldHelp.tsx
+++ b/frontend/src/shared/FieldHelp.tsx
@@ -15,6 +15,7 @@
 
 import { useEffect, useId, useRef, useState } from 'react';
 import { HelpCircle, ExternalLink } from 'lucide-react';
+import type { LocaleCode } from '../i18n/locales';
 
 export type HelpField = 'probability' | 'impact' | 'asset_criticality';
 
@@ -224,7 +225,7 @@ export function FieldHelp({
   className = '',
 }: {
   field: HelpField;
-  lang?: 'fr' | 'en';
+  lang?: LocaleCode;
   /** The tenant's sector, so the example is one they recognise. */
   sector?: string;
   className?: string;

--- a/frontend/src/shared/ScoreExplainer.tsx
+++ b/frontend/src/shared/ScoreExplainer.tsx
@@ -17,10 +17,12 @@
 //   • inherent and residual are both shown, so "we treated it" is visible as a
 //     delta rather than as an unexplained drop.
 
+import { localeTag } from '../i18n/locales';
 import { useEffect, useState } from 'react';
 import { Info, X, CheckCircle2, MinusCircle } from 'lucide-react';
 
 import { useUIStore } from '../store/uiStore';
+import type { LocaleCode } from '../i18n/locales';
 import {
   bandColor,
   bandLabel,
@@ -275,7 +277,7 @@ function ScoreCard({
   hint: string;
   value: number;
   band: Score['band'];
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
   emphasis?: boolean;
 }) {
   const color = bandColor(band);
@@ -303,7 +305,7 @@ function ScoreCard({
   );
 }
 
-function FactorBar({ factor, max, lang }: { factor: ScoreFactor; max: number; lang: 'fr' | 'en' }) {
+function FactorBar({ factor, max, lang }: { factor: ScoreFactor; max: number; lang: LocaleCode }) {
   const width = Math.max(2, (factor.contribution / max) * 100);
   return (
     <li data-testid={`score-factor-${factor.factor}`}>
@@ -339,10 +341,10 @@ function formatInput(value: unknown): string {
   return String(value);
 }
 
-function formatDate(iso: string, lang: 'fr' | 'en'): string {
+function formatDate(iso: string, lang: LocaleCode): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString(lang === 'fr' ? 'fr-FR' : 'en-GB', {
+  return d.toLocaleString(localeTag(lang), {
     dateStyle: 'short',
     timeStyle: 'short',
   });

--- a/frontend/src/shared/ShortcutsOverlay.tsx
+++ b/frontend/src/shared/ShortcutsOverlay.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect } from 'react';
 import { Keyboard, X } from 'lucide-react';
+import type { LocaleCode } from '../i18n/locales';
 
 interface Row {
   keys: string[];
@@ -48,7 +49,7 @@ export function ShortcutsOverlay({
 }: {
   open: boolean;
   onClose: () => void;
-  lang: 'fr' | 'en';
+  lang: LocaleCode;
 }) {
   useEffect(() => {
     if (!open) return;

--- a/frontend/src/shared/Term.tsx
+++ b/frontend/src/shared/Term.tsx
@@ -8,10 +8,11 @@
 import type { ReactNode } from 'react';
 import { GLOSSARY } from './glossary';
 import { useUIStore } from '../store/uiStore';
+import { pickLocalized } from '../i18n/locales';
 
 export function Term({ term, children }: { term: string; children?: ReactNode }) {
   const lang = useUIStore((s) => s.lang);
-  const def = GLOSSARY[term]?.[lang];
+  const def = pickLocalized(lang, GLOSSARY[term]);
   const content = children ?? term;
   if (!def) return <>{content}</>;
   return (

--- a/frontend/src/shared/datatable/DataTable.tsx
+++ b/frontend/src/shared/datatable/DataTable.tsx
@@ -116,8 +116,9 @@ function useLabels() {
       searchAria: fr ? 'Recherche instantanée' : 'Instant search',
       clearSearch: fr ? 'Effacer la recherche' : 'Clear search',
       filters: fr ? 'Filtres' : 'Filters',
-      results: (n: number) =>
-        fr ? `${n} résultat${n > 1 ? 's' : ''}` : `${n} result${n > 1 ? 's' : ''}`,
+      // Pluralized through the catalogue, not through `n > 1`: English takes the
+      // plural at zero ("0 results"), which the old inline rule got wrong.
+      results: (n: number) => t('common.results', { count: n }),
       reset: fr ? 'Réinitialiser' : 'Reset',
       savedViews: fr ? 'Filtres sauvegardés' : 'Saved filters',
       // #580's strings live in /src/locales rather than inline, so FR/EN parity
@@ -163,7 +164,7 @@ function useLabels() {
       allMatchingSelected: (n: number) =>
         fr ? `Les ${n} résultats sont sélectionnés.` : `All ${n} results are selected.`,
       clearSelection: fr ? 'Effacer la sélection' : 'Clear selection',
-      selected: (n: number) => (fr ? `${n} sélectionné${n > 1 ? 's' : ''}` : `${n} selected`),
+      selected: (n: number) => t('common.selected', { count: n }),
       failed: fr ? 'Échec' : 'Failed',
       actions: fr ? 'Actions' : 'Actions',
       rowsRange: (from: number, to: number, total: number) =>

--- a/frontend/src/shared/useSoftDelete.ts
+++ b/frontend/src/shared/useSoftDelete.ts
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useUIStore } from '../store/uiStore';
+import type { LocaleCode } from '../i18n/locales';
 
 interface SoftDeleteOptions<T> {
   /** The real delete — fires only after the undo window elapses. */
@@ -22,7 +23,7 @@ interface SoftDeleteOptions<T> {
   /** Stable id accessor (defaults to item.id). */
   idOf?: (item: T) => string;
   /** Toast label, e.g. (r) => `Risk "${r.name}" deleted`. FR/EN via `lang`. */
-  message: (item: T, lang: 'fr' | 'en') => string;
+  message: (item: T, lang: LocaleCode) => string;
   /** Milliseconds the undo window stays open (default 5000). */
   delayMs?: number;
 }

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -3,6 +3,13 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  DEFAULT_LOCALE,
+  ENABLED_LOCALES,
+  localeDirection,
+  resolveLocale,
+  type LocaleCode,
+} from '../i18n/locales';
 
 export type Theme = 'dark' | 'light';
 /**
@@ -24,7 +31,13 @@ export function resolveTheme(mode: ThemeMode): Theme {
   return mode === 'system' ? systemTheme() : mode;
 }
 export type Variant = 'azure' | 'iris';
-export type Lang = 'fr' | 'en';
+/**
+ * The active language. Derived from the locale registry rather than written out
+ * here: adding a language to `src/i18n/locales.ts` widens this type and every
+ * `switch` and comparison in the app keeps compiling. Nothing outside the
+ * registry is allowed to enumerate languages.
+ */
+export type Lang = LocaleCode;
 /** UI density (docs/UI_ELEVATION_PROPOSAL §1.2). Confort is the ratified default. */
 export type Density = 'comfort' | 'compact' | 'spacious';
 
@@ -61,6 +74,10 @@ function applyDom(theme: Theme, variant: Variant, lang: Lang) {
   root.setAttribute('data-theme', theme);
   root.setAttribute('data-variant', variant);
   root.setAttribute('lang', lang);
+  // Writing direction comes from the registry, never from a list of RTL codes
+  // kept somewhere else. This is what makes `dir`-scoped CSS and the browser's
+  // own bidi algorithm work the moment an RTL locale is enabled.
+  root.setAttribute('dir', localeDirection(lang));
 }
 
 /** Reflect density onto <html> (drives --den-* tokens). Comfort clears the attr. */
@@ -73,9 +90,22 @@ function applyDensity(density: Density) {
 
 const DENSITY_CYCLE: Density[] = ['comfort', 'compact', 'spacious'];
 
-// Legacy i18n key used by the pre-existing useI18n hook; default to FR per design.
-const legacyLocale =
-  (typeof localStorage !== 'undefined' && (localStorage.getItem('locale') as Lang)) || 'fr';
+/**
+ * First language on a first visit: the legacy `locale` key if one was stored,
+ * else French — the primary market, per the original design default.
+ *
+ * The registry also exposes `negotiateLocale()`, which would pick from
+ * `navigator.languages` instead. It is deliberately NOT wired here: defaulting
+ * to the browser's language is a product decision (it would open the app in
+ * English for a French customer on an English laptop), and it is logged for the
+ * owner in docs/DECISIONS.md rather than taken as a side effect of #315.
+ *
+ * The stored value is an untrusted string, so it goes through the registry.
+ */
+const legacyLocale: Lang = resolveLocale(
+  typeof localStorage !== 'undefined' ? localStorage.getItem('locale') : null,
+  DEFAULT_LOCALE,
+);
 
 export const useUIStore = create<UIState>()(
   persist(
@@ -107,14 +137,23 @@ export const useUIStore = create<UIState>()(
         applyDom(get().theme, variant, get().lang);
         set({ variant });
       },
-      setLang: (lang) => {
+      setLang: (requested) => {
+        // A registered-but-disabled locale (one with no catalogue yet) must never
+        // become the active language, however it arrives — a stale localStorage
+        // value, a deep link, or a switcher rendered from a stale build.
+        const lang = resolveLocale(requested, get().lang);
         if (typeof localStorage !== 'undefined') localStorage.setItem('locale', lang);
         applyDom(get().theme, get().variant, lang);
         set({ lang });
         // Keep any consumer listening on the legacy event in sync.
         window.dispatchEvent(new CustomEvent('locale-change', { detail: { locale: lang } }));
       },
-      toggleLang: () => get().setLang(get().lang === 'fr' ? 'en' : 'fr'),
+      /** Cycle through the languages actually offered, in registry order. */
+      toggleLang: () => {
+        const offered = ENABLED_LOCALES;
+        const next = offered[(offered.indexOf(get().lang) + 1) % offered.length];
+        get().setLang(next);
+      },
       setDensity: (density) => {
         applyDensity(density);
         set({ density });
@@ -145,6 +184,9 @@ export const useUIStore = create<UIState>()(
           // Re-resolve rather than trusting a stored resolved value: under
           // 'system' the OS may have changed since the last visit.
           state.theme = resolveTheme(state.themeMode ?? 'system');
+          // A persisted language from an older build may name a locale this
+          // build no longer offers; re-resolve instead of trusting it.
+          state.lang = resolveLocale(state.lang, DEFAULT_LOCALE);
           applyDom(state.theme, state.variant, state.lang);
           applyDensity(state.density);
         }


### PR DESCRIPTION
Closes #315

## What this delivers

A single i18n entry point at `frontend/src/i18n/`. Before it, adding a third
language meant touching 117 files: `'fr' | 'en'` unions in 38 modules, ad-hoc
`n > 1 ? 's' : ''` plurals, and 77 `toLocale*` call sites — ten of which
hardcoded `'fr-FR'` or `'en-US'` and ignored the user's language entirely, so
the same product showed `12/03/2026` on fifteen screens and `03/12/2026` on
nine. Adding a language is now one registry entry plus one catalogue.

| Module | Role |
|---|---|
| `i18n/locales.ts` | the registry — tag, direction, endonym, currency, `enabled`; `LocaleCode` is derived from it |
| `i18n/plural.ts` | `Intl.PluralRules` with the real CLDR categories |
| `i18n/format.ts` | number, percent, compact, currency, date, date-time, time, relative, list — all bound to the active tag |
| `i18n/translate.ts` | lookup, fallback chain, named interpolation with inline formats |
| `i18n/catalog.ts`, `i18n/messages.ts` | the JSON catalogues plus the typed plural overlay |
| `docs/adr/0002-…` | why the registry owns the tag, why an RTL locale ships disabled |

Arabic (`ar-MA`, RTL, six plural categories) is **registered and disabled**. It
exercises the direction plumbing and the RTL plural categories in the test suite
without claiming a translation that does not exist.

## Acceptance criteria

1 ✅ · 2 ✅ · 3 ✅ · 4 ✅ · 5 ✅ · 6 ✅ · 7 ✅ · 8 ✅ · 9 ⚠️ (see below)

1. Single entry point; adding a locale needs no component edit. Three
   `'fr' | 'en'` unions survive on purpose and are ratcheted: `Locale`,
   `ReportLocale`, `BoardLocale` describe what the **server** can render, not
   the UI, and widening them would claim OpenRisk generates Arabic reports.
2. `<html lang>` **and** `<html dir>` follow the active locale, read from the
   registry rather than a list of RTL codes kept elsewhere.
3. Pluralization is `Intl.PluralRules`; `t()` selects the form from a message
   object; every plural set must define `other`, enforced by a test.
4. `formatCurrency('fr', 1234567, { currency: 'XAF' })` → `1 234 567 FCFA`,
   zero decimals, from `Intl` rather than a hand-written special case.
5. `{count, number}` / `{amount, currency}` interpolate through the formatters;
   a missing key falls back active → default → key and never renders blank.
6. `parity.test.ts` fails on a key present in one catalogue and absent in the
   other, on an empty translation, and on a plural set with no `other`.
7. `ratchet.test.ts` freezes the remaining debt at its measured value — 260
   inline ternaries, 62 raw `toLocale*`, 0 hardcoded BCP-47 tags outside the
   registry — and those numbers may only go down.
8. RTL is proved by a registered RTL locale flipping `dir`, and the physical-
   property debt is measured: **339 physical-direction Tailwind utilities across
   131 files**, tracked in the follow-up issue below.
9. `npx tsc -p tsconfig.app.json --noEmit` reports **zero errors from this
   branch**. `npm run build` still fails on three errors that predate it — see
   *Known blocker*.

## Verification

```
$ npx vitest run
 Test Files  55 passed (55)
      Tests  583 passed (583)

$ npx tsc -p tsconfig.app.json --noEmit
src/services/savedViewService.ts(19,50): error TS2339: Property 'SavedView' does not exist …
src/services/savedViewService.ts(23,57): error TS2339: Property 'CreateSavedViewInput' does not exist …
src/services/savedViewService.ts(24,57): error TS2339: Property 'UpdateSavedViewInput' does not exist …
```

## Known blocker — not introduced here

Those three errors are on `master` already. `savedViewService.ts` (merged by
#580) reads `components['schemas']['SavedView']`, but `docs/openapi.yaml` never
gained the schema, so the generated client types do not contain it. The backend
does implement saved views (`backend/internal/handler/saved_view_handler.go`,
`backend/internal/application/savedview/`); only the spec is missing. Both files
are untouched by this branch. Tracked separately.

## Escalations raised

`docs/DECISIONS.md` gains **D-037** (English date order: `en-US` or `en-GB` —
centralizing the tags forces one answer) and **D-038** (should a first visit
negotiate from `navigator.languages`? `negotiateLocale()` is implemented and
tested, and deliberately not wired, because changing the first-visit default
away from French is a product call).

## Deliberately out of scope

Extracting the 260 remaining inline ternaries, converting the 339 physical
utilities, and replacing the backend's 6 `Accept-Language` prefix checks. This
issue delivers the framework those sweeps use; each has its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
