### PR TITLE
feat(activation): version the Aha metric and add posture.revealed (#438, PR 1/4)

### DIFF
--- a/backend/internal/application/activation/activation_test.go
+++ b/backend/internal/application/activation/activation_test.go
@@ -10,8 +10,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 
 	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/monitoring"
 )
 
 // ---------------------------------------------------------------------------
@@ -307,6 +311,74 @@ func TestMaybeRecordAha_OncePerTenant(t *testing.T) {
 	if count != 1 {
 		t.Errorf("aha recorded %d times, want exactly 1", count)
 	}
+}
+
+// D-010's carried-forward defect, proved at the call site: the tenant is counted
+// when the Aha is recorded, even though no signup row exists to measure a
+// duration against. Before this change the increment lived inside
+// ObserveTimeToAha and this tenant vanished from the activation rate.
+func TestMaybeRecordAha_CountsATenantWithNoSignupAnchor(t *testing.T) {
+	repo := newFakeRepo()
+	tenant := uuid.New()
+	ctx := context.Background()
+
+	countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+	v1Before := ahaObservations(t, monitoring.AhaDefinitionV1)
+
+	NewAhaRecorder(repo).MaybeRecordAha(ctx, tenant, true, 3, 7)
+
+	if has, _ := repo.HasEvent(ctx, tenant, domain.ActivationAhaReached); !has {
+		t.Fatal("the aha event must be recorded with or without a signup anchor")
+	}
+	if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 1 {
+		t.Errorf("aha_reached_total moved by %v, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV1) - v1Before; got != 0 {
+		t.Errorf("a duration was observed with no signup anchor: +%d", got)
+	}
+}
+
+// The executive-dashboard Aha is the v1 definition and stays there: the Posture
+// Reveal will observe v2 from its own call site (D-010).
+func TestMaybeRecordAha_ObservesTheV1Definition(t *testing.T) {
+	repo := newFakeRepo()
+	tenant := uuid.New()
+	ctx := context.Background()
+	repo.events = append(repo.events, domain.ActivationEvent{
+		TenantID:   tenant,
+		EventKey:   domain.ActivationSignup,
+		OccurredAt: time.Now().UTC().Add(-6 * time.Minute),
+	})
+
+	v1Before := ahaObservations(t, monitoring.AhaDefinitionV1)
+	v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+
+	NewAhaRecorder(repo).MaybeRecordAha(ctx, tenant, true, 3, 7)
+
+	if got := ahaObservations(t, monitoring.AhaDefinitionV1) - v1Before; got != 1 {
+		t.Errorf("v1 gained %d observations, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 0 {
+		t.Errorf("the dashboard Aha leaked %d observations into v2, want 0", got)
+	}
+}
+
+// ahaObservations reads one aha_definition series of the time_to_aha histogram.
+func ahaObservations(t *testing.T, definition monitoring.AhaDefinition) uint64 {
+	t.Helper()
+	obs, err := monitoring.TimeToAha.GetMetricWithLabelValues(definition)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%q): %v", definition, err)
+	}
+	metric, ok := obs.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("observer for %q is not a prometheus.Metric", definition)
+	}
+	var out dto.Metric
+	if err := metric.Write(&out); err != nil {
+		t.Fatalf("writing metric for %q: %v", definition, err)
+	}
+	return out.GetHistogram().GetSampleCount()
 }
 
 func TestGetState_ReportsTimeToAha(t *testing.T) {

--- a/backend/internal/application/activation/aha.go
+++ b/backend/internal/application/activation/aha.go
@@ -92,14 +92,23 @@ func (a *AhaRecorder) MaybeRecordAha(ctx context.Context, tenantID uuid.UUID, sc
 		"compliance_gaps": complianceGaps,
 	})
 
-	// Observe signup → Aha. Without a signup anchor there is no honest duration,
-	// so we record the event but observe nothing rather than inventing a t0 that
-	// would flatter the histogram.
+	// Count the tenant here, not inside ObserveTimeToAha. A tenant with no signup
+	// anchor has still reached the Aha; counting it only alongside the duration
+	// dropped exactly those tenants from the activation rate (D-010).
+	monitoring.CountAhaReached()
+
+	// Observe signup → Aha under the v1 definition. Without a signup anchor there
+	// is no honest duration, so we record the event but observe nothing rather
+	// than inventing a t0 that would flatter the histogram.
+	//
+	// v1 is this definition and only this one. When the Posture Reveal ships it
+	// observes AhaDefinitionV2 from its own call site; the two series are never
+	// mixed, because the durations they measure are not comparable (D-010).
 	firsts, err := a.repo.FirstOccurrences(ctx, tenantID)
 	if err != nil {
 		return
 	}
 	if signup, ok := firsts[domain.ActivationSignup]; ok {
-		monitoring.ObserveTimeToAha(reachedAt.Sub(signup))
+		monitoring.ObserveTimeToAha(monitoring.AhaDefinitionV1, reachedAt.Sub(signup))
 	}
 }

