### PR TITLE
fix(api): document the saved-views endpoints and unbreak the frontend build (#608)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.288.0
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
@@ -156,7 +157,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.6 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect

--- a/backend/internal/handler/saved_view_contract_test.go
+++ b/backend/internal/handler/saved_view_contract_test.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	savedviewapp "github.com/opendefender/openrisk/internal/application/savedview"
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// The saved-views wire contract.
+//
+// #580 shipped a frontend client whose types are DERIVED from
+// docs/openapi.yaml, against a spec that never described this API. The generated
+// types therefore had no SavedView in them and `npm run build` failed on master
+// (#608). Documenting the endpoints fixes today; this test is what stops the
+// spec and the handler drifting apart again.
+//
+// It drives the REAL handler through a REAL Fiber app and compares the JSON that
+// comes back, field for field, with what docs/openapi.yaml promises. Reading the
+// handler's source proves nothing about the bytes on the wire — a `json:"-"`, an
+// omitempty or a renamed tag changes the response without changing the spec.
+// ---------------------------------------------------------------------------
+
+/* ------------------------------------------------------------ the spec side */
+
+type openAPISchema struct {
+	Type       any                      `yaml:"type"`
+	Required   []string                 `yaml:"required"`
+	Properties map[string]openAPISchema `yaml:"properties"`
+	Enum       []string                 `yaml:"enum"`
+	Ref        string                   `yaml:"$ref"`
+}
+
+type openAPIDoc struct {
+	Paths      map[string]map[string]any `yaml:"paths"`
+	Components struct {
+		Schemas map[string]openAPISchema `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+func loadOpenAPI(t *testing.T) openAPIDoc {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "openapi.yaml"))
+	require.NoError(t, err, "docs/openapi.yaml must be readable from the handler package")
+	var doc openAPIDoc
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	return doc
+}
+
+// resolve follows a local $ref one hop, which is all this spec uses.
+func resolve(t *testing.T, doc openAPIDoc, s openAPISchema) openAPISchema {
+	t.Helper()
+	if s.Ref == "" {
+		return s
+	}
+	name := filepath.Base(s.Ref)
+	target, ok := doc.Components.Schemas[name]
+	require.True(t, ok, "spec references %s, which is not defined", s.Ref)
+	return target
+}
+
+// assertMatchesSchema checks a decoded JSON object against a spec schema: every
+// required property present, and no property the spec does not declare.
+func assertMatchesSchema(t *testing.T, doc openAPIDoc, schemaName string, body map[string]any) {
+	t.Helper()
+	schema, ok := doc.Components.Schemas[schemaName]
+	require.True(t, ok, "docs/openapi.yaml declares no %s schema", schemaName)
+
+	for _, field := range schema.Required {
+		_, present := body[field]
+		require.True(t, present,
+			"%s: the spec marks %q required, the handler did not send it", schemaName, field)
+	}
+	for field := range body {
+		_, declared := schema.Properties[field]
+		require.True(t, declared,
+			"%s: the handler sends %q, which docs/openapi.yaml does not document", schemaName, field)
+	}
+	// Nested objects are checked too — a saved view is mostly its state.
+	for field, value := range body {
+		nested, isObject := value.(map[string]any)
+		if !isObject {
+			continue
+		}
+		sub := resolve(t, doc, schema.Properties[field])
+		for _, req := range sub.Required {
+			_, present := nested[req]
+			require.True(t, present, "%s.%s: the spec marks %q required, it is absent", schemaName, field, req)
+		}
+		for key := range nested {
+			_, declared := sub.Properties[key]
+			require.True(t, declared, "%s.%s: undocumented field %q", schemaName, field, key)
+		}
+	}
+}
+
+/* --------------------------------------------------------- the handler side */
+
+type contractRepo struct {
+	views map[uuid.UUID]*domain.SavedView
+}
+
+func newContractRepo() *contractRepo {
+	return &contractRepo{views: map[uuid.UUID]*domain.SavedView{}}
+}
+
+func (r *contractRepo) Create(_ context.Context, v *domain.SavedView) error {
+	if v.ID == uuid.Nil {
+		v.ID = uuid.New()
+	}
+	copied := *v
+	r.views[v.ID] = &copied
+	return nil
+}
+
+func (r *contractRepo) GetByID(_ context.Context, id, tenantID uuid.UUID) (*domain.SavedView, error) {
+	v, ok := r.views[id]
+	if !ok || v.TenantID != tenantID {
+		return nil, nil
+	}
+	copied := *v
+	return &copied, nil
+}
+
+func (r *contractRepo) ListVisible(_ context.Context, tenantID, userID uuid.UUID, tableID string) ([]domain.SavedView, error) {
+	out := []domain.SavedView{}
+	for _, v := range r.views {
+		if v.TenantID != tenantID {
+			continue
+		}
+		if tableID != "" && v.TableID != tableID {
+			continue
+		}
+		if v.UserID != userID && !v.IsShared() {
+			continue
+		}
+		out = append(out, *v)
+	}
+	return out, nil
+}
+
+func (r *contractRepo) Update(_ context.Context, v *domain.SavedView) error {
+	existing, ok := r.views[v.ID]
+	if !ok || existing.TenantID != v.TenantID {
+		return domain.NewNotFoundError("saved view", v.ID)
+	}
+	existing.Name = v.Name
+	existing.Visibility = v.Visibility
+	existing.State = v.State
+	existing.Columns = v.Columns
+	return nil
+}
+
+func (r *contractRepo) Delete(_ context.Context, id, tenantID uuid.UUID) error {
+	v, ok := r.views[id]
+	if !ok || v.TenantID != tenantID {
+		return domain.NewNotFoundError("saved view", id)
+	}
+	delete(r.views, id)
+	return nil
+}
+
+func (r *contractRepo) ExistsByName(_ context.Context, tenantID, userID uuid.UUID, tableID, name string, excludeID uuid.UUID) (bool, error) {
+	for _, v := range r.views {
+		if v.ID == excludeID {
+			continue
+		}
+		if v.TenantID == tenantID && v.UserID == userID && v.TableID == tableID && v.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// setupSavedViewApp mounts the four real routes behind a stand-in for the auth
+// middleware, exactly as cmd/server/main.go registers them.
+func setupSavedViewApp(repo domain.SavedViewRepository, tenant, user uuid.UUID) *fiber.App {
+	app := fiber.New()
+	h := NewSavedViewHandler(
+		savedviewapp.NewListSavedViewsUseCase(repo),
+		savedviewapp.NewCreateSavedViewUseCase(repo),
+		savedviewapp.NewUpdateSavedViewUseCase(repo),
+		savedviewapp.NewDeleteSavedViewUseCase(repo),
+	)
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("tenant_id", tenant)
+		c.Locals("user_id", user)
+		return c.Next()
+	})
+	app.Get("/saved-views", h.ListSavedViews)
+	app.Post("/saved-views", h.CreateSavedView)
+	app.Patch("/saved-views/:id", h.UpdateSavedView)
+	app.Delete("/saved-views/:id", h.DeleteSavedView)
+	return app
+}
+
+func call(t *testing.T, app *fiber.App, method, target string, body any) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(encoded)
+	}
+	req := httptest.NewRequest(method, target, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	payload, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, payload
+}
+
+/* ----------------------------------------------------------------- the test */
+
+func TestSavedViewContract_ResponsesMatchOpenAPISpec(t *testing.T) {
+	doc := loadOpenAPI(t)
+	tenant, user := uuid.New(), uuid.New()
+	app := setupSavedViewApp(newContractRepo(), tenant, user)
+
+	// --- POST /saved-views -> 201 SavedView -----------------------------------
+	status, payload := call(t, app, "POST", "/saved-views", map[string]any{
+		"table_id":   "risks",
+		"name":       "Comité de mars",
+		"visibility": "shared",
+		"state": map[string]any{
+			"q":       "fraude",
+			"filters": map[string][]string{"severity": {"critical", "high"}},
+			"sort":    map[string]string{"key": "score", "dir": "desc"},
+		},
+		"columns": map[string][]string{"order": {"name", "score"}, "hidden": {"owner"}},
+	})
+	require.Equal(t, 201, status, "POST /saved-views: %s", payload)
+
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(payload, &created))
+	assertMatchesSchema(t, doc, "SavedView", created)
+	require.Equal(t, "shared", created["visibility"])
+	id, _ := created["id"].(string)
+	require.NotEmpty(t, id)
+
+	// The enum in the spec must cover what the handler actually emits.
+	visibility := doc.Components.Schemas["SavedViewVisibility"]
+	require.Contains(t, visibility.Enum, created["visibility"])
+
+	// --- POST the same name again -> 409, as documented -----------------------
+	status, payload = call(t, app, "POST", "/saved-views", map[string]any{
+		"table_id": "risks", "name": "Comité de mars",
+	})
+	require.Equal(t, 409, status, "a duplicate name must conflict: %s", payload)
+
+	// --- GET /saved-views?table_id=risks -> 200 [SavedView] -------------------
+	status, payload = call(t, app, "GET", "/saved-views?table_id=risks", nil)
+	require.Equal(t, 200, status, "GET /saved-views: %s", payload)
+
+	var listed []map[string]any
+	require.NoError(t, json.Unmarshal(payload, &listed))
+	require.Len(t, listed, 1)
+	assertMatchesSchema(t, doc, "SavedView", listed[0])
+
+	// --- PATCH /saved-views/{id} -> 200 SavedView -----------------------------
+	status, payload = call(t, app, "PATCH", "/saved-views/"+id, map[string]any{
+		"visibility": "personal",
+	})
+	require.Equal(t, 200, status, "PATCH /saved-views/{id}: %s", payload)
+
+	var patched map[string]any
+	require.NoError(t, json.Unmarshal(payload, &patched))
+	assertMatchesSchema(t, doc, "SavedView", patched)
+	require.Equal(t, "personal", patched["visibility"], "a patch must apply")
+	require.Equal(t, "Comité de mars", patched["name"], "a patch must not reset an absent field")
+
+	// --- DELETE /saved-views/{id} -> 204, empty body --------------------------
+	status, payload = call(t, app, "DELETE", "/saved-views/"+id, nil)
+	require.Equal(t, 204, status)
+	require.Empty(t, payload, "204 carries no body")
+
+	// --- and it is gone -------------------------------------------------------
+	status, payload = call(t, app, "GET", "/saved-views?table_id=risks", nil)
+	require.Equal(t, 200, status)
+	require.NoError(t, json.Unmarshal(payload, &listed))
+	require.Empty(t, listed)
+}
+
+// TestSavedViewContract_SpecDocumentsEveryRoute fails if a verb is registered in
+// main.go and not described in the spec — the other half of the drift #608 was.
+func TestSavedViewContract_SpecDocumentsEveryRoute(t *testing.T) {
+	doc := loadOpenAPI(t)
+
+	for path, verbs := range map[string][]string{
+		"/saved-views":      {"get", "post"},
+		"/saved-views/{id}": {"patch", "delete"},
+	} {
+		item, ok := doc.Paths[path]
+		require.True(t, ok, "docs/openapi.yaml documents no %s", path)
+		for _, verb := range verbs {
+			_, ok := item[verb]
+			require.True(t, ok, "docs/openapi.yaml documents no %s %s", verb, path)
+		}
+	}
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,7 +5,23 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
-None. Every entry in this register is resolved as of 2026-09-07.
+### D-039 — should `master` refuse a merge while CI is red? · raised 2026-09-09
+**Context** — #608 found `npm run build` broken on `master`. The gate that
+should have caught it was not missing: `frontend-typecheck` in `.github/
+workflows/ci.yml` **ran and failed** on PR #601's branch (run 34209169493 —
+Frontend Typecheck: failure, Build Frontend: skipped), and the PR was merged
+anyway. Six of that run's twelve jobs were red.
+**So the fix for #608 is not a new CI step.** The step exists and worked. What
+is missing is anything that makes a red run block a merge.
+**Options** — (A) branch protection on `master` requiring `CI Status` green;
+(B) required reviewers plus a manual rule; (C) leave it, and accept that the
+owner reads CI before merging.
+**Cost of delay** — this already cost one broken `master` and one P0. The next
+one is silent until someone tries to build.
+**Recommendation** — (A). It is a repository setting, it is reversible, and it
+costs nothing when CI is green. It needs the owner: an agent cannot change
+branch protection, and turning it on will block merges that are red today.
+
 
 ## Resolved
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Data export
   - name: Gamification
     description: Gamification and user profiles
+  - name: Saved Views
+    description: Named filter/sort/column views of a register (#580)
 
 paths:
   /health:
@@ -2345,6 +2347,145 @@ paths:
         '404': {description: An id did not resolve — absent, or another tenant's, deliberately indistinguishable. Nothing was modified.}
         '409': {description: The selection changed since it was previewed. Nothing was modified.}
 
+  # ==================== SAVED VIEWS (#580) ====================
+  # A saved view is a named filter/sort/column combination for one register.
+  # It grants no access to data: applying one still runs the register's own
+  # query under the caller's own permissions. Every route derives the tenant and
+  # the user from the signed session — never from the body or the query string.
+  /saved-views:
+    get:
+      tags:
+        - Saved Views
+      summary: List the saved views the caller may see
+      operationId: listSavedViews
+      description: >-
+        The caller's own views for a register, plus every view their tenant has
+        shared. A personal view belonging to another user is never returned, not
+        even to a tenant admin. Omitting `table_id` returns the views of every
+        register, which is what the one-time localStorage migration reads.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: table_id
+          in: query
+          required: false
+          description: >-
+            The register the views belong to — the same id the table is mounted
+            with ("risks", "vulnerabilities", "assets", …). Omit for all of them.
+          schema:
+            type: string
+            maxLength: 64
+      responses:
+        '200':
+          description: The views this caller may see, most recent first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SavedView'
+        '401':
+          description: Unauthorized
+    post:
+      tags:
+        - Saved Views
+      summary: Save a new view of a register
+      operationId: createSavedView
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSavedViewInput'
+      responses:
+        '201':
+          description: The view as stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedView'
+        '400':
+          description: >-
+            Invalid body, or a value outside its bounds — name over 120
+            characters, table_id over 64, more than 40 facets, more than 200
+            values in one facet, or more than 200 columns.
+        '401':
+          description: Unauthorized
+        '409':
+          description: This user already has a view of that name on that register.
+
+  /saved-views/{id}:
+    patch:
+      tags:
+        - Saved Views
+      summary: Rename, re-share or re-point a saved view
+      operationId: updateSavedView
+      description: >-
+        A patch: an absent field is left alone, so renaming a view cannot
+        silently reset its filters. Only the view's owner, or a tenant admin,
+        may change it.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSavedViewInput'
+      responses:
+        '200':
+          description: The view as stored after the patch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedView'
+        '400':
+          description: Invalid id, invalid body, or a value outside its bounds.
+        '401':
+          description: Unauthorized
+        '403':
+          description: The caller neither owns this view nor administers the tenant.
+        '404':
+          description: >-
+            No such view for this tenant. An id belonging to another tenant
+            answers identically, deliberately: a 403 would confirm it exists.
+        '409':
+          description: This user already has another view of that name on that register.
+    delete:
+      tags:
+        - Saved Views
+      summary: Delete a saved view
+      operationId: deleteSavedView
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Deleted. Soft-deleted server-side; it does not come back.
+        '400':
+          description: Invalid id.
+        '401':
+          description: Unauthorized
+        '403':
+          description: The caller neither owns this view nor administers the tenant.
+        '404':
+          description: No such view for this tenant.
+
 # ==================== COMPONENTS ====================
 components:
   securitySchemes:
@@ -4126,6 +4267,165 @@ components:
           description: >-
             Audit entries written. Below `applied` only if the trail was
             unavailable; the mutation still happened and the gap is reported.
+
+    # ========== SAVED VIEWS (#580) ==========
+    SavedViewVisibility:
+      type: string
+      enum: [personal, shared]
+      description: >-
+        `personal` — only its owner sees it. `shared` — every member of the same
+        tenant sees it. Sharing never crosses a tenant, and there is nothing in
+        between on purpose: a view shared with a named subset of people is a
+        permissions design, not a table feature.
+
+    SavedViewSort:
+      type: object
+      required: [key, dir]
+      properties:
+        key:
+          type: string
+          description: The column the view sorts on.
+        dir:
+          type: string
+          enum: [asc, desc]
+
+    SavedViewState:
+      type: object
+      description: >-
+        The part of the table state a view restores. Page and page size are
+        deliberately absent — "page 3" is not part of what a view means.
+      required: [q, filters, sort]
+      properties:
+        q:
+          type: string
+          description: The instant search term. Empty when the view carries none.
+        filters:
+          type: [object, 'null']
+          description: >-
+            Facet key → selected values. Null when the view carries no facet
+            selection at all. At most 40 facets, each with at most 200 values.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        sort:
+          oneOf:
+            - $ref: '#/components/schemas/SavedViewSort'
+            - type: 'null'
+          description: Null when the view does not pin a sort.
+
+    SavedViewColumns:
+      type: object
+      description: >-
+        The column layout the view restores. Keys the current build does not
+        know are dropped on read rather than rejected, so a view saved before a
+        column was removed still opens. At most 200 entries per list.
+      required: [order, hidden]
+      properties:
+        order:
+          type: [array, 'null']
+          items:
+            type: string
+        hidden:
+          type: [array, 'null']
+          items:
+            type: string
+
+    SavedView:
+      type: object
+      description: >-
+        One named view of one register, owned by one user inside one tenant.
+        Server-side since #580, so it survives a browser and can be handed to a
+        colleague. A usability capability, not a compliance control.
+      required:
+        - id
+        - tenant_id
+        - user_id
+        - table_id
+        - name
+        - visibility
+        - state
+        - columns
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenant_id:
+          type: string
+          format: uuid
+          description: The owning tenant. Every read of this resource filters on it.
+        user_id:
+          type: string
+          format: uuid
+          description: The owner — the only person who may edit it, plus tenant admins.
+        table_id:
+          type: string
+          maxLength: 64
+          description: >-
+            The register the view belongs to. A free string on purpose: the
+            eighth register does not need a migration.
+          example: risks
+        name:
+          type: string
+          maxLength: 120
+        visibility:
+          $ref: '#/components/schemas/SavedViewVisibility'
+        state:
+          $ref: '#/components/schemas/SavedViewState'
+        columns:
+          $ref: '#/components/schemas/SavedViewColumns'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        owner_email:
+          type: string
+          description: >-
+            Resolved on read for display ("shared by Amina"). Not a column, and
+            absent when the server could not resolve a name.
+
+    CreateSavedViewInput:
+      type: object
+      required: [table_id, name]
+      properties:
+        table_id:
+          type: string
+          maxLength: 64
+          example: risks
+        name:
+          type: string
+          maxLength: 120
+        visibility:
+          $ref: '#/components/schemas/SavedViewVisibility'
+          description: >-
+            Defaults to `personal` when omitted. Sharing is an explicit act: a
+            default of shared would publish one user's working view to their
+            whole institution.
+        state:
+          $ref: '#/components/schemas/SavedViewState'
+        columns:
+          $ref: '#/components/schemas/SavedViewColumns'
+
+    UpdateSavedViewInput:
+      type: object
+      description: >-
+        A patch. Every field is optional and an absent one is left untouched, so
+        renaming a view cannot silently reset its filters. A present `state` or
+        `columns` replaces the stored one whole.
+      properties:
+        name:
+          type: string
+          maxLength: 120
+        visibility:
+          $ref: '#/components/schemas/SavedViewVisibility'
+        state:
+          $ref: '#/components/schemas/SavedViewState'
+        columns:
+          $ref: '#/components/schemas/SavedViewColumns'
 
     ErrorResponse:
       type: object

--- a/frontend/src/types/openapi.generated.ts
+++ b/frontend/src/types/openapi.generated.ts
@@ -1439,6 +1439,48 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/saved-views": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the saved views the caller may see
+         * @description The caller's own views for a register, plus every view their tenant has shared. A personal view belonging to another user is never returned, not even to a tenant admin. Omitting `table_id` returns the views of every register, which is what the one-time localStorage migration reads.
+         */
+        get: operations["listSavedViews"];
+        put?: never;
+        /** Save a new view of a register */
+        post: operations["createSavedView"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/saved-views/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a saved view */
+        delete: operations["deleteSavedView"];
+        options?: never;
+        head?: never;
+        /**
+         * Rename, re-share or re-point a saved view
+         * @description A patch: an absent field is left alone, so renaming a view cannot silently reset its filters. Only the view's owner, or a tenant admin, may change it.
+         */
+        patch: operations["updateSavedView"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2564,6 +2606,79 @@ export interface components {
             ids?: string[];
             /** @description Audit entries written. Below `applied` only if the trail was unavailable; the mutation still happened and the gap is reported. */
             audited?: number;
+        };
+        /**
+         * @description `personal` — only its owner sees it. `shared` — every member of the same tenant sees it. Sharing never crosses a tenant, and there is nothing in between on purpose: a view shared with a named subset of people is a permissions design, not a table feature.
+         * @enum {string}
+         */
+        SavedViewVisibility: "personal" | "shared";
+        SavedViewSort: {
+            /** @description The column the view sorts on. */
+            key: string;
+            /** @enum {string} */
+            dir: "asc" | "desc";
+        };
+        /** @description The part of the table state a view restores. Page and page size are deliberately absent — "page 3" is not part of what a view means. */
+        SavedViewState: {
+            /** @description The instant search term. Empty when the view carries none. */
+            q: string;
+            /** @description Facet key → selected values. Null when the view carries no facet selection at all. At most 40 facets, each with at most 200 values. */
+            filters: {
+                [key: string]: string[];
+            } | null;
+            /** @description Null when the view does not pin a sort. */
+            sort: components["schemas"]["SavedViewSort"] | null;
+        };
+        /** @description The column layout the view restores. Keys the current build does not know are dropped on read rather than rejected, so a view saved before a column was removed still opens. At most 200 entries per list. */
+        SavedViewColumns: {
+            order: string[] | null;
+            hidden: string[] | null;
+        };
+        /** @description One named view of one register, owned by one user inside one tenant. Server-side since #580, so it survives a browser and can be handed to a colleague. A usability capability, not a compliance control. */
+        SavedView: {
+            /** Format: uuid */
+            id: string;
+            /**
+             * Format: uuid
+             * @description The owning tenant. Every read of this resource filters on it.
+             */
+            tenant_id: string;
+            /**
+             * Format: uuid
+             * @description The owner — the only person who may edit it, plus tenant admins.
+             */
+            user_id: string;
+            /**
+             * @description The register the view belongs to. A free string on purpose: the eighth register does not need a migration.
+             * @example risks
+             */
+            table_id: string;
+            name: string;
+            visibility: components["schemas"]["SavedViewVisibility"];
+            state: components["schemas"]["SavedViewState"];
+            columns: components["schemas"]["SavedViewColumns"];
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** @description Resolved on read for display ("shared by Amina"). Not a column, and absent when the server could not resolve a name. */
+            owner_email?: string;
+        };
+        CreateSavedViewInput: {
+            /** @example risks */
+            table_id: string;
+            name: string;
+            /** @description Defaults to `personal` when omitted. Sharing is an explicit act: a default of shared would publish one user's working view to their whole institution. */
+            visibility?: components["schemas"]["SavedViewVisibility"];
+            state?: components["schemas"]["SavedViewState"];
+            columns?: components["schemas"]["SavedViewColumns"];
+        };
+        /** @description A patch. Every field is optional and an absent one is left untouched, so renaming a view cannot silently reset its filters. A present `state` or `columns` replaces the stored one whole. */
+        UpdateSavedViewInput: {
+            name?: string;
+            visibility?: components["schemas"]["SavedViewVisibility"];
+            state?: components["schemas"]["SavedViewState"];
+            columns?: components["schemas"]["SavedViewColumns"];
         };
         ErrorResponse: {
             /** @example Invalid input */
@@ -5423,6 +5538,190 @@ export interface operations {
                 content?: never;
             };
             /** @description The selection changed since it was previewed. Nothing was modified. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listSavedViews: {
+        parameters: {
+            query?: {
+                /** @description The register the views belong to — the same id the table is mounted with ("risks", "vulnerabilities", "assets", …). Omit for all of them. */
+                table_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The views this caller may see, most recent first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    createSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSavedViewInput"];
+            };
+        };
+        responses: {
+            /** @description The view as stored */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            /** @description Invalid body, or a value outside its bounds — name over 120 characters, table_id over 64, more than 40 facets, more than 200 values in one facet, or more than 200 columns. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description This user already has a view of that name on that register. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted. Soft-deleted server-side; it does not come back. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid id. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The caller neither owns this view nor administers the tenant. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such view for this tenant. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateSavedView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSavedViewInput"];
+            };
+        };
+        responses: {
+            /** @description The view as stored after the patch */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SavedView"];
+                };
+            };
+            /** @description Invalid id, invalid body, or a value outside its bounds. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The caller neither owns this view nor administers the tenant. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No such view for this tenant. An id belonging to another tenant answers identically, deliberately: a 403 would confirm it exists. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description This user already has another view of that name on that register. */
             409: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Closes #608

## The break

`npm run build` failed on `master`. `savedViewService.ts` (merged by #580)
derives its types from the generated OpenAPI client:

```ts
export type SavedViewDTO = components['schemas']['SavedView'];
```

`docs/openapi.yaml` described no saved-views API at all — no schema, no path —
so `openapi-typescript` emitted no such type and `tsc -b` stopped the build
before `vite` ever ran. The backend was never the missing piece: the handler,
the domain entity and the four use cases all shipped in #580. Only the published
contract was skipped.

## The fix

- `docs/openapi.yaml` — `GET`/`POST /saved-views` and
  `PATCH`/`DELETE /saved-views/{id}`, plus `SavedView`, `SavedViewState`,
  `SavedViewSort`, `SavedViewColumns`, `SavedViewVisibility`,
  `CreateSavedViewInput`, `UpdateSavedViewInput`, written against
  `backend/internal/domain/saved_view.go` and
  `backend/internal/handler/saved_view_handler.go` field for field — including
  the nullable `sort`, `filters`, `order` and `hidden` that a nil Go map or
  slice actually marshals to.
- `frontend/src/types/openapi.generated.ts` — regenerated (+299 lines, nothing
  else changed).
- `backend/internal/handler/saved_view_contract_test.go` — the regression gate.

## Acceptance criteria

1 ✅ · 2 ✅ · 3 ✅ · 4 ✅ · 5 ⚠️ · 6 ✅ (as a finding, not a change) · 7 ✅

**5 — checked against the handler on the wire, not against a live server.**
No Docker daemon is available in this environment, so no live HTTP call was
possible. Instead of reading the handler's source — which proves nothing about
the bytes on the wire, since a `json:"-"`, an omitempty or a renamed tag changes
the response without changing the spec — the new test drives the **real handler
through a real Fiber app** and compares the JSON that comes back with what the
spec promises: every required property present, no undocumented property sent,
nested `state` and `columns` included, and the documented status codes. It also
asserts every registered verb is described. This is weaker than a live call in
one respect (no database, no auth middleware) and stronger in another (it runs
on every CI run, forever). **A live call against a running stack is still worth
doing before this is considered closed.**

**6 — the CI gate already exists and already fired.** `.github/workflows/ci.yml`
runs `frontend-typecheck` (`tsc -b --noEmit`) and `npm run build` on every PR.
On PR #601's branch that run was **red** — run `34209169493`: Frontend Typecheck
`failure`, Build Frontend `skipped`, 6 of 12 jobs failed — and the PR was merged
anyway. So no CI change is warranted; the gap is that nothing blocks a merge
over a red run. Raised as **D-039** in `docs/DECISIONS.md`: branch protection is
a repository setting an agent cannot change.

**7 — no other divergence.** Every `components['schemas'][…]` referenced under
`frontend/src` now resolves; 86 schemas, and `tsc` passing is the proof — an
absent one is exactly the error this issue was about.

## Verification

```
$ cd frontend && npm run build
✓ built in 4.26s                                    # exit 0

$ npx tsc -p tsconfig.app.json --noEmit
                                                    # exit 0, no output

$ npx vitest run
 Test Files  48 passed (48)
      Tests  536 passed (536)

$ cd backend && go build ./...                      # exit 0
$ go test ./internal/handler/ ./internal/application/savedview/
ok  github.com/opendefender/openrisk/internal/handler            15.121s
ok  github.com/opendefender/openrisk/internal/application/savedview  0.015s
```

The contract test was verified to fail on drift — adding one required field to
the spec that the handler does not send turns it red:

```
--- FAIL: TestSavedViewContract_ResponsesMatchOpenAPISpec
    SavedView: the spec marks "bogus_field" required, the handler did not send it
```

## Note

`gopkg.in/yaml.v3` moves from indirect to direct in `backend/go.mod` — it was
already in the module graph, nothing new is downloaded, `go.sum` is unchanged.

Found while verifying #315 (PR #604), which is blocked on this for its own
criterion 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
