### PR TITLE
fix(rbac): add events:read to the permission catalog and gate the drift (#616)

### DIFF
--- a/backend/internal/domain/business_roles.go
+++ b/backend/internal/domain/business_roles.go
@@ -51,6 +51,13 @@ const (
 	// their invitations, the membership audit trail and the org profile.
 	PermGroupOrg PermissionGroup = "organization"
 
+	// PermGroupRealtime covers the server-sent event streams the UI subscribes
+	// to. It is a real gate: /api/v1/realtime/events is mounted behind
+	// RequirePermission("events:read") (main.go), and the mitigation stream
+	// validates the same token itself because native EventSource cannot send an
+	// Authorization header.
+	PermGroupRealtime PermissionGroup = "realtime"
+
 	// PermGroupGovernance covers the immutable audit trail and the approval
 	// machinery. Its routes are guarded by the admin ROLE today, so an admin
 	// already passes through "*"; the strings exist so an auditor or an internal
@@ -137,6 +144,11 @@ var PermissionCatalog = []PermissionDef{
 	{"organization:members:update", PermGroupOrg, "Modifier le rôle des membres", "Change member roles"},
 	{"organization:members:deactivate", PermGroupOrg, "Désactiver ou révoquer des membres", "Deactivate or revoke members"},
 	{"organization:audit:read", PermGroupOrg, "Consulter l'audit des accès", "Read membership audit"},
+	// Realtime. Every business role preset already grants this, and
+	// /api/v1/realtime/events already enforces it — the key was simply missing
+	// from the catalog, so ValidateBusinessRoles rejected all eleven presets and
+	// the RBAC matrix could not show a permission the API was really applying.
+	{"events:read", PermGroupRealtime, "Recevoir les événements temps réel", "Receive real-time events"},
 	// Governance. The entity drawer's audit tab (W1-02) gates on this: the
 	// timeline says what changed, the audit trail carries the before/after
 	// snapshot, the actor's IP and the request id, and those are not the same

--- a/backend/internal/domain/permission_catalog_sync_test.go
+++ b/backend/internal/domain/permission_catalog_sync_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// PermissionCatalog says of itself: "Keep it in sync with the
+// RequirePermission(...) call sites in main.go." Nothing checked that, and it
+// drifted: `events:read` guarded /api/v1/realtime/events while being absent from
+// the catalog, which made ValidateBusinessRoles reject ALL ELEVEN business role
+// presets and left the RBAC matrix unable to display a permission the API was
+// really enforcing (#616).
+//
+// This closes the direction that hurts: a route may not gate on a permission the
+// catalog does not know.
+//
+// The reverse is deliberately NOT asserted. Several catalog keys are gate-able
+// without being gated by RequirePermission today — the organization profile and
+// the audit trail are guarded by the admin ROLE, and the strings exist so a
+// scoped business role CAN be granted them. Requiring a call site for every key
+// would forbid that, which the catalog's own comments explicitly want to allow.
+// ---------------------------------------------------------------------------
+
+var requirePermissionCall = regexp.MustCompile(`RequirePermission\("([^"]+)"\)`)
+
+func TestPermissionCatalog_CoversEveryGuardedPermission(t *testing.T) {
+	main := filepath.Join("..", "..", "cmd", "server", "main.go")
+	src, err := os.ReadFile(main)
+	if err != nil {
+		t.Fatalf("cmd/server/main.go must be readable from the domain package: %v", err)
+	}
+
+	matches := requirePermissionCall.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatal("no RequirePermission(...) call found — this test has stopped testing anything")
+	}
+
+	missing := map[string]bool{}
+	for _, m := range matches {
+		key := m[1]
+		if key == PermissionAll { // the admin wildcard is not a catalog entry
+			continue
+		}
+		if !IsCatalogPermission(key) {
+			missing[key] = true
+		}
+	}
+
+	if len(missing) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(missing))
+	for k := range missing {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	t.Errorf(`these permissions guard a route but are absent from PermissionCatalog: %v
+
+A route gating on a key the catalog does not know has two consequences:
+  * ValidateBusinessRoles() rejects every preset that grants it, and
+  * the RBAC matrix cannot show it, so an administrator cannot see or grant a
+    permission the API is really enforcing.
+
+Add each one to PermissionCatalog with its group and its bilingual labels.`, keys)
+}


### PR DESCRIPTION
Closes #616

## The issue's own description was wrong, and that changes the fix

It said `events:read` is "a permission no route checks". It is checked:

```
backend/cmd/server/main.go:2768
    realtimeRead := middleware.RequirePermission("events:read")
backend/cmd/server/main.go:2771
    protected.Get("/realtime/events", realtimeRead, realtimeHandler.Stream)
```

The eleven presets were right. The **catalog** was out of date. So the fix adds
the key rather than removing it from the presets.

## What was broken

`go test ./internal/domain/` was red on master:
`TestBusinessRolesReferenceOnlyCatalogPermissions` rejected all eleven business
role presets, because each grants `events:read` and `PermissionCatalog` did not
contain it.

The catalog does two things, and both were broken by the gap:

- it validates the presets — so every preset was rejected;
- it feeds the RBAC matrix — so an administrator could **not see or grant a
  permission the API was really enforcing**. That is the user-visible defect.

## No authorization changed

`RequirePermission` checks the role's granted permissions, never the catalog.
Nobody gains or loses access. Criterion 4's per-persona impact table is therefore
empty *by construction* — that is the honest answer, not an omission.

## The audit (criterion 1)

Every `RequirePermission` call site in `main.go`, compared to the catalog:

```
guarded permissions: 51    catalog keys: 54

guarded but NOT in the catalog:   events:read      ← the only one
in the catalog, guarded by no RequirePermission:
    governance:audit:read, incidents:read, organization:read, organization:update
```

Those four are deliberate and stay: the organization profile and the audit trail
are guarded by the admin **role**, and the strings exist so a scoped business
role *can* be granted them without being handed the tenant. That is why the new
test asserts one direction only — demanding a call site for every key would
forbid exactly what the design wants.

## Criterion 5 — checked, nothing to change

`/api/v1/mitigations/events` is mounted on `app` rather than `protected`, but it
authenticates itself:

```
backend/internal/handler/mitigation_events_handler.go:41
    claims, err := authpkg.ValidateAccessToken(h.rsaKeys, c.Query("token"), h.blacklist)
    if err != nil || claims.TenantID == uuid.Nil { 401 }
```

Native `EventSource` cannot send an `Authorization` header, so the token arrives
as `?token=` and is validated in the handler, tenant included. The reason is
already written at the call site.

## Verification

```
$ cd backend && go build ./...                      # exit 0
$ go test -count=1 ./internal/domain/
ok  github.com/opendefender/openrisk/internal/domain  0.059s
$ gofmt -l internal/domain/business_roles.go internal/domain/permission_catalog_sync_test.go
(no output)
```

Both guards fail when the catalog entry is removed, rather than passing
vacuously:

```
--- FAIL: TestBusinessRolesReferenceOnlyCatalogPermissions
    [rssi:unknown_permission:events:read … viewer:unknown_permission:events:read]
--- FAIL: TestPermissionCatalog_CoversEveryGuardedPermission
```

`PermissionCatalog` says of itself *"Keep it in sync with the
RequirePermission(...) call sites in main.go"*. Nothing checked it, which is how
it drifted. `TestPermissionCatalog_CoversEveryGuardedPermission` now does.

## Honest remainders

`go test ./...` on this branch has two failures, neither from this change:

- **`TestSelfHostDoc_MatchesTheMatrix`** — `docs/SELF_HOSTING.md` lost its
  generated entitlements block in the merge of #610 (`562ad3f` resolved the
  conflict in favour of master's copy) while the test that requires it landed.
  **Master is red for this**, it is my regression from that PR, and it is being
  fixed in its own PR rather than smuggled into this one.
- **`TestRateLimit_TrustedProxyForwardedForIsHonoured`** — passes on its own
  (`ok … 0.026s`) and fails only under the parallel `./...` run. Pre-existing
  flake, unrelated; not investigated here.

Everything else passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