--- a/backend/internal/domain/activation.go
+++ b/backend/internal/domain/activation.go
@@ -57,7 +57,31 @@ const (
 	// dashboard use case the first time a cyber score is computed on the tenant's
 	// OWN data while at least one compliance gap is identified.
 	ActivationAhaReached ActivationEventKey = "aha.reached"
+
+	// ActivationPostureRevealed is NOT a checklist step either: it is recorded
+	// server-side when the Posture Reveal renders a posture summary computed from
+	// the tenant's own rows (#438, D-011). It is the v2 Aha definition — the
+	// endpoint the time-to-value promise is measured against.
+	//
+	// Named `ActivationPostureRevealed` rather than D-011's `EventKeyPostureRevealed`
+	// so it reads like every other key in this block; the wire value
+	// "posture.revealed" is exactly what D-011 specified.
+	//
+	// Deliberately NOT added to activationSteps: it is a server-observed outcome,
+	// not a user chore, and putting it in the panel would show the user a row they
+	// cannot act on. ValidateNonChecklistEventKeys() is what keeps a later edit
+	// from quietly promoting it.
+	ActivationPostureRevealed ActivationEventKey = "posture.revealed"
 )
+
+// nonChecklistEventKeys are the event keys that must never be bound to a
+// checklist step: anchors (signup) and server-observed outcomes (aha.reached,
+// posture.revealed).
+var nonChecklistEventKeys = []ActivationEventKey{
+	ActivationSignup,
+	ActivationAhaReached,
+	ActivationPostureRevealed,
+}
 
 // ActivationEvent is one immutable occurrence. The table is append-only: the same
 // key may be recorded many times (a tenant creates many risks) and the read model
@@ -270,6 +294,39 @@ func ValidateActivationSteps() error {
 		}
 	}
 	return nil
+}
+
+// ValidateNonChecklistEventKeys is the sibling assertion to
+// ValidateActivationSteps (D-011). The two answer different questions and
+// neither implies the other:
+//
+//   - ValidateActivationSteps: every step in the catalogue maps to exactly one
+//     event key. It iterates the catalogue and is deliberately left untouched.
+//   - this one: no anchor or server-observed outcome has leaked INTO the
+//     catalogue. That is the direction a future edit breaks — someone adds a
+//     "see your posture" row to the checklist, binds it to posture.revealed, and
+//     the bijection still holds while the panel now shows a row the user cannot
+//     act on.
+//
+// Called by a test; cheap enough to call at boot if ever wanted.
+func ValidateNonChecklistEventKeys() error {
+	for _, key := range nonChecklistEventKeys {
+		for _, s := range activationSteps {
+			if s.EventKey == key {
+				return NewValidationError("activation step " + s.Key +
+					" is bound to the non-checklist event key " + string(key))
+			}
+		}
+	}
+	return nil
+}
+
+// NonChecklistEventKeys returns a copy of the keys that are recorded but never
+// shown as a checklist row.
+func NonChecklistEventKeys() []ActivationEventKey {
+	out := make([]ActivationEventKey, len(nonChecklistEventKeys))
+	copy(out, nonChecklistEventKeys)
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/domain/activation_test.go
+++ b/backend/internal/domain/activation_test.go
@@ -39,6 +39,63 @@ func TestActivationSteps_ExcludeNonStepEvents(t *testing.T) {
 	}
 }
 
