### PR TITLE
fix(db): stop a healthy backend from logging 'record not found' as an error (#615)

### DIFF
--- a/backend/internal/infrastructure/database/database.go
+++ b/backend/internal/infrastructure/database/database.go
@@ -7,6 +7,7 @@ package database
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -17,6 +18,46 @@ import (
 )
 
 var DB *gorm.DB
+
+// gormLogger builds the SQL logger.
+//
+// Two things it fixes, both of which made a HEALTHY backend look broken (#615):
+//
+//   - IgnoreRecordNotFoundError. A "record not found" is not a database error,
+//     it is an answer: the report worker polling an empty queue
+//     (repository.ClaimQueued) gets one every interval and handles it correctly,
+//     but GORM logged it, with a file and line, before the application ever saw
+//     it. An operator watching `docker compose logs -f` after ./install.sh saw a
+//     continuous stream of errors from an idle system.
+//
+//   - The level. logger.Info logs EVERY statement with its parameter values.
+//     That buries anything real — one boot emits hundreds of pg_catalog lines —
+//     and puts user and tenant values into a log the operator may ship anywhere,
+//     which CLAUDE.md rule 6 does not want. Development keeps the full trace,
+//     because that is where you read SQL; production keeps warnings, slow
+//     queries and real errors.
+//
+// SlowThreshold is stated rather than left to GORM's implicit default, so the
+// number is a decision someone can argue with.
+func gormLogger() logger.Interface { return gormLoggerTo(os.Stdout) }
+
+// gormLoggerTo is gormLogger with the destination injected, so the behaviour
+// above can be asserted instead of described.
+func gormLoggerTo(w io.Writer) logger.Interface {
+	level := logger.Info
+	if os.Getenv("APP_ENV") == "production" {
+		level = logger.Warn
+	}
+	return logger.New(
+		log.New(w, "", log.LstdFlags),
+		logger.Config{
+			SlowThreshold:             200 * time.Millisecond,
+			LogLevel:                  level,
+			IgnoreRecordNotFoundError: true,
+			Colorful:                  false,
+		},
+	)
+}
 
 func Connect() {
 	// Build DSN from environment variables with sensible defaults
@@ -53,7 +94,7 @@ func Connect() {
 
 	var err error
 	DB, err = gorm.Open(postgres.Open(databaseURL), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
+		Logger: gormLogger(),
 		// TranslateError lets repositories detect constraint violations via
 		// sentinel errors (e.g. errors.Is(err, gorm.ErrDuplicatedKey))
 		// instead of parsing driver-specific error codes.

--- a/backend/internal/infrastructure/database/logger_test.go
+++ b/backend/internal/infrastructure/database/logger_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package database
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// trace drives the logger the way GORM does and returns what it wrote.
+func trace(t *testing.T, env string, err error) string {
+	t.Helper()
+	t.Setenv("APP_ENV", env)
+	var buf bytes.Buffer
+	l := gormLoggerTo(&buf)
+	l.Trace(context.Background(), time.Now(),
+		func() (string, int64) { return `SELECT * FROM "reports" WHERE run_state = 'queued'`, 0 },
+		err)
+	return buf.String()
+}
+
+// A "record not found" is an answer, not a failure. The report worker polls an
+// empty queue on an interval and handles it; before #615 GORM reported every one
+// of them AS AN ERROR, with a file and line, so an idle backend looked broken.
+//
+// What must never appear is the error. In development the statement itself is
+// still traced — that is what logger.Info is for, and it is not the complaint.
+func TestGormLogger_RecordNotFoundIsNeverAnError(t *testing.T) {
+	for _, env := range []string{"", "production"} {
+		out := trace(t, env, gorm.ErrRecordNotFound)
+		if strings.Contains(strings.ToLower(out), "record not found") {
+			t.Errorf("APP_ENV=%q: an empty queue must not be reported as an error, got:\n%s", env, out)
+		}
+	}
+}
+
+// In production it is not merely not-an-error: it is not logged at all, so
+// polling an idle queue writes nothing whatsoever.
+func TestGormLogger_ProductionIsSilentOnAnEmptyQueue(t *testing.T) {
+	if out := trace(t, "production", gorm.ErrRecordNotFound); out != "" {
+		t.Errorf("production must log nothing for an empty queue, got:\n%s", out)
+	}
+}
+
+// Production must not print every statement and its parameter values.
+func TestGormLogger_ProductionDoesNotTraceStatements(t *testing.T) {
+	if out := trace(t, "production", nil); out != "" {
+		t.Errorf("production must not log a successful query, got:\n%s", out)
+	}
+}
+
+// Development keeps the full trace — that is where SQL gets read.
+func TestGormLogger_DevelopmentTracesStatements(t *testing.T) {
+	out := trace(t, "", nil)
+	if !strings.Contains(out, "reports") {
+		t.Errorf("development must log the statement, got:\n%q", out)
+	}
+}
+
+// Quieter must not mean deaf: a real error still reaches the log in production.
+func TestGormLogger_ProductionStillLogsRealErrors(t *testing.T) {
+	out := trace(t, "production", errors.New("connection refused"))
+	if !strings.Contains(out, "connection refused") {
+		t.Errorf("a real database error must be logged in production, got:\n%q", out)
+	}
+}


### PR DESCRIPTION
Closes #615

## The complaint

A healthy backend reported failures continuously:

```
openrisk_backend | /app/internal/infrastructure/repository/gorm_report_repository.go:244 record not found
openrisk_backend | [1.048ms] [rows:0] SELECT * FROM "reports" WHERE run_state = 'queued' ORDER BY created_at ASC LIMIT 1
```

Nothing was wrong. That is the report worker polling an empty queue, and
`ClaimQueued` already handles it correctly — `errors.Is(err,
gorm.ErrRecordNotFound)` → `return nil, nil`. GORM's logger wrote the line, with
a file and line number, *before* the application ever saw the error. The dev
backend running on this machine had accumulated **13 282** of them.

## The fix

One config site, `backend/internal/infrastructure/database/database.go:56`,
which had two problems on the same line.

- **`IgnoreRecordNotFoundError: true`.** A "record not found" is an answer, not a
  database error; every caller already decides what it means.
- **The level.** It pinned `logger.Info`, which logs *every* statement with its
  parameter values, in production. That buries anything real — one boot emits
  hundreds of `pg_catalog` lines — and puts user and tenant values into a log the
  operator may ship anywhere, which CLAUDE.md rule 6 does not want. Development
  keeps the full trace, because that is where SQL gets read; `APP_ENV=production`
  keeps warnings, slow queries and real errors. `SlowThreshold` is now stated
  explicitly instead of relying on GORM's implicit default.

The destination is injectable (`gormLoggerTo`) so the behaviour is asserted
rather than described.

## Verification

Measured on the running stack — rebuilt the backend image, restarted, let the
worker poll an empty queue for ~45 s:

```
before:  docker logs openrisk_backend | grep -c "record not found"     → 13282
after:   docker logs --since 3m openrisk_backend | grep -c "record not found" →     0
         docker logs --since 3m openrisk_backend | grep -c "run_state = 'queued'" →    52
```

52 polls, zero fake errors: the worker still runs, it just stopped crying wolf.
(In development the statement is still traced — that is `logger.Info` doing its
job, and it was never the complaint. Under `APP_ENV=production` those 52 lines
go too.)

```
$ cd backend && go build ./...                                    # exit 0
$ go test -count=1 ./internal/infrastructure/database/ -run TestGormLogger -v
--- PASS: TestGormLogger_RecordNotFoundIsNeverAnError
--- PASS: TestGormLogger_ProductionIsSilentOnAnEmptyQueue
--- PASS: TestGormLogger_ProductionDoesNotTraceStatements
--- PASS: TestGormLogger_DevelopmentTracesStatements
--- PASS: TestGormLogger_ProductionStillLogsRealErrors
ok  github.com/opendefender/openrisk/internal/infrastructure/database  0.003s

$ go test -count=1 ./internal/infrastructure/repository/ -run 'Report|Claim'
ok  github.com/opendefender/openrisk/internal/infrastructure/repository  0.031s
```

The fourth test is the one that matters for trusting a quieter log: **quieter is
not deaf** — a real error still reaches the log under `APP_ENV=production`.

## Acceptance criteria

1 ✅ · 2 ✅ · 3 ✅ · 4 ✅ · 5 ✅ · 6 ⚠️ · 7 ✅

## Honest remainders

- **Criterion 6 cannot be claimed: `go test ./...` is red on master already**,
  for an unrelated reason. `TestBusinessRolesReferenceOnlyCatalogPermissions`
  fails because all eleven business role presets grant `events:read`, which is
  not a catalog permission. Reproduced on `origin/master` (`1a2fd14`) in a clean
  worktree, so it is neither this branch nor this change — filed as **#616**,
  and it is a real authorization defect, not just a red test. Every other package
  passes.
- This changes logging only. `ClaimQueued` returns the same values as before, and
  its tests are untouched and green.
- The dev backend on this machine now runs the rebuilt image, so the noise is
  already gone there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