+// D-011: the sibling assertion to ValidateActivationSteps. It answers the
+// opposite question — not "does every step own one key?" but "has a key that is
+// never a chore leaked into the catalogue?".
+func TestValidateNonChecklistEventKeys(t *testing.T) {
+	if err := ValidateNonChecklistEventKeys(); err != nil {
+		t.Fatalf("catalogue holds a non-checklist event key: %v", err)
+	}
+
+	// posture.revealed is the key #438 adds; the wire value is what the reveal
+	// and the E2E suite match on, so it is asserted literally.
+	if ActivationPostureRevealed != "posture.revealed" {
+		t.Errorf("posture event key = %q, want %q", ActivationPostureRevealed, "posture.revealed")
+	}
+
+	keys := NonChecklistEventKeys()
+	want := map[ActivationEventKey]bool{
+		ActivationSignup:          false,
+		ActivationAhaReached:      false,
+		ActivationPostureRevealed: false,
+	}
+	for _, k := range keys {
+		if _, known := want[k]; !known {
+			t.Errorf("unexpected non-checklist key %q", k)
+			continue
+		}
+		want[k] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("%q must be declared non-checklist", k)
+		}
+	}
+}
+
+// The failure the assertion exists to catch: a later edit adds a checklist row
+// bound to a server-observed outcome. ValidateActivationSteps stays happy — the
+// bijection still holds — and the panel shows a row nobody can act on.
+func TestValidateNonChecklistEventKeys_CatchesALeakedKey(t *testing.T) {
+	original := activationSteps
+	t.Cleanup(func() { activationSteps = original })
+
+	activationSteps = append(append([]ActivationStepDef{}, original...), ActivationStepDef{
+		Key:       "posture",
+		EventKey:  ActivationPostureRevealed,
+		LabelI18n: map[string]string{"fr": "Voyez votre posture", "en": "See your posture"},
+		DeepLink:  "/posture",
+		Order:     len(original) + 1,
+	})
+
+	if err := ValidateActivationSteps(); err != nil {
+		t.Fatalf("precondition: the bijection must still hold, got %v", err)
+	}
+	if err := ValidateNonChecklistEventKeys(); err == nil {
+		t.Error("a checklist step bound to posture.revealed must be rejected")
+	}
+}
+
 // ActivationSteps hands out a copy: a caller mutating the result must not be able
 // to corrupt the catalog for everyone else.
 func TestActivationSteps_ReturnsCopy(t *testing.T) {

--- a/backend/pkg/monitoring/activation.go
+++ b/backend/pkg/monitoring/activation.go
@@ -24,14 +24,39 @@ import (
 // P50 > 12 min). The buckets below are chosen around that threshold so the
 // quantile is interpolated inside a narrow bucket rather than across a 10-minute
 // gap: a histogram whose bucket edges straddle the SLO cannot measure the SLO.
+// AhaDefinition is the value of the `aha_definition` label carried by
+// openrisk_time_to_aha_seconds. It exists because the product moved the Aha
+// moment (D-010): the two definitions measure different journeys and their
+// durations are NOT comparable, so splicing them into one series would make the
+// P50 behind SlowTimeToAha lie on the day of the switch.
+//
+// Rule: never add an observation to a definition that is frozen, and never
+// reuse a value for a third definition. A new definition gets a new value.
+type AhaDefinition = string
+
+const (
+	// AhaDefinitionV1 is the executive-dashboard definition: the first cyber
+	// score computed on the tenant's own data while at least one compliance gap
+	// is identified (internal/application/activation/aha.go). It FREEZES when
+	// the Posture Reveal ships — v1 observations stop, the recorded history
+	// stays queryable.
+	AhaDefinitionV1 AhaDefinition = "v1"
+
+	// AhaDefinitionV2 is the Posture Reveal definition: the posture summary
+	// computed and shown to the user (`posture.revealed`). It starts empty; a
+	// histogram with no observations has no quantile, so SlowTimeToAha simply
+	// does not fire until the first tenant reaches it.
+	AhaDefinitionV2 AhaDefinition = "v2"
+)
+
 var (
-	// TimeToAha measures signup → first Aha, in seconds. "Aha" is defined by the
-	// product, not by this package: the first cyber score computed on the
-	// tenant's OWN data while at least one compliance gap is identified.
-	TimeToAha = promauto.NewHistogram(prometheus.HistogramOpts{
+	// TimeToAha measures signup → first Aha, in seconds, PER DEFINITION. "Aha" is
+	// defined by the product, not by this package; see AhaDefinition for why the
+	// label is not optional.
+	TimeToAha = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "openrisk",
 		Name:      "time_to_aha_seconds",
-		Help:      "Seconds between signup and the first Aha moment (first cyber score on the tenant's own data with at least one compliance gap identified).",
+		Help:      "Seconds between signup and the first Aha moment, by Aha definition (v1: first cyber score on the tenant's own data with a compliance gap; v2: posture reveal).",
 		Buckets: []float64{
 			60,    // 1 min
 			120,   // 2 min
@@ -46,7 +71,7 @@ var (
 			21600, // 6 h
 			86400, // 1 day: came back another day to find value
 		},
-	})
+	}, []string{"aha_definition"})
 
 	// ActivationEventsTotal counts activation signals by key. Labelled by key
 	// only — never by tenant: tenant labels are unbounded cardinality, and the
@@ -60,6 +85,17 @@ var (
 
 	// AhaReachedTotal counts tenants that reached the Aha moment. The ratio to
 	// signups is the activation rate.
+	//
+	// Counted by CountAhaReached, which is deliberately NOT called from
+	// ObserveTimeToAha: a tenant with no signup anchor has no honest duration to
+	// observe but has still reached the Aha, and burying the increment inside the
+	// observation dropped exactly those tenants from the numerator of the
+	// activation rate (D-010).
+	//
+	// Left UNLABELLED on purpose while the histogram gains one: this counter is
+	// the numerator of NoActivationDespiteSignups, and a CounterVec has no series
+	// at all until its first increment, which would leave that alert with an
+	// empty right-hand side and silently stop it firing.
 	AhaReachedTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "openrisk",
 		Name:      "aha_reached_total",
@@ -67,14 +103,24 @@ var (
 	})
 )
 
-// ObserveTimeToAha records one signup → Aha duration. A non-positive duration is
-// dropped: a clock skew or a missing signup anchor would otherwise report an
-// impossibly fast activation and quietly flatter the P50 the alert watches.
-func ObserveTimeToAha(d time.Duration) {
-	if d <= 0 {
+// ObserveTimeToAha records one signup → Aha duration under the given definition.
+// A non-positive duration is dropped: a clock skew or a missing signup anchor
+// would otherwise report an impossibly fast activation and quietly flatter the
+// P50 the alert watches. An empty definition is dropped too — an unlabelled
+// observation would silently create a third series nothing queries.
+//
+// It does NOT count the tenant: see AhaReachedTotal and CountAhaReached.
+func ObserveTimeToAha(definition AhaDefinition, d time.Duration) {
+	if definition == "" || d <= 0 {
 		return
 	}
-	TimeToAha.Observe(d.Seconds())
+	TimeToAha.WithLabelValues(definition).Observe(d.Seconds())
+}
+
+// CountAhaReached counts one tenant reaching the Aha moment. Called at the
+// moment the event is recorded, whether or not a signup anchor exists to measure
+// a duration against.
+func CountAhaReached() {
 	AhaReachedTotal.Inc()
 }
 

--- a/backend/pkg/monitoring/activation_test.go
+++ b/backend/pkg/monitoring/activation_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// ahaSampleCount reads the number of observations recorded on one
+// aha_definition series. testutil.ToFloat64 only handles counters and gauges, so
+// the histogram is read through the dto the collector writes.
+func ahaSampleCount(t *testing.T, definition AhaDefinition) uint64 {
+	t.Helper()
+	obs, err := TimeToAha.GetMetricWithLabelValues(definition)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%q): %v", definition, err)
+	}
+	metric, ok := obs.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("observer for %q is not a prometheus.Metric", definition)
+	}
+	var out dto.Metric
+	if err := metric.Write(&out); err != nil {
+		t.Fatalf("writing metric for %q: %v", definition, err)
+	}
+	return out.GetHistogram().GetSampleCount()
+}
+
+// D-010: the two definitions measure different journeys. An observation under
+// one must never land in the other's series, because SlowTimeToAha reads the
+// quantile of v2 alone.
+func TestObserveTimeToAha_SeriesAreSeparatePerDefinition(t *testing.T) {
+	v1Before := ahaSampleCount(t, AhaDefinitionV1)
+	v2Before := ahaSampleCount(t, AhaDefinitionV2)
+
+	ObserveTimeToAha(AhaDefinitionV1, 7*time.Minute)
+
+	if got := ahaSampleCount(t, AhaDefinitionV1) - v1Before; got != 1 {
+		t.Errorf("v1 gained %d observations, want 1", got)
+	}
+	if got := ahaSampleCount(t, AhaDefinitionV2) - v2Before; got != 0 {
+		t.Errorf("v2 gained %d observations from a v1 call, want 0", got)
+	}
+
+	ObserveTimeToAha(AhaDefinitionV2, 4*time.Minute)
+	if got := ahaSampleCount(t, AhaDefinitionV2) - v2Before; got != 1 {
+		t.Errorf("v2 gained %d observations, want 1", got)
+	}
+	if got := ahaSampleCount(t, AhaDefinitionV1) - v1Before; got != 1 {
+		t.Errorf("v1 moved to %d observations after a v2 call, want it left at 1", got)
+	}
+}
+
+// A missing signup anchor or a skewed clock must not flatter the P50, and an
+// unlabelled observation must not create a third series nothing queries.
+func TestObserveTimeToAha_DropsDishonestObservations(t *testing.T) {
+	before := ahaSampleCount(t, AhaDefinitionV1)
+
+	ObserveTimeToAha(AhaDefinitionV1, 0)
+	ObserveTimeToAha(AhaDefinitionV1, -3*time.Minute)
+	ObserveTimeToAha("", 5*time.Minute)
+
+	if got := ahaSampleCount(t, AhaDefinitionV1) - before; got != 0 {
+		t.Errorf("dropped observations still landed: +%d", got)
+	}
+	if n := testutil.CollectAndCount(TimeToAha); n > 2 {
+		t.Errorf("time_to_aha_seconds has %d series; only v1 and v2 may exist", n)
+	}
+}
+
+// The defect D-010 tells this work not to inherit: the increment used to live
+// inside ObserveTimeToAha, so a tenant with no signup anchor reached the Aha
+// without ever being counted.
+func TestCountAhaReached_IsIndependentOfTheObservation(t *testing.T) {
+	before := testutil.ToFloat64(AhaReachedTotal)
+
+	CountAhaReached()
+	if got := testutil.ToFloat64(AhaReachedTotal) - before; got != 1 {
+		t.Fatalf("CountAhaReached() moved the counter by %v, want 1", got)
+	}
+
+	ObserveTimeToAha(AhaDefinitionV1, 6*time.Minute)
+	if got := testutil.ToFloat64(AhaReachedTotal) - before; got != 1 {
+		t.Errorf("observing a duration moved the counter by %v; it must count nothing", got)
+	}
+}

--- a/deployment/monitoring/alerts.yml
+++ b/deployment/monitoring/alerts.yml
@@ -192,8 +192,15 @@ groups:
       # compliance gap identified). The alert fires at 12 minutes so there is
       # headroom between the target and the page — an alert set at the target
       # fires on every ordinary bad day and gets muted.
+      #
+      # The `aha_definition="v2"` selector is not optional (D-010). The Aha moved
+      # from the executive-dashboard score computation (v1) to the Posture Reveal
+      # (v2); the two measure different journeys, so a quantile over both would
+      # step at the switch for a reason that has nothing to do with the product
+      # getting slower. v2 starts empty — a histogram with no observations has no
+      # quantile, so this alert is simply silent until the first reveal lands.
       - alert: SlowTimeToAha
-        expr: histogram_quantile(0.5, sum(rate(openrisk_time_to_aha_seconds_bucket[6h])) by (le)) > 720
+        expr: histogram_quantile(0.5, sum(rate(openrisk_time_to_aha_seconds_bucket{aha_definition="v2"}[6h])) by (le)) > 720
         for: 30m
         labels:
           severity: warning

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -128,6 +128,56 @@ Système de **rôles métiers** par-dessus le RBAC runtime existant. **Additionn
 - **Audit des boutons morts** : `docs/ui/dead-controls.md` recense **13 contrôles morts en production** (traités) + 4 dans du code inatteignable (fichiers supprimés) + 5 laissés avec leur raison. Notamment : point vert « Realtime » → **vrai indicateur de connexion** (`lib/connection.ts`, alimenté par les événements online/offline **et** l'issue de chaque appel axios ; un 4xx n'est pas une panne) · **micro supprimé** · « Voir toutes les notifications » **supprimé** (il ne faisait que fermer le panneau) · **« Supprimer l'organisation » implémenté** (c'était un `<button>` sans `onClick` — `DELETE /rbac/tenants/:id` + radiographie d'impact + logout) · Actualiser / Synchroniser / Matcher → états en vol visibles · funnel de l'Asset Universe → **vrai filtre par criticité** (masque aussi les arêtes pendantes).
 - **Tests** : `frontend/src/shared/datatable/__tests__/DataTable.test.tsx` (**25 tests, verts**) pour toute la logique pure ; `tests/e2e/datatable.spec.ts` + `tests/e2e/dead-controls.spec.ts` (**68 cas** listés par Playwright) pour les effets observables, dont l'obligatoire *« menu de la dernière ligne d'une table de 200 items entièrement visible »*. **Restes honnêtes — apurés le 2026-09-08 (#583)** : la chaîne Go est passée (`go build ./...` et `go vet ./...`, sortie 0, Go 1.25.12) et les E2E ont été **exécutés** contre un backend + frontend réels. Le compte de « 68 cas » était un compte de fichiers : la suite complète fait **270 cas** (chromium + Mobile Chrome) et sort à **197 passés · 62 échoués · 11 skippés · 0 flaky**. Le cas obligatoire — *menu de la dernière ligne d'une table de 200 items entièrement visible* — **passe** sur les deux projets, ainsi que les 25 tests unitaires `DataTable` (vérifiés : 25/25, dans une suite front de 516 tests tous verts). Les 62 échecs sont déposés en issues #587 → #596 ; ils ne sont **pas** corrigés ici. Reste ouvert : la suite n'a jamais tourné en CI — le job `E2E Tests` meurt au démarrage du backend faute de clé RSA (#587) — et 31 des 62 échecs sont le throttle d'authentification du produit lui-même (#588). Tant que ces deux-là tiennent, un E2E rouge ne se lit pas comme « le produit est cassé ».
 
+## Posture Reveal W1-05 (#438) — PR 1/4 : la métrique Aha devient versionnée, `posture.revealed` entre dans le vocabulaire
+
+**Problème** — #438 déplace le moment Aha du calcul de score du tableau de bord
+exécutif vers le Posture Reveal. Les deux mesurent des parcours différents : leurs
+durées ne sont **pas comparables**, et les additionner dans une seule série ferait
+marcher un échelon dans le P50 de `SlowTimeToAha` le jour de la bascule, pour une
+raison qui n'a rien à voir avec un ralentissement du produit. Cette PR pose la
+plomberie ; elle ne construit ni le tunnel ni le reveal.
+
+- **D-010 — `openrisk_time_to_aha_seconds` gagne un label `aha_definition`**
+  (`backend/pkg/monitoring/activation.go`). `TimeToAha` passe de `Histogram` à
+  `HistogramVec{aha_definition}` ; `AhaDefinitionV1` = définition tableau de bord
+  exécutif (le site d'appel actuel, `internal/application/activation/aha.go`),
+  `AhaDefinitionV2` = Posture Reveal, vide jusqu'à la PR 3. `ObserveTimeToAha`
+  exige désormais la définition et rejette la chaîne vide : une observation non
+  étiquetée créerait en silence une troisième série que rien n'interroge.
+  `SlowTimeToAha` (`deployment/monitoring/alerts.yml`) sélectionne
+  `aha_definition="v2"` — un histogramme sans observation n'a pas de quantile,
+  donc l'alerte est muette et non menteuse jusqu'au premier reveal.
+- **Le défaut que D-010 interdit d'hériter est corrigé** : `AhaReachedTotal.Inc()`
+  vivait *à l'intérieur* de `ObserveTimeToAha`, si bien qu'un tenant sans ancre
+  `signup` atteignait l'Aha **sans jamais être compté** — précisément les tenants
+  amorcés par le backfill #234. Le comptage sort dans `CountAhaReached()`, appelé
+  au moment où l'événement est enregistré, avec ou sans durée honnête à observer.
+  Le compteur reste **non étiqueté** volontairement : il est le numérateur de
+  `NoActivationDespiteSignups`, et un `CounterVec` n'a aucune série tant qu'il n'a
+  pas été incrémenté, ce qui aurait laissé cette alerte avec un membre droit vide.
+- **D-011 — `posture.revealed` est une clé hors catalogue**
+  (`backend/internal/domain/activation.go`). `ActivationPostureRevealed` est
+  ajoutée, `ValidateActivationSteps()` est laissée **intacte** (elle itère
+  `activationSteps` et n'avait besoin d'aucun amendement), et une sœur
+  `ValidateNonChecklistEventKeys()` assure la direction inverse : aucune ancre ni
+  aucun résultat observé côté serveur (`signup`, `aha.reached`, `posture.revealed`)
+  n'a fui **dans** le catalogue. C'est la direction qu'une édition future casse —
+  quelqu'un ajoute une ligne « voyez votre posture » à la checklist, la bijection
+  tient toujours, et le panneau affiche une ligne sur laquelle l'utilisateur ne
+  peut pas agir. Le test négatif prouve exactement ce scénario.
+- **Nommage** — D-011 écrivait `EventKeyPostureRevealed` ; le symbole est
+  `ActivationPostureRevealed` pour suivre le préfixe `Activation*` des huit autres
+  clés du même bloc. La valeur sur le fil, `"posture.revealed"`, est bien celle que
+  D-011 fixe, et un test l'assère littéralement.
+
+**Ce qui n'est PAS fait dans cette PR** — le tunnel bloquant à cinq étapes, la
+route `/posture`, `/onboarding/recognition`, le catalogue de risques de démarrage,
+`SourceStarter` (D-012), le score résiduel et son ADR (D-013), la mise à jour de
+`ROADMAP.md` 17.6 et la ligne de `docs/MARKETING_CLAIM_MATRIX.md` citant
+`posture.revealed`. Rien de tout cela n'est vrai tant que le reveal n'existe pas,
+et la RÈGLE #12 interdit de le documenter avant. PR 2 → 4 de #438.
+
+
 ## Onboarding W1-04 (#234) — la checklist dit enfin la vérité aux tenants déjà configurés
 
 **Problème** — le journal d'événements d'activation est **en avant seulement** : une


### PR DESCRIPTION
Part of #438 — **PR 1 of 4**. Plumbing only: no tunnel, no reveal, no new route, no new
endpoint. It executes the two owner decisions that gate every later PR.

Does **not** close #438. The sequence recorded on the issue is
ADR for D-013 → **PR 1 (D-010, D-011)** → PR 2 (D-012, D-013) → PR 3 → PR 4.

## What changed

**D-010 — `openrisk_time_to_aha_seconds` gains an `aha_definition` label.**
`monitoring.TimeToAha` becomes a `HistogramVec`. `AhaDefinitionV1` is the
executive-dashboard definition (the existing call site in
`backend/internal/application/activation/aha.go`); `AhaDefinitionV2` is the Posture Reveal
and starts empty until PR 3 gives it a call site. `ObserveTimeToAha` now requires the
definition and drops an empty one — an unlabelled observation would silently create a third
series nothing queries. `SlowTimeToAha` in `deployment/monitoring/alerts.yml` selects
`aha_definition="v2"`: an empty histogram has no quantile, so the alert is silent rather than
lying until the first reveal lands.

Per D-010's own warning, the framing "`first_risk` → `posture.revealed`" from the #438 brief
was **not** copied into code or comments. The real switch is executive-dashboard score
computation → posture-summary computation, and that is how every new comment words it.

**The defect D-010 says this work must not inherit is fixed at the source.**
`AhaReachedTotal.Inc()` sat *inside* `ObserveTimeToAha`, so a tenant with no `signup` anchor
reached the Aha without ever being counted — precisely the tenants #234 backfilled. Counting
moves out into `CountAhaReached()`, called when the event is recorded, with or without an
honest duration to observe. The counter stays **unlabelled** on purpose: it is the numerator
of `NoActivationDespiteSignups`, and a `CounterVec` has no series at all until its first
increment, which would have left that alert with an empty right-hand side.

**D-011 — `posture.revealed` is a non-catalogue key.**
`ActivationPostureRevealed` is added to `backend/internal/domain/activation.go`.
`ValidateActivationSteps()` is left **untouched**, as D-011 specifies — it iterates
`activationSteps` only and needed no amendment. The new sibling
`ValidateNonChecklistEventKeys()` asserts the opposite direction: no anchor
(`signup`) and no server-observed outcome (`aha.reached`, `posture.revealed`) has leaked
**into** the catalogue. That is the direction a future edit breaks — someone adds a "see your
posture" row, binds it to `posture.revealed`, the bijection still holds, and the panel shows a
row the user cannot act on. `TestValidateNonChecklistEventKeys_CatchesALeakedKey` builds
exactly that catalogue and proves the old validator stays happy while the new one rejects it.

**One deliberate deviation, disclosed.** D-011 names the symbol `EventKeyPostureRevealed`; it
ships as `ActivationPostureRevealed` so it reads like the eight other keys in the same `const`
block. The wire value, `"posture.revealed"`, is exactly what D-011 fixed, and a test asserts
it literally.

## Verification

```
$ go build ./...
(no output — success)

$ go vet ./internal/domain/ ./internal/application/activation/ ./pkg/monitoring/
(no output — success)

$ go test ./pkg/monitoring/ -run Aha -v
=== RUN   TestObserveTimeToAha_SeriesAreSeparatePerDefinition
--- PASS: TestObserveTimeToAha_SeriesAreSeparatePerDefinition (0.00s)
=== RUN   TestObserveTimeToAha_DropsDishonestObservations
--- PASS: TestObserveTimeToAha_DropsDishonestObservations (0.00s)
=== RUN   TestCountAhaReached_IsIndependentOfTheObservation
--- PASS: TestCountAhaReached_IsIndependentOfTheObservation (0.00s)
PASS
ok      github.com/opendefender/openrisk/pkg/monitoring  0.004s

$ go test ./internal/domain/ -run 'Activation|NonChecklist' -v
=== RUN   TestActivationSteps_OneEventKeyPerStep
--- PASS: TestActivationSteps_OneEventKeyPerStep (0.00s)
=== RUN   TestActivationSteps_ExcludeNonStepEvents
--- PASS: TestActivationSteps_ExcludeNonStepEvents (0.00s)
=== RUN   TestValidateNonChecklistEventKeys
--- PASS: TestValidateNonChecklistEventKeys (0.00s)
=== RUN   TestValidateNonChecklistEventKeys_CatchesALeakedKey
--- PASS: TestValidateNonChecklistEventKeys_CatchesALeakedKey (0.00s)
=== RUN   TestActivationSteps_ReturnsCopy
--- PASS: TestActivationSteps_ReturnsCopy (0.00s)
PASS
ok      github.com/opendefender/openrisk/internal/domain 0.016s

$ go test ./internal/application/activation/ -run Aha -v
=== RUN   TestAhaSignal_Definition
--- PASS: TestAhaSignal_Definition (0.00s)
=== RUN   TestMaybeRecordAha_OncePerTenant
--- PASS: TestMaybeRecordAha_OncePerTenant (0.00s)
=== RUN   TestMaybeRecordAha_CountsATenantWithNoSignupAnchor
--- PASS: TestMaybeRecordAha_CountsATenantWithNoSignupAnchor (0.00s)
=== RUN   TestMaybeRecordAha_ObservesTheV1Definition
--- PASS: TestMaybeRecordAha_ObservesTheV1Definition (0.00s)
=== RUN   TestGetState_ReportsTimeToAha
--- PASS: TestGetState_ReportsTimeToAha (0.00s)
PASS
ok      github.com/opendefender/openrisk/internal/application/activation 0.019s

$ go test ./internal/application/activation/ ./pkg/monitoring/
ok      github.com/opendefender/openrisk/internal/application/activation 0.022s
ok      github.com/opendefender/openrisk/pkg/monitoring  0.004s
```

`go test ./internal/domain/` as a whole package is **RED**, and was red before this branch was
cut. Proved by stashing this branch's changes and re-running on the base commit:

```
$ git stash -u && go test ./internal/domain/ -run TestBusinessRolesReferenceOnlyCatalogPermissions
--- FAIL: TestBusinessRolesReferenceOnlyCatalogPermissions (0.00s)
    business_roles_test.go:14: business role presets reference invalid permissions or lack a
    landing: [rssi:unknown_permission:events:read dsi:unknown_permission:events:read ...]
FAIL
```

Already tracked by #616, #576 and #416. Not touched here.

Alert file: `promtool` is not installed in this environment, so `promtool check rules` could
not be run. `deployment/monitoring/alerts.yml` was validated as YAML instead (2 groups, 29
rules parse). **This is a gap, not a pass** — see remainders.

## Security review

No new DB query, no new endpoint, no new handler, no auth or crypto surface, no secret in any
log line. The one thing worth naming is metric cardinality: `aha_definition` is bounded to two
literal values and `ObserveTimeToAha` rejects an empty label, so the label cannot be driven by
user input.

## Honest remainders

- **Not done in this PR, by design:** the blocking five-step tunnel, `/posture`,
  `/onboarding/recognition`, the starter-risk catalogue, `SourceStarter` (D-012), the residual
  score and its ADR (D-013), the `ROADMAP.md` 17.6 update and the
  `docs/MARKETING_CLAIM_MATRIX.md` row citing `posture.revealed`. None of that is true yet and
  RULE #12 forbids documenting it before it exists. PRs 2 → 4.
- **`promtool` was not run.** The alert expression change is unverified by a rules linter. CI
  should gate this; #621 asks for exactly that.
- **`ValidateNonChecklistEventKeys()` is called by a test, not at boot** — the same choice
  `ValidateActivationSteps()` already made. A catalogue edit is caught in CI, not at runtime.
- **No `TestXxx_Success`/`_NotFound`/`_Unauthorized` trio here.** ABSOLUTE RULE #4 is scoped to
  use cases; this PR adds none. It lands with PR 2's first use case.
- **Found and filed, not fixed: #621.** `NoActivationDespiteSignups` can never fire — its two
  sides have mismatched label sets, so PromQL's `and` finds no match. Pre-existing, unrelated
  to the `aha_definition` label, and it matters more after this PR because v2 is empty until
  PR 3 and this alert is the only backstop in that window.
- **`internal/domain` is red on master** (#616). This PR does not fix it and does not depend
  on it.
