### PR TITLE
feat(scoring): residual from control coverage, starter catalogue, source=starter (#438, PR 2/4)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2859,15 +2859,24 @@ func main() {
 	// The only writes are (a) acknowledging that a celebration was shown, and
 	// (b) the wizard's own answers.
 	// =========================================================================
+	// The Posture Reveal's read side (#438). Every query it runs filters on
+	// tenant_id — criterion 10 — and the compile-time assertions in
+	// gorm_posture_repository.go are what keep its three ports honest.
+	postureRepo := repository.NewGormPostureRepository(database.DB)
 	onboardingUC := appactivation.NewOnboardingUseCase(activationRepo, activationRecorder).
 		WithOrgUpdater(orgRepo).
 		WithOrgCurrencyUpdater(orgRepo).
-		WithProfileUpdater(userRepo)
+		WithProfileUpdater(userRepo).
+		// Auto-skip (criteria 2 and 3): GET /onboarding/state resolves the whole
+		// tunnel in one call, skipped steps included.
+		WithStepProbe(postureRepo)
 	activationHandler := handlers.NewActivationHandler(
 		appactivation.NewGetStateUseCase(activationRepo),
 		appactivation.NewMarkCelebratedUseCase(activationRepo),
 		onboardingUC,
-	)
+	).
+		WithPosture(appactivation.NewPostureUseCase(postureRepo, activationRepo, activationRecorder)).
+		WithRecognition(appactivation.NewRecognitionUseCase(postureRepo))
 	// Readable by any authenticated member: the get-started panel is not a
 	// privileged view, and gating it behind a permission would hide the product's
 	// own instructions from exactly the people who need them most.
@@ -2882,7 +2891,13 @@ func main() {
 	protected.Get("/onboarding/state", activationHandler.GetOnboardingState)
 	protected.Get("/onboarding/suggestions", activationHandler.GetOnboardingSuggestions)
 	protected.Post("/onboarding/complete", activationHandler.CompleteOnboarding)
+	protected.Get("/onboarding/recognition", activationHandler.GetRecognition)
 	protected.Put("/onboarding/steps/:step", activationHandler.SaveOnboardingStep)
+
+	// The Posture Reveal (#438). Outside the /onboarding group on purpose: it is
+	// a product surface a user returns to, not a step of a wizard they complete
+	// once. A 404 here is criterion 8's explicit error state, not a bug.
+	protected.Get("/posture", activationHandler.GetPosture)
 
 	// The periodic sync worker (NVD 1h / CISA 6h + post-sync matching) runs in
 	// production. In dev it stays off by default to avoid hitting the feeds on every

--- a/backend/internal/application/activation/autoskip_test.go
+++ b/backend/internal/application/activation/autoskip_test.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// fakeProbe counts its calls: criterion 2 allows exactly ONE resolution per
+// GET /onboarding/state, and a probe that were called per step would be the
+// per-step status call the criterion forbids.
+type fakeProbe struct {
+	data  domain.OnboardingStepData
+	calls int
+	fail  bool
+}
+
+func (p *fakeProbe) OnboardingStepData(_ context.Context, _, _ uuid.UUID) (domain.OnboardingStepData, error) {
+	p.calls++
+	if p.fail {
+		return domain.OnboardingStepData{}, errors.New("probe down")
+	}
+	return p.data, nil
+}
+
+// Criterion 3: a step whose data exists is absent from the stepper count shown
+// to that user.
+func TestWizard_AutoSkippedStepsAreAbsentFromTheStepper(t *testing.T) {
+	repo := newFakeRepo()
+	probe := &fakeProbe{data: domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasFramework:           true,
+	}}
+	uc := newWizard(repo).WithStepProbe(probe)
+	tenant, user := uuid.New(), uuid.New()
+
+	state, err := uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+
+	if len(state.Steps) != 3 {
+		t.Errorf("stepper shows %d steps (%v), want 3", len(state.Steps), state.Steps)
+	}
+	for _, s := range state.Steps {
+		if s == string(domain.OnboardingStepOrganization) || s == string(domain.OnboardingStepFramework) {
+			t.Errorf("skipped step %q is still in the stepper", s)
+		}
+	}
+	if len(state.SkippedSteps) != 2 {
+		t.Errorf("skipped = %v, want organization and framework", state.SkippedSteps)
+	}
+	// The cursor must not land on a step the client is forbidden to render.
+	if state.CurrentStep == string(domain.OnboardingStepOrganization) {
+		t.Errorf("the cursor parked on a skipped step: %q", state.CurrentStep)
+	}
+}
+
+// Criterion 2: one call resolves the whole tunnel.
+func TestWizard_StateResolvesAutoSkipInASingleProbe(t *testing.T) {
+	repo := newFakeRepo()
+	probe := &fakeProbe{data: domain.OnboardingStepData{HasUserProfile: true}}
+	uc := newWizard(repo).WithStepProbe(probe)
+
+	if _, err := uc.GetState(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if probe.calls != 1 {
+		t.Errorf("GET /onboarding/state probed %d times, want exactly 1", probe.calls)
+	}
+}
+
+// `goal` is a preference, not a record. Nothing stored can prove what a user
+// wants next, so skipping it would silently choose their landing page.
+func TestWizard_GoalIsNeverSkippable(t *testing.T) {
+	everything := domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasUserProfile:         true,
+		HasFramework:           true,
+		HasTeam:                true,
+	}
+
+	visible := everything.VisibleSteps()
+	if len(visible) != 1 || visible[0] != domain.OnboardingStepGoal {
+		t.Fatalf("visible steps = %v, want only the goal", visible)
+	}
+	if everything.SkipsStep(domain.OnboardingStepGoal) {
+		t.Error("the goal step must never be skipped")
+	}
+
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: everything})
+	state, err := uc.GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if len(state.Steps) != 1 || state.Steps[0] != string(domain.OnboardingStepGoal) {
+		t.Errorf("a fully configured user must still answer the goal, got %v", state.Steps)
+	}
+}
+
+// The cursor steps OVER hidden steps in both directions. Landing on one would
+// strand the user on a screen the client must not draw.
+func TestWizard_CursorStepsOverHiddenSteps(t *testing.T) {
+	repo := newFakeRepo()
+	// profile and framework hidden ⇒ visible: organization, goal, team
+	probe := &fakeProbe{data: domain.OnboardingStepData{HasUserProfile: true, HasFramework: true}}
+	uc := newWizard(repo).WithStepProbe(probe)
+	tenant, user := uuid.New(), uuid.New()
+
+	// Forward from organization: profile is hidden, so goal is next.
+	state, err := uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepOrganization,
+		Answers: domain.JSONMap{"industry": "banking", "country": "CM"},
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepGoal) {
+		t.Errorf("forward cursor = %q, want goal (profile is hidden)", state.CurrentStep)
+	}
+
+	// Forward from goal: framework is hidden, so team is next.
+	state, err = uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepGoal,
+		Answers: domain.JSONMap{"goal": "compliance"},
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepTeam) {
+		t.Errorf("forward cursor = %q, want team (framework is hidden)", state.CurrentStep)
+	}
+
+	// An explicit backwards Next naming a HIDDEN step is honoured as a direction:
+	// the cursor lands on the nearest visible step behind it, never on the hidden
+	// one and never staying put.
+	state, err = uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepTeam,
+		Answers: domain.JSONMap{},
+		Next:    string(domain.OnboardingStepFramework),
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepGoal) {
+		t.Errorf("backwards cursor = %q, want goal (framework is hidden)", state.CurrentStep)
+	}
+}
+
+// Criterion 5 in the presence of skips: the resumed cursor still reads as a
+// sensible "step N of M" rather than "step 0 of 3" or a negative index.
+func TestWizard_StepIndexIsRelativeToVisibleSteps(t *testing.T) {
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	repo.progress[user.String()] = &domain.OnboardingProgress{
+		TenantID:    tenant,
+		UserID:      user,
+		CurrentStep: domain.OnboardingStepTeam,
+	}
+	// organization hidden ⇒ visible: profile, goal, framework, team
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: domain.OnboardingStepData{HasOrganizationProfile: true}})
+
+	state, err := uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state.StepIndex != 3 || len(state.Steps) != 4 {
+		t.Errorf("step %d of %d, want 3 of 4", state.StepIndex, len(state.Steps))
+	}
+
+	// A stored cursor parked on a NOW-hidden step must not render as index −1.
+	repo.progress[user.String()].CurrentStep = domain.OnboardingStepOrganization
+	state, err = uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state.StepIndex < 0 || state.StepIndex >= len(state.Steps) {
+		t.Errorf("a cursor on a hidden step resolved to index %d of %d", state.StepIndex, len(state.Steps))
+	}
+}
+
+// A probe failure must show every step, not hide one whose data does not exist.
+// Showing a redundant step costs a click; hiding a needed one strands the user.
+func TestWizard_ProbeFailureShowsEveryStep(t *testing.T) {
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{fail: true})
+
+	state, err := uc.GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("a probe failure must not fail the wizard: %v", err)
+	}
+	if len(state.Steps) != len(domain.OnboardingStepOrder) {
+		t.Errorf("a failed probe hid %d steps", len(domain.OnboardingStepOrder)-len(state.Steps))
+	}
+	if len(state.SkippedSteps) != 0 {
+		t.Errorf("a failed probe reported skips: %v", state.SkippedSteps)
+	}
+}
+
+// No probe at all is the old behaviour, unchanged.
+func TestWizard_NoProbeShowsEveryStep(t *testing.T) {
+	state, err := newWizard(newFakeRepo()).GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if len(state.Steps) != len(domain.OnboardingStepOrder) {
+		t.Errorf("steps = %v, want the full catalogue", state.Steps)
+	}
+}
+
+// Complete parks the cursor on the last step this user actually saw, not on the
+// catalogue's last step — which may be one they never walked.
+func TestWizard_CompleteParksOnTheLastVisibleStep(t *testing.T) {
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: domain.OnboardingStepData{HasTeam: true}})
+	tenant, user := uuid.New(), uuid.New()
+
+	state, err := uc.Complete(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if state.CurrentStep == string(domain.OnboardingStepTeam) {
+		t.Error("the cursor parked on the hidden team step")
+	}
+	if state.CurrentStep != string(domain.OnboardingStepFramework) {
+		t.Errorf("cursor = %q, want the last visible step (framework)", state.CurrentStep)
+	}
+	if !state.Completed {
+		t.Error("Complete must complete")
+	}
+}
+
+func TestOnboardingStepData_SkipsStep(t *testing.T) {
+	full := domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasUserProfile:         true,
+		HasFramework:           true,
+		HasTeam:                true,
+	}
+	for step, want := range map[domain.OnboardingStepKey]bool{
+		domain.OnboardingStepOrganization: true,
+		domain.OnboardingStepProfile:      true,
+		domain.OnboardingStepFramework:    true,
+		domain.OnboardingStepTeam:         true,
+		domain.OnboardingStepGoal:         false,
+	} {
+		if got := full.SkipsStep(step); got != want {
+			t.Errorf("SkipsStep(%q) = %v, want %v", step, got, want)
+		}
+	}
+
+	empty := domain.OnboardingStepData{}
+	for _, step := range domain.OnboardingStepOrder {
+		if empty.SkipsStep(step) {
+			t.Errorf("an empty tenant must skip nothing, skipped %q", step)
+		}
+	}
+	if len(empty.VisibleSteps()) != len(domain.OnboardingStepOrder) {
+		t.Error("an empty tenant must see every step")
+	}
+}

--- a/backend/internal/application/activation/onboarding.go
+++ b/backend/internal/application/activation/onboarding.go
@@ -46,8 +46,16 @@ type ProfileUpdater interface {
 
 // WizardState is the payload of GET /onboarding/state.
 type WizardState struct {
-	CurrentStep string         `json:"current_step"`
-	Steps       []string       `json:"steps"`
+	CurrentStep string `json:"current_step"`
+	// Steps is what the ProgressStepper renders: the steps THIS USER will
+	// actually see, with auto-skipped ones removed (#438 criterion 3). It is not
+	// the canonical catalogue — a user who skips two steps must read
+	// "step 2 of 3", not "step 2 of 5" with two rows that never arrive.
+	Steps []string `json:"steps"`
+	// SkippedSteps is what was removed and is returned for transparency, not for
+	// rendering. A client that drew these would flash a step criterion 3 forbids.
+	SkippedSteps []string `json:"skipped_steps"`
+	// StepIndex is the cursor's position among the VISIBLE steps.
 	StepIndex   int            `json:"step_index"`
 	Completed   bool           `json:"completed"`
 	CompletedAt *time.Time     `json:"completed_at,omitempty"`
@@ -68,7 +76,33 @@ type OnboardingUseCase struct {
 	orgs     OrgUpdater
 	orgCur   OrgCurrencyUpdater
 	profiles ProfileUpdater
-	now      func() time.Time
+	// probe decides which steps are auto-skipped. Optional and nil-safe: with no
+	// probe every step is shown, which is the old behaviour and the safe default
+	// — showing a step the user did not need costs them a click; hiding one they
+	// did need loses their answer.
+	probe domain.OnboardingStepProbe
+	now   func() time.Time
+}
+
+// WithStepProbe attaches the auto-skip reader (#438 criteria 2 and 3).
+func (uc *OnboardingUseCase) WithStepProbe(p domain.OnboardingStepProbe) *OnboardingUseCase {
+	uc.probe = p
+	return uc
+}
+
+// stepData resolves the auto-skip decisions once. A probe failure degrades to
+// "skip nothing": a wizard that shows a redundant step is a minor annoyance, and
+// one that hides a step whose data does NOT exist strands the user on a tunnel
+// they cannot complete.
+func (uc *OnboardingUseCase) stepData(ctx context.Context, tenantID, userID uuid.UUID) domain.OnboardingStepData {
+	if uc.probe == nil {
+		return domain.OnboardingStepData{}
+	}
+	data, err := uc.probe.OnboardingStepData(ctx, tenantID, userID)
+	if err != nil {
+		return domain.OnboardingStepData{}
+	}
+	return data
 }
 
 // WithOrgCurrencyUpdater attaches the optional tenant-currency writer.
@@ -114,7 +148,10 @@ func (uc *OnboardingUseCase) GetState(ctx context.Context, tenantID, userID uuid
 			CurrentStep: domain.OnboardingStepOrganization,
 		}
 	}
-	return toWizardState(progress), nil
+
+	// Criterion 2: ONE call resolves the whole tunnel, auto-skip decisions
+	// included. No step may issue its own status call on mount.
+	return toWizardState(progress, uc.stepData(ctx, tenantID, userID)), nil
 }
 
 // SaveStepInput is one step's submission.
@@ -194,27 +231,68 @@ func (uc *OnboardingUseCase) SaveStep(ctx context.Context, tenantID, userID uuid
 	}
 
 	// Move the cursor. An explicit Next wins (including backwards); otherwise
-	// advance one step, clamped at the last.
-	progress.CurrentStep = uc.nextStep(input.Step, input.Next)
+	// advance one step, clamped at the last. Auto-skipped steps are stepped over
+	// in both directions — landing on a hidden step would strand the user on a
+	// screen the client is forbidden to render.
+	data := uc.stepData(ctx, tenantID, userID)
+	progress.CurrentStep = uc.nextStep(input.Step, input.Next, data)
 
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress), nil
+	return toWizardState(progress, data), nil
 }
 
-// nextStep resolves the cursor move.
-func (uc *OnboardingUseCase) nextStep(current domain.OnboardingStepKey, next string) domain.OnboardingStepKey {
+// nextStep resolves the cursor move over the VISIBLE steps only.
+//
+// An explicit Next that names a skipped step is honoured as a direction, not as
+// a destination: the cursor lands on the nearest visible step in that direction.
+// Silently ignoring it would leave the user on the step they just submitted.
+func (uc *OnboardingUseCase) nextStep(current domain.OnboardingStepKey, next string, data domain.OnboardingStepData) domain.OnboardingStepKey {
+	visible := data.VisibleSteps()
+	if len(visible) == 0 {
+		// Unreachable while `goal` is unskippable, but a cursor with nowhere to
+		// go must not be a panic.
+		return current
+	}
+
 	if next != "" {
 		if parsed, err := domain.ParseOnboardingStep(next); err == nil {
-			return parsed
+			backwards := parsed.Index() < current.Index()
+			return nearestVisible(parsed, visible, backwards)
 		}
 	}
+
 	idx := current.Index() + 1
 	if idx >= len(domain.OnboardingStepOrder) {
 		idx = len(domain.OnboardingStepOrder) - 1
 	}
-	return domain.OnboardingStepOrder[idx]
+	return nearestVisible(domain.OnboardingStepOrder[idx], visible, false)
+}
+
+// nearestVisible snaps a target onto the visible sequence, searching forward
+// (or backward) and falling back to the other direction at the ends.
+func nearestVisible(target domain.OnboardingStepKey, visible []domain.OnboardingStepKey, backwards bool) domain.OnboardingStepKey {
+	for _, s := range visible {
+		if s == target {
+			return target
+		}
+	}
+
+	if backwards {
+		for i := len(visible) - 1; i >= 0; i-- {
+			if visible[i].Index() < target.Index() {
+				return visible[i]
+			}
+		}
+		return visible[0]
+	}
+	for _, s := range visible {
+		if s.Index() > target.Index() {
+			return s
+		}
+	}
+	return visible[len(visible)-1]
 }
 
 // Complete closes the wizard and lifts the route guard. Idempotent: completing an
@@ -237,14 +315,17 @@ func (uc *OnboardingUseCase) Complete(ctx context.Context, tenantID, userID uuid
 		progress.Completed = true
 		progress.CompletedAt = &now
 	}
-	progress.CurrentStep = domain.OnboardingStepTeam
+	// Park the cursor on the last step this user actually saw, not on the
+	// catalogue's last step — which may be one they never walked.
+	visible := uc.stepData(ctx, tenantID, userID).VisibleSteps()
+	progress.CurrentStep = visible[len(visible)-1]
 	progress.TenantID = tenantID
 	progress.UserID = userID
 
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress), nil
+	return toWizardState(progress, uc.stepData(ctx, tenantID, userID)), nil
 }
 
 // Suggestions is the payload of GET /onboarding/suggestions: the sector/goal
@@ -294,10 +375,17 @@ func (uc *OnboardingUseCase) GetSuggestions(ctx context.Context, tenantID, userI
 // helpers
 // ---------------------------------------------------------------------------
 
-func toWizardState(p *domain.OnboardingProgress) *WizardState {
-	steps := make([]string, 0, len(domain.OnboardingStepOrder))
-	for _, s := range domain.OnboardingStepOrder {
+func toWizardState(p *domain.OnboardingProgress, data domain.OnboardingStepData) *WizardState {
+	visible := data.VisibleSteps()
+	steps := make([]string, 0, len(visible))
+	for _, s := range visible {
 		steps = append(steps, string(s))
+	}
+	skipped := make([]string, 0, len(domain.OnboardingStepOrder)-len(visible))
+	for _, s := range domain.OnboardingStepOrder {
+		if data.SkipsStep(s) {
+			skipped = append(skipped, string(s))
+		}
 	}
 
 	answers := p.Answers
@@ -305,26 +393,56 @@ func toWizardState(p *domain.OnboardingProgress) *WizardState {
 		answers = domain.JSONMap{}
 	}
 
-	idx := p.CurrentStep.Index()
+	// The cursor's position among the VISIBLE steps — what "step N of M" reads.
+	//
+	// A cursor pointing at a hidden step is SNAPPED onto the visible sequence
+	// rather than merely re-indexed. Two ways it gets there and both are normal:
+	// a brand-new progress row is initialised on `organization`, which may be the
+	// first step skipped; and a stored row can predate the data that now skips
+	// its step. Reporting the hidden key would tell the client to render a screen
+	// criterion 3 forbids, and reporting index 0 while naming a hidden step would
+	// have the stepper and the screen disagree.
+	cursor := p.CurrentStep
+	idx := -1
+	for i, s := range visible {
+		if s == cursor {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 && len(visible) > 0 {
+		cursor = nearestVisible(cursor, visible, false)
+		for i, s := range visible {
+			if s == cursor {
+				idx = i
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		idx = 0
+	}
+
 	state := &WizardState{
-		CurrentStep: string(p.CurrentStep),
-		Steps:       steps,
-		StepIndex:   idx,
-		Completed:   p.Completed,
-		CompletedAt: p.CompletedAt,
-		Industry:    p.Industry,
-		Country:     p.Country,
-		Goal:        p.Goal,
-		Answers:     answers,
-		Landing:     onboarding.LandingForGoal(p.Goal),
+		CurrentStep:  string(cursor),
+		Steps:        steps,
+		SkippedSteps: skipped,
+		StepIndex:    idx,
+		Completed:    p.Completed,
+		CompletedAt:  p.CompletedAt,
+		Industry:     p.Industry,
+		Country:      p.Country,
+		Goal:         p.Goal,
+		Answers:      answers,
+		Landing:      onboarding.LandingForGoal(p.Goal),
 	}
 	if p.Completed {
 		state.Percent = 100
 	} else {
 		state.Percent = idx * 100 / len(steps)
 	}
-	if state.CurrentStep == "" {
-		state.CurrentStep = string(domain.OnboardingStepOrganization)
+	if state.CurrentStep == "" && len(visible) > 0 {
+		state.CurrentStep = string(visible[0])
 	}
 	return state
 }

--- a/backend/internal/application/activation/posture.go
+++ b/backend/internal/application/activation/posture.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package activation
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/monitoring"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// The Posture Reveal (#438) — the surface that DEFINES the Aha moment.
+//
+// Everything here is computed from the tenant's OWN rows. #438 criterion 7 is
+// absolute: no sample, no demo, no placeholder value may reach the payload. That
+// is not a UI preference — the reveal is the launch-gate metric, and a screen
+// that renders a plausible number from fixture data would make the metric report
+// success while activation is nil.
+//
+// Criterion 8 is the counterpart and is why Execute returns an error rather than
+// a half-empty summary: if the payload would be empty, NOTHING is recorded. No
+// `posture.revealed` event, no histogram observation. A reveal that cannot show
+// anything has not revealed anything, and recording it would quietly turn a
+// rendering failure into a product success.
+// ---------------------------------------------------------------------------
+
+// The read models and the ports live in internal/domain (see domain/posture.go
+// for why: repository cannot import this package). Aliased here so the use case
+// and its tests read naturally and so a caller never has to know which package a
+// shape came from.
+type (
+	PostureRiskCounts    = domain.PostureRiskCounts
+	PostureControlCounts = domain.PostureControlCounts
+	PostureRisk          = domain.PostureRisk
+	PostureReader        = domain.PostureReader
+)
+
+// PostureRiskView is one risk with its residual, as the reveal renders it.
+type PostureRiskView struct {
+	PostureRisk
+	Residual scoring.Residual `json:"residual"`
+}
+
+// TopRiskLimit is how many risks the reveal composes — defined in the domain so
+// the repository shares the same number without importing this package.
+const TopRiskLimit = domain.TopRiskLimit
+
+// PostureSummary is the payload of GET /posture.
+type PostureSummary struct {
+	Risks    PostureRiskCounts    `json:"risks"`
+	Controls PostureControlCounts `json:"controls"`
+	// CoveragePercent is nil, NOT zero, when no applicable control exists. Zero
+	// would read as "you have covered nothing", which is a different and false
+	// statement from "there is nothing to cover yet".
+	CoveragePercent *float64          `json:"coverage_percent"`
+	TopRisks        []PostureRiskView `json:"top_risks"`
+	// ResidualFormulaVersion is echoed so a stored or forwarded figure can never
+	// be reinterpreted under a later formula (ADR 0003).
+	ResidualFormulaVersion string    `json:"residual_formula_version"`
+	GeneratedAt            time.Time `json:"generated_at"`
+	// RevealedAt is when this tenant FIRST reached the reveal. Stable across
+	// re-renders — criterion 11, first-occurrence-wins.
+	RevealedAt *time.Time `json:"revealed_at,omitempty"`
+	// FirstReveal is true only on the render that recorded the event, so the
+	// client can celebrate once without deciding anything itself.
+	FirstReveal bool `json:"first_reveal"`
+}
+
+// IsRevealable encodes criterion 6's three requirements and criterion 8's
+// refusal. All three must hold or there is nothing to reveal:
+//
+//	a non-zero risk count · a non-null coverage percentage · at least one residual
+func (s *PostureSummary) IsRevealable() bool {
+	return s != nil &&
+		s.Risks.Total > 0 &&
+		s.CoveragePercent != nil &&
+		len(s.TopRisks) > 0
+}
+
+// PostureUseCase computes the reveal and records the Aha exactly once.
+type PostureUseCase struct {
+	reader   PostureReader
+	repo     domain.ActivationRepository
+	recorder *Recorder
+	now      func() time.Time
+}
+
+// NewPostureUseCase builds the use case. Both dependencies are required: unlike
+// the rest of this package, the reveal must NOT degrade silently — a reveal that
+// renders zeros because its reader was nil is exactly the failure criterion 8
+// exists to prevent.
+func NewPostureUseCase(reader PostureReader, repo domain.ActivationRepository, recorder *Recorder) *PostureUseCase {
+	return &PostureUseCase{
+		reader:   reader,
+		repo:     repo,
+		recorder: recorder,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Execute computes the reveal for one (tenant, user) and, when it is revealable
+// and this is the first time, records `posture.revealed` and observes the v2
+// time-to-Aha histogram.
+//
+// Errors are typed and each one means something different to the client:
+//
+//   - ErrForbidden  — no tenant or no user on the session.
+//   - ErrNotFound   — the tenant has nothing to reveal yet (criterion 8). NOTHING
+//     is recorded and NOTHING is observed on this path.
+func (uc *PostureUseCase) Execute(ctx context.Context, tenantID, userID uuid.UUID) (*PostureSummary, error) {
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant and a user are required to read a posture")
+	}
+	if uc.reader == nil {
+		return nil, domain.NewInternalError("posture reader is not wired")
+	}
+
+	counts, err := uc.reader.RiskCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	controls, err := uc.reader.ControlCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	top, err := uc.reader.TopRisks(ctx, tenantID, TopRiskLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]uuid.UUID, 0, len(top))
+	for _, r := range top {
+		ids = append(ids, r.ID)
+	}
+	credits := map[uuid.UUID][]scoring.ControlCredit{}
+	if len(ids) > 0 {
+		credits, err = uc.reader.ControlCreditsByRisk(ctx, tenantID, ids)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	views := make([]PostureRiskView, 0, len(top))
+	for _, r := range top {
+		views = append(views, PostureRiskView{
+			PostureRisk: r,
+			Residual:    scoring.ComputeResidual(r.Inherent, credits[r.ID]),
+		})
+	}
+
+	summary := &PostureSummary{
+		Risks:                  counts,
+		Controls:               controls,
+		CoveragePercent:        coveragePercent(controls),
+		TopRisks:               views,
+		ResidualFormulaVersion: scoring.ResidualFormulaVersion,
+		GeneratedAt:            uc.now(),
+	}
+
+	if !summary.IsRevealable() {
+		// Criterion 8: fail loudly, record nothing, observe nothing. The client
+		// renders an explicit error state and the metric stays honest.
+		return nil, domain.NewNotFoundError("posture", tenantID)
+	}
+
+	uc.recordReveal(ctx, tenantID, userID, summary)
+	return summary, nil
+}
+
+// recordReveal writes `posture.revealed` at most once per tenant and observes the
+// v2 histogram. Best-effort like the rest of this package: a metric must never be
+// able to fail the screen it measures.
+func (uc *PostureUseCase) recordReveal(ctx context.Context, tenantID, userID uuid.UUID, summary *PostureSummary) {
+	if uc.repo == nil {
+		return
+	}
+
+	firsts, err := uc.repo.FirstOccurrences(ctx, tenantID)
+	if err != nil {
+		return
+	}
+
+	// Criterion 11: first-occurrence-wins. An already-revealed tenant gets its
+	// original timestamp back and no second row is written.
+	if at, seen := firsts[domain.ActivationPostureRevealed]; seen {
+		revealedAt := at
+		summary.RevealedAt = &revealedAt
+		return
+	}
+
+	recorded := uc.recorder.RecordOnce(ctx, tenantID, string(domain.ActivationPostureRevealed),
+		map[string]interface{}{
+			"risk_count":       summary.Risks.Total,
+			"coverage_percent": summary.CoveragePercent,
+			"top_risks":        len(summary.TopRisks),
+			"formula_version":  summary.ResidualFormulaVersion,
+		})
+	if !recorded {
+		// Another request won the race. Not an error, and not a second event.
+		return
+	}
+
+	// Read the timestamp BACK from the stored event rather than taking a second
+	// clock reading. The recorder stamps `occurred_at` with its own clock, so a
+	// second reading here would report a `revealed_at` that differs — by
+	// microseconds in production, by enough to fail criterion 11's "completed_at
+	// is unchanged" the moment the screen is rendered twice.
+	stored, err := uc.repo.FirstOccurrences(ctx, tenantID)
+	if err != nil {
+		return
+	}
+	at, ok := stored[domain.ActivationPostureRevealed]
+	if !ok {
+		// Recorded but unreadable: the store swallowed it. Do not observe a
+		// duration against a t0 we cannot prove.
+		return
+	}
+	revealedAt := at
+	summary.RevealedAt = &revealedAt
+	summary.FirstReveal = true
+
+	// Count the tenant whether or not a signup anchor exists to measure against —
+	// the defect D-010 told this work not to inherit.
+	monitoring.CountAhaReached()
+
+	// v2 is the Posture Reveal definition and only that. Without a signup anchor
+	// there is no honest duration, so nothing is observed rather than inventing a
+	// t0 that would flatter the histogram.
+	if signup, ok := firsts[domain.ActivationSignup]; ok {
+		monitoring.ObserveTimeToAha(monitoring.AhaDefinitionV2, revealedAt.Sub(signup))
+	}
+}
+
+// coveragePercent is implemented controls over APPLICABLE controls, rounded to
+// one decimal. Nil when nothing is applicable: zero would say "you have covered
+// nothing", which is false when there is nothing to cover.
+//
+// `in_progress` earns no coverage here even though ADR 0003 gives it residual
+// credit. The two answer different questions: coverage is "how much of the
+// framework is done", and a control being worked on is not done.
+func coveragePercent(c PostureControlCounts) *float64 {
+	applicable := c.Applicable()
+	if applicable <= 0 {
+		return nil
+	}
+	pct := float64(c.Implemented) / float64(applicable) * 100
+	pct = float64(int64(pct*10+0.5)) / 10
+	return &pct
+}

--- a/backend/internal/application/activation/posture_test.go
+++ b/backend/internal/application/activation/posture_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/monitoring"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// Tenant-aware reader double.
+//
+// Keyed BY TENANT on purpose: a double that ignored the tenant argument could
+// not fail the isolation test, and a test that cannot fail proves nothing
+// (#438 criterion 10).
+// ---------------------------------------------------------------------------
+
+type fakePostureReader struct {
+	counts   map[uuid.UUID]PostureRiskCounts
+	controls map[uuid.UUID]PostureControlCounts
+	top      map[uuid.UUID][]PostureRisk
+	credits  map[uuid.UUID]map[uuid.UUID][]scoring.ControlCredit
+	recog    map[uuid.UUID]RecognitionCounts
+
+	fail bool
+	// seenTenants records every tenant the use case actually asked about.
+	seenTenants []uuid.UUID
+}
+
+func newFakePostureReader() *fakePostureReader {
+	return &fakePostureReader{
+		counts:   map[uuid.UUID]PostureRiskCounts{},
+		controls: map[uuid.UUID]PostureControlCounts{},
+		top:      map[uuid.UUID][]PostureRisk{},
+		credits:  map[uuid.UUID]map[uuid.UUID][]scoring.ControlCredit{},
+		recog:    map[uuid.UUID]RecognitionCounts{},
+	}
+}
+
+func (f *fakePostureReader) RiskCounts(_ context.Context, tenantID uuid.UUID) (PostureRiskCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return PostureRiskCounts{}, errors.New("risk store down")
+	}
+	return f.counts[tenantID], nil
+}
+
+func (f *fakePostureReader) ControlCounts(_ context.Context, tenantID uuid.UUID) (PostureControlCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return PostureControlCounts{}, errors.New("compliance store down")
+	}
+	return f.controls[tenantID], nil
+}
+
+func (f *fakePostureReader) TopRisks(_ context.Context, tenantID uuid.UUID, limit int) ([]PostureRisk, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return nil, errors.New("risk store down")
+	}
+	rs := f.top[tenantID]
+	if len(rs) > limit {
+		rs = rs[:limit]
+	}
+	return rs, nil
+}
+
+func (f *fakePostureReader) ControlCreditsByRisk(_ context.Context, tenantID uuid.UUID, ids []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return nil, errors.New("mapping store down")
+	}
+	out := map[uuid.UUID][]scoring.ControlCredit{}
+	for _, id := range ids {
+		if c, ok := f.credits[tenantID][id]; ok {
+			out[id] = c
+		}
+	}
+	return out, nil
+}
+
+func (f *fakePostureReader) RecognitionCounts(_ context.Context, tenantID uuid.UUID) (RecognitionCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return RecognitionCounts{}, errors.New("store down")
+	}
+	return f.recog[tenantID], nil
+}
+
+// seedRevealable gives a tenant everything the reveal needs: risks, applicable
+// controls and one mapped control.
+func seedRevealable(r *fakePostureReader, tenant uuid.UUID) uuid.UUID {
+	riskID := uuid.New()
+	r.counts[tenant] = PostureRiskCounts{Total: 12, ByLevel: map[string]int{"critical": 2, "high": 4, "medium": 5, "low": 1}}
+	r.controls[tenant] = PostureControlCounts{Frameworks: 1, Total: 20, Implemented: 8, NotApplicable: 4, InProgress: 3}
+	r.top[tenant] = []PostureRisk{{ID: riskID, Title: "Compromission d'un compte à privilèges", Inherent: 16, Level: "critical"}}
+	r.credits[tenant] = map[uuid.UUID][]scoring.ControlCredit{
+		riskID: {{Status: scoring.ControlImplemented, HasEvidence: true}, {Status: scoring.ControlInProgress}},
+	}
+	return riskID
+}
+
+func newPosture(reader PostureReader, repo *fakeRepo) *PostureUseCase {
+	return NewPostureUseCase(reader, repo, NewRecorder(repo))
+}
+
+// ---------------------------------------------------------------------------
+// RULE #4 — the trio
+// ---------------------------------------------------------------------------
+
+func TestPostureSummary_Success(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+
+	got, err := newPosture(reader, repo).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got.Risks.Total != 12 {
+		t.Errorf("risk count = %d, want 12", got.Risks.Total)
+	}
+	// 8 implemented over 16 applicable (20 − 4 not applicable) = 50%.
+	if got.CoveragePercent == nil || *got.CoveragePercent != 50 {
+		t.Errorf("coverage = %v, want 50", got.CoveragePercent)
+	}
+	if len(got.TopRisks) != 1 {
+		t.Fatalf("top risks = %d, want 1", len(got.TopRisks))
+	}
+	// ADR 0003, checkable by hand: (1.0 + 0.30)/2 = 0.65 · 0.80 × 0.65 = 0.52
+	// 16 × (1 − 0.52) = 7.68
+	if v := got.TopRisks[0].Residual.Value; v != 7.68 {
+		t.Errorf("residual = %v, want 7.68", v)
+	}
+	if got.ResidualFormulaVersion != scoring.ResidualFormulaVersion {
+		t.Errorf("formula version = %q", got.ResidualFormulaVersion)
+	}
+	if !got.FirstReveal || got.RevealedAt == nil {
+		t.Errorf("the first reveal must be flagged and dated, got first=%v at=%v", got.FirstReveal, got.RevealedAt)
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); !has {
+		t.Error("posture.revealed must be recorded on a successful reveal")
+	}
+}
+
+// Criterion 8: a payload that would be empty renders an error state, records
+// NOTHING and observes NOTHING.
+func TestPostureSummary_NotFound(t *testing.T) {
+	cases := map[string]func(*fakePostureReader, uuid.UUID){
+		"no risks at all": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.controls[tenant] = PostureControlCounts{Total: 10, Implemented: 5}
+		},
+		"risks but no applicable control": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.counts[tenant] = PostureRiskCounts{Total: 4}
+			r.controls[tenant] = PostureControlCounts{Total: 3, NotApplicable: 3}
+			r.top[tenant] = []PostureRisk{{ID: uuid.New(), Title: "x", Inherent: 9}}
+		},
+		"counted risks but none readable": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.counts[tenant] = PostureRiskCounts{Total: 4}
+			r.controls[tenant] = PostureControlCounts{Total: 10, Implemented: 5}
+		},
+	}
+
+	for name, seed := range cases {
+		reader := newFakePostureReader()
+		repo := newFakeRepo()
+		tenant, user := uuid.New(), uuid.New()
+		seed(reader, tenant)
+
+		countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+		v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+
+		got, err := newPosture(reader, repo).Execute(context.Background(), tenant, user)
+		if err == nil {
+			t.Errorf("%s: an unrevealable posture must error, got %+v", name, got)
+			continue
+		}
+		if !errors.Is(err, domain.ErrNotFound) {
+			t.Errorf("%s: error = %v, want ErrNotFound", name, err)
+		}
+		if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); has {
+			t.Errorf("%s: posture.revealed was recorded for an empty reveal", name)
+		}
+		if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 0 {
+			t.Errorf("%s: aha_reached_total moved by %v on an empty reveal", name, got)
+		}
+		if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 0 {
+			t.Errorf("%s: v2 histogram observed %d times on an empty reveal", name, got)
+		}
+	}
+}
+
+func TestPostureSummary_Unauthorized(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	uc := newPosture(reader, repo)
+
+	for name, call := range map[string][2]uuid.UUID{
+		"no tenant": {uuid.Nil, user},
+		"no user":   {tenant, uuid.Nil},
+		"neither":   {uuid.Nil, uuid.Nil},
+	} {
+		_, err := uc.Execute(context.Background(), call[0], call[1])
+		if err == nil || !errors.Is(err, domain.ErrForbidden) {
+			t.Errorf("%s: error = %v, want ErrForbidden", name, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Criteria 10 and 11
+// ---------------------------------------------------------------------------
+
+// Criterion 10: every read is scoped to the caller's tenant. Tenant B holds a
+// full posture; tenant A holds nothing and must see nothing of B's.
+func TestPostureSummary_NeverReadsAnotherTenant(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenantA, tenantB, user := uuid.New(), uuid.New(), uuid.New()
+	seedRevealable(reader, tenantB)
+
+	_, err := newPosture(reader, repo).Execute(context.Background(), tenantA, user)
+	if err == nil {
+		t.Fatal("tenant A holds nothing; it must not be able to reveal tenant B's posture")
+	}
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+
+	for _, seen := range reader.seenTenants {
+		if seen != tenantA {
+			t.Errorf("the use case read tenant %v while serving tenant %v", seen, tenantA)
+		}
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenantB, domain.ActivationPostureRevealed); has {
+		t.Error("tenant A's request recorded a reveal against tenant B")
+	}
+}
+
+// Criterion 11: rendering twice creates no duplicate row and does not move
+// completed_at.
+func TestPostureSummary_RevealIsIdempotent(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	uc := newPosture(reader, repo)
+
+	first, err := uc.Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("first reveal: %v", err)
+	}
+	second, err := uc.Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("second reveal: %v", err)
+	}
+
+	rows := 0
+	for _, e := range repo.events {
+		if e.TenantID == tenant && e.EventKey == domain.ActivationPostureRevealed {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Errorf("posture.revealed recorded %d times, want exactly 1", rows)
+	}
+	if second.FirstReveal {
+		t.Error("the second render must not be flagged as the first reveal")
+	}
+	if first.RevealedAt == nil || second.RevealedAt == nil || !first.RevealedAt.Equal(*second.RevealedAt) {
+		t.Errorf("revealed_at moved: %v then %v", first.RevealedAt, second.RevealedAt)
+	}
+}
+
+// D-010: the reveal is the v2 definition. It must never touch v1, whose series
+// is frozen at the executive-dashboard definition.
+func TestPostureSummary_ObservesV2AndNeverV1(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	repo.events = append(repo.events, domain.ActivationEvent{
+		TenantID:   tenant,
+		EventKey:   domain.ActivationSignup,
+		OccurredAt: time.Now().UTC().Add(-5 * time.Minute),
+	})
+
+	v1Before := ahaObservations(t, monitoring.AhaDefinitionV1)
+	v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+	countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 1 {
+		t.Errorf("v2 gained %d observations, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV1) - v1Before; got != 0 {
+		t.Errorf("the reveal leaked %d observations into the frozen v1 series", got)
+	}
+	if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 1 {
+		t.Errorf("aha_reached_total moved by %v, want 1", got)
+	}
+}
+
+// The tenant with no signup anchor is still counted — the D-010 defect again,
+// this time on the reveal's own path.
+func TestPostureSummary_CountsATenantWithNoSignupAnchor(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+
+	countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+	v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 1 {
+		t.Errorf("aha_reached_total moved by %v, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 0 {
+		t.Errorf("a duration was observed with no signup anchor: +%d", got)
+	}
+}
+
+// A dead store must surface, not degrade into a plausible-looking zero posture:
+// that is the failure that would make the launch-gate metric lie.
+func TestPostureSummary_PropagatesReaderFailure(t *testing.T) {
+	reader := newFakePostureReader()
+	reader.fail = true
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err == nil {
+		t.Fatal("a failing reader must surface as an error, not as an empty posture")
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); has {
+		t.Error("a failed read recorded a reveal")
+	}
+}
+
+// Zero coverage and "nothing to cover" are different statements. Nil is the only
+// honest answer to the second.
+func TestCoveragePercent_NilWhenNothingIsApplicable(t *testing.T) {
+	if got := coveragePercent(PostureControlCounts{}); got != nil {
+		t.Errorf("no controls at all: coverage = %v, want nil", *got)
+	}
+	if got := coveragePercent(PostureControlCounts{Total: 5, NotApplicable: 5}); got != nil {
+		t.Errorf("everything scoped out: coverage = %v, want nil", *got)
+	}
+	if got := coveragePercent(PostureControlCounts{Total: 4, Implemented: 0}); got == nil || *got != 0 {
+		t.Errorf("applicable but none implemented: coverage = %v, want 0", got)
+	}
+	// in_progress earns no coverage: a control being worked on is not done.
+	got := coveragePercent(PostureControlCounts{Total: 4, Implemented: 1, InProgress: 3})
+	if got == nil || *got != 25 {
+		t.Errorf("coverage = %v, want 25", got)
+	}
+}
+
+func TestPostureSummary_IsRevealableRequiresAllThree(t *testing.T) {
+	pct := 40.0
+	full := &PostureSummary{
+		Risks:           PostureRiskCounts{Total: 3},
+		CoveragePercent: &pct,
+		TopRisks:        []PostureRiskView{{}},
+	}
+	if !full.IsRevealable() {
+		t.Fatal("a complete summary must be revealable")
+	}
+
+	noRisks := *full
+	noRisks.Risks = PostureRiskCounts{}
+	noCoverage := *full
+	noCoverage.CoveragePercent = nil
+	noTop := *full
+	noTop.TopRisks = nil
+
+	for name, s := range map[string]*PostureSummary{
+		"no risk count": &noRisks,
+		"no coverage":   &noCoverage,
+		"no residual":   &noTop,
+		"nil summary":   nil,
+	} {
+		if s.IsRevealable() {
+			t.Errorf("%s must not be revealable", name)
+		}
+	}
+}

--- a/backend/internal/application/activation/recognition.go
+++ b/backend/internal/application/activation/recognition.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package activation
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Recognition (#438 criterion 9) — the screen for the tenant that was already
+// configured before any of this shipped.
+//
+// #234's backfill made their checklist truthful and then stopped. Their
+// activation question is not "how do I create a risk"; it is "what does OpenRisk
+// already know about us that we did not". Walking a CISO whose bank has two
+// hundred risks through a five-step tunnel that asks them to write their first
+// one is worse than showing them nothing.
+//
+// So this surface answers with THEIR OWN NUMBERS and nothing else. Same rule as
+// the reveal: no sample, no demo, no placeholder.
+// ---------------------------------------------------------------------------
+
+// Read model and port live in internal/domain (domain/posture.go explains why).
+type (
+	RecognitionCounts = domain.RecognitionCounts
+	RecognitionReader = domain.RecognitionReader
+)
+
+// Recognition is the payload of GET /onboarding/recognition.
+type Recognition struct {
+	Counts RecognitionCounts `json:"counts"`
+	// Recognised is true when the tenant holds pre-existing data, which is what
+	// decides between this screen and the five-step tunnel. The SERVER decides:
+	// a client that could choose would be a client that can skip the tunnel.
+	Recognised bool `json:"recognised"`
+	// SkipTunnel mirrors Recognised for the guard, named for what the client does
+	// with it rather than for what it means.
+	SkipTunnel bool `json:"skip_tunnel"`
+}
+
+// RecognitionUseCase answers "does this tenant already have a posture?".
+type RecognitionUseCase struct {
+	reader RecognitionReader
+}
+
+// NewRecognitionUseCase builds the use case.
+func NewRecognitionUseCase(reader RecognitionReader) *RecognitionUseCase {
+	return &RecognitionUseCase{reader: reader}
+}
+
+// Execute returns the tenant's own counts.
+//
+// Typed errors: ErrForbidden with no tenant or no user on the session. Unlike
+// the reveal there is no ErrNotFound — a tenant holding nothing is a legitimate
+// answer here ("you are new, take the tunnel"), not a failure.
+func (uc *RecognitionUseCase) Execute(ctx context.Context, tenantID, userID uuid.UUID) (*Recognition, error) {
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant and a user are required to read a recognition")
+	}
+	if uc.reader == nil {
+		return nil, domain.NewInternalError("recognition reader is not wired")
+	}
+
+	counts, err := uc.reader.RecognitionCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	recognised := counts.Any()
+	return &Recognition{
+		Counts:     counts,
+		Recognised: recognised,
+		SkipTunnel: recognised,
+	}, nil
+}

--- a/backend/internal/application/activation/recognition_test.go
+++ b/backend/internal/application/activation/recognition_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// Criterion 9: the tenant configured before any of this shipped sees ITS OWN
+// counts and is not walked through a tunnel that asks for its first risk.
+func TestRecognition_Success(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	reader.recog[tenant] = RecognitionCounts{Risks: 214, Frameworks: 2, Controls: 187, Assets: 43, Members: 9}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Counts.Risks != 214 || got.Counts.Controls != 187 {
+		t.Errorf("counts = %+v, want the tenant's own rows", got.Counts)
+	}
+	if !got.Recognised || !got.SkipTunnel {
+		t.Errorf("a configured tenant must be recognised and skip the tunnel, got %+v", got)
+	}
+}
+
+// A tenant that holds nothing is NOT an error — it is the brand-new case, and
+// the honest answer is "take the tunnel".
+func TestRecognition_BrandNewTenantIsNotAnError(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("a brand-new tenant must not error: %v", err)
+	}
+	if got.Recognised || got.SkipTunnel {
+		t.Errorf("a brand-new tenant must not skip the tunnel, got %+v", got)
+	}
+}
+
+// The founding member alone is not "a team". Counting them as pre-existing data
+// would send every brand-new tenant to the recognition screen instead of the
+// tunnel — the exact inversion of criterion 9.
+func TestRecognition_FoundingMemberAloneIsNotRecognition(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	reader.recog[tenant] = RecognitionCounts{Members: 1}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Recognised {
+		t.Error("one member and nothing else is a brand-new tenant, not a recognised one")
+	}
+
+	reader.recog[tenant] = RecognitionCounts{Members: 2}
+	got, _ = NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if !got.Recognised {
+		t.Error("a second member is real pre-existing data")
+	}
+}
+
+func TestRecognition_NotFound(t *testing.T) {
+	// There is no NotFound on this path by design, and that is worth pinning:
+	// an empty tenant is a legitimate answer, so a future edit that starts
+	// returning ErrNotFound here would silently break the brand-new journey.
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("an empty tenant must not be a 404: %v", err)
+	}
+	if got == nil {
+		t.Fatal("an empty tenant must still get a payload")
+	}
+
+	// An unwired reader IS an error — a zeroed recognition would send a
+	// configured bank into the tunnel.
+	if _, err := NewRecognitionUseCase(nil).Execute(context.Background(), tenant, user); err == nil {
+		t.Error("an unwired reader must error rather than report an empty tenant")
+	}
+}
+
+func TestRecognition_Unauthorized(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	uc := NewRecognitionUseCase(reader)
+
+	for name, call := range map[string][2]uuid.UUID{
+		"no tenant": {uuid.Nil, user},
+		"no user":   {tenant, uuid.Nil},
+		"neither":   {uuid.Nil, uuid.Nil},
+	} {
+		if _, err := uc.Execute(context.Background(), call[0], call[1]); err == nil || !errors.Is(err, domain.ErrForbidden) {
+			t.Errorf("%s: error = %v, want ErrForbidden", name, err)
+		}
+	}
+}
+
+// Criterion 10 again, on this surface.
+func TestRecognition_NeverReadsAnotherTenant(t *testing.T) {
+	reader := newFakePostureReader()
+	tenantA, tenantB, user := uuid.New(), uuid.New(), uuid.New()
+	reader.recog[tenantB] = RecognitionCounts{Risks: 214, Frameworks: 2, Controls: 187}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenantA, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Counts.Risks != 0 || got.Recognised {
+		t.Errorf("tenant A saw tenant B's data: %+v", got.Counts)
+	}
+	for _, seen := range reader.seenTenants {
+		if seen != tenantA {
+			t.Errorf("the use case read tenant %v while serving tenant %v", seen, tenantA)
+		}
+	}
+}
+
+func TestRecognitionCounts_Any(t *testing.T) {
+	cases := map[string]struct {
+		counts RecognitionCounts
+		want   bool
+	}{
+		"empty":       {RecognitionCounts{}, false},
+		"one member":  {RecognitionCounts{Members: 1}, false},
+		"two members": {RecognitionCounts{Members: 2}, true},
+		"one risk":    {RecognitionCounts{Risks: 1}, true},
+		"a framework": {RecognitionCounts{Frameworks: 1}, true},
+		"controls":    {RecognitionCounts{Controls: 1}, true},
+		"assets":      {RecognitionCounts{Assets: 1}, true},
+	}
+	for name, tc := range cases {
+		if got := tc.counts.Any(); got != tc.want {
+			t.Errorf("%s: Any() = %v, want %v", name, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/domain/posture.go
+++ b/backend/internal/domain/posture.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package domain
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// Posture read models (#438).
+//
+// These live in the domain rather than in the application package for one
+// structural reason: `internal/infrastructure/repository` cannot import
+// `internal/application/activation` — that package imports
+// `infrastructure/audittrail`, which imports `infrastructure/repository`, and
+// the cycle is real. Ports are declared in the application layer and satisfied
+// structurally by the repository (the pattern `OrgUpdater` already uses), which
+// only works if the TYPES they exchange sit in a package both may import.
+//
+// So: the shapes are here, the use cases and the ports stay in the application
+// layer, and no layer points the wrong way.
+// ---------------------------------------------------------------------------
+
+// TopRiskLimit is how many risks the reveal composes. Small on purpose: the
+// screen makes one statement the user can forward to their CISO, not a register
+// dump. Lives here so the use case and the repository share one number.
+const TopRiskLimit = 5
+
+// PostureRiskCounts is the tenant's risk register, in numbers.
+type PostureRiskCounts struct {
+	Total int `json:"total"`
+	// ByLevel is keyed by the Score Engine's own bands (low/medium/high/critical).
+	// The reveal never invents a banding of its own.
+	ByLevel map[string]int `json:"by_level"`
+}
+
+// PostureControlCounts is the tenant's compliance position, in numbers.
+type PostureControlCounts struct {
+	Frameworks int `json:"frameworks"`
+	Total      int `json:"total"`
+	// Implemented, InProgress and NotApplicable are counted separately because
+	// coverage and residual credit treat them differently: coverage excludes
+	// scoped-out controls from BOTH sides of the ratio, and gives `in_progress`
+	// nothing, while ADR 0003 gives `in_progress` partial residual credit.
+	Implemented   int `json:"implemented"`
+	NotApplicable int `json:"not_applicable"`
+	InProgress    int `json:"in_progress"`
+}
+
+// Applicable is Total minus the deliberately scoped-out controls.
+func (c PostureControlCounts) Applicable() int {
+	n := c.Total - c.NotApplicable
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// PostureRisk is one risk as the reveal reads it, before the residual is applied.
+type PostureRisk struct {
+	ID    uuid.UUID `json:"id"`
+	Title string    `json:"title"`
+	// Inherent is Risk.Score — the FROZEN P×I×AC value. The reveal reads it and
+	// never recomputes it.
+	Inherent float64 `json:"inherent"`
+	Level    string  `json:"level"`
+}
+
+// RecognitionCounts is what a tenant already holds, straight from its own rows.
+type RecognitionCounts struct {
+	Risks      int `json:"risks"`
+	Frameworks int `json:"frameworks"`
+	Controls   int `json:"controls"`
+	Assets     int `json:"assets"`
+	Members    int `json:"members"`
+}
+
+// Any is false for a tenant that holds nothing — the brand-new case, which
+// belongs in the tunnel and not on the recognition screen.
+//
+// One member is NOT recognition: every brand-new tenant has exactly one. Testing
+// `Members > 0` here would send every newcomer to the recognition screen and
+// nobody to the tunnel, which is the precise inversion of criterion 9.
+func (c RecognitionCounts) Any() bool {
+	return c.Risks > 0 || c.Frameworks > 0 || c.Controls > 0 || c.Assets > 0 || c.Members > 1
+}
+
+// PostureReader is the tenant-scoped read side of the Posture Reveal.
+//
+// EVERY method MUST filter on tenantID — #438 criterion 10, ABSOLUTE RULE #2.
+// The tenant is an argument on every call rather than a field on the
+// implementation, so a forgotten filter is a visible omission in a query rather
+// than an invisible one in a long-lived struct.
+type PostureReader interface {
+	RiskCounts(ctx context.Context, tenantID uuid.UUID) (PostureRiskCounts, error)
+	// TopRisks returns the tenant's highest-scoring risks, most exposed first.
+	TopRisks(ctx context.Context, tenantID uuid.UUID, limit int) ([]PostureRisk, error)
+	ControlCounts(ctx context.Context, tenantID uuid.UUID) (PostureControlCounts, error)
+	// ControlCreditsByRisk returns, per risk id, the credits ADR 0003 consumes.
+	// HasEvidence must be filled from the evidence library, or every implemented
+	// control silently earns 0.70 instead of 1.00 and the reveal under-reports
+	// the tenant's own posture.
+	ControlCreditsByRisk(ctx context.Context, tenantID uuid.UUID, riskIDs []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error)
+}
+
+// ---------------------------------------------------------------------------
+// Auto-skip (#438 criteria 2 and 3)
+// ---------------------------------------------------------------------------
+
+// OnboardingStepData says which of the tunnel's questions this (tenant, user)
+// has ALREADY answered with real data.
+//
+// The server decides, and it decides once: criterion 2 allows exactly one
+// GET /onboarding/state for the whole tunnel, so no step may probe on mount.
+// Criterion 3 then requires a step whose data exists to never render, never
+// flash, and to be absent from the stepper count shown to that user.
+type OnboardingStepData struct {
+	// HasOrganizationProfile is true when the organisation already carries the
+	// facts the organization step collects (an industry and a size), so asking
+	// again would be asking a member to re-describe a company that is already
+	// described.
+	HasOrganizationProfile bool `json:"has_organization_profile"`
+	// HasUserProfile is true when this user already has a name and a job title.
+	HasUserProfile bool `json:"has_user_profile"`
+	// HasFramework is true when the tenant already imported a framework.
+	HasFramework bool `json:"has_framework"`
+	// HasTeam is true when the tenant has more than its founding member.
+	HasTeam bool `json:"has_team"`
+}
+
+// OnboardingStepProbe reads the auto-skip decisions. Tenant AND user scoped:
+// the profile question is about a person, the framework question is about a
+// company, and conflating them would skip a new member's profile step because
+// their colleague filled one in.
+type OnboardingStepProbe interface {
+	OnboardingStepData(ctx context.Context, tenantID, userID uuid.UUID) (OnboardingStepData, error)
+}
+
+// SkipsStep answers whether one wizard step should be hidden from this user.
+//
+// `goal` is NEVER skippable and that is deliberate: it is a preference, not a
+// record. No stored row can prove what a user wants to do next, and skipping it
+// from an inferred answer would silently choose their landing page for them.
+func (d OnboardingStepData) SkipsStep(step OnboardingStepKey) bool {
+	switch step {
+	case OnboardingStepOrganization:
+		return d.HasOrganizationProfile
+	case OnboardingStepProfile:
+		return d.HasUserProfile
+	case OnboardingStepFramework:
+		return d.HasFramework
+	case OnboardingStepTeam:
+		return d.HasTeam
+	default:
+		return false
+	}
+}
+
+// VisibleSteps is the ordered sequence this user will actually walk. Never
+// empty: `goal` is unskippable, so there is always at least one step and the
+// tunnel can never complete without the user having done anything.
+func (d OnboardingStepData) VisibleSteps() []OnboardingStepKey {
+	out := make([]OnboardingStepKey, 0, len(OnboardingStepOrder))
+	for _, s := range OnboardingStepOrder {
+		if !d.SkipsStep(s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// RecognitionReader is the tenant-scoped read side of the recognition screen.
+type RecognitionReader interface {
+	RecognitionCounts(ctx context.Context, tenantID uuid.UUID) (RecognitionCounts, error)
+}

--- a/backend/internal/domain/risk.go
+++ b/backend/internal/domain/risk.go
@@ -155,6 +155,14 @@ const (
 	SourceImport   RiskSource = "import"    // Imported from file
 	SourceVendor   RiskSource = "vendor"    // From vendor assessment
 	SourceAI       RiskSource = "ai"        // AI-generated
+	// SourceStarter marks a risk the onboarding tunnel wrote from the starter
+	// catalogue after the user selected it (#438, D-012). Provenance matters more
+	// here than anywhere else on this enum: these are rows OpenRisk put in a
+	// customer's register, and a GRC product that cannot say which risks its own
+	// onboarding wrote has a credibility problem no support ticket recovers.
+	//
+	// The column is already varchar(20), so this value needs NO migration.
+	SourceStarter RiskSource = "starter"
 )
 
 // ParseRiskSource validates and converts a string into a RiskSource.
@@ -166,7 +174,7 @@ func ParseRiskSource(s string) (RiskSource, error) {
 		return SourceManual, nil
 	}
 	switch RiskSource(s) {
-	case SourceManual, SourceCTIAuto, SourceScanAuto, SourceImport, SourceVendor, SourceAI:
+	case SourceManual, SourceCTIAuto, SourceScanAuto, SourceImport, SourceVendor, SourceAI, SourceStarter:
 		return RiskSource(s), nil
 	default:
 		return "", NewValidationError(fmt.Sprintf("invalid risk source: %q", s))
@@ -309,7 +317,7 @@ type Risk struct {
 	LastReviewedAt     *time.Time `json:"last_reviewed_at,omitempty"`
 
 	// Source Tracking
-	Source      RiskSource `gorm:"type:varchar(20);default:'manual';index" json:"source"` // manual|cti_auto|scan_auto|import|vendor|ai
+	Source      RiskSource `gorm:"type:varchar(20);default:'manual';index" json:"source"` // manual|cti_auto|scan_auto|import|vendor|ai|starter
 	SourceCVEID *string    `gorm:"index" json:"source_cve_id"`                            // CVE identifier if from CTI
 
 	// Origin of an automatically proposed risk (Attack Surface §4). A machine

--- a/backend/internal/domain/risk_source_test.go
+++ b/backend/internal/domain/risk_source_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package domain
+
+import "testing"
+
+// D-012: the onboarding tunnel writes real rows into a customer's register, so
+// the register must be able to say which rows it wrote. "starter" is that answer,
+// and PR 4 of #438 proves the rows by querying `source = 'starter'` — which only
+// works if the parser accepts the value the writer stores.
+func TestParseRiskSource_AcceptsStarter(t *testing.T) {
+	got, err := ParseRiskSource("starter")
+	if err != nil {
+		t.Fatalf("ParseRiskSource(\"starter\") errored: %v", err)
+	}
+	if got != SourceStarter {
+		t.Errorf("ParseRiskSource(\"starter\") = %q, want %q", got, SourceStarter)
+	}
+	if SourceStarter != "starter" {
+		t.Errorf("SourceStarter = %q, want the stored value %q", SourceStarter, "starter")
+	}
+	// The column is varchar(20); a longer value would be silently truncated by
+	// Postgres and would break the provenance query that PR 4 depends on.
+	if len(string(SourceStarter)) > 20 {
+		t.Errorf("SourceStarter is %d chars, the column holds 20", len(string(SourceStarter)))
+	}
+}
+
+func TestParseRiskSource_KnownValuesAndRejections(t *testing.T) {
+	for _, want := range []RiskSource{
+		SourceManual, SourceCTIAuto, SourceScanAuto,
+		SourceImport, SourceVendor, SourceAI, SourceStarter,
+	} {
+		got, err := ParseRiskSource(string(want))
+		if err != nil || got != want {
+			t.Errorf("ParseRiskSource(%q) = (%q, %v)", want, got, err)
+		}
+	}
+
+	// Empty still means manual — the ERD column default.
+	if got, err := ParseRiskSource(""); err != nil || got != SourceManual {
+		t.Errorf("ParseRiskSource(\"\") = (%q, %v), want manual", got, err)
+	}
+
+	for _, bad := range []string{"Starter", "starter_risk", "seed", "onboarding"} {
+		if _, err := ParseRiskSource(bad); err == nil {
+			t.Errorf("ParseRiskSource(%q) must be rejected", bad)
+		}
+	}
+}

--- a/backend/internal/handler/activation_handler.go
+++ b/backend/internal/handler/activation_handler.go
@@ -25,6 +25,11 @@ type ActivationHandler struct {
 	state      *appactivation.GetStateUseCase
 	celebrated *appactivation.MarkCelebratedUseCase
 	onboarding *appactivation.OnboardingUseCase
+	// posture and recognition are OPTIONAL (nil-safe): a deployment that has not
+	// wired the posture reader still serves the checklist and the wizard. They
+	// answer 503 rather than an empty posture — see GetPosture.
+	posture     *appactivation.PostureUseCase
+	recognition *appactivation.RecognitionUseCase
 }
 
 // NewActivationHandler wires the handler.
@@ -34,6 +39,67 @@ func NewActivationHandler(
 	onboarding *appactivation.OnboardingUseCase,
 ) *ActivationHandler {
 	return &ActivationHandler{state: state, celebrated: celebrated, onboarding: onboarding}
+}
+
+// WithPosture attaches the Posture Reveal use case (#438).
+func (h *ActivationHandler) WithPosture(uc *appactivation.PostureUseCase) *ActivationHandler {
+	h.posture = uc
+	return h
+}
+
+// WithRecognition attaches the recognition use case (#438 criterion 9).
+func (h *ActivationHandler) WithRecognition(uc *appactivation.RecognitionUseCase) *ActivationHandler {
+	h.recognition = uc
+	return h
+}
+
+// GetPosture GET /posture
+//
+// The Posture Reveal: the screen that DEFINES the Aha moment, computed entirely
+// from this tenant's own rows. Recording `posture.revealed` and observing the v2
+// time-to-Aha histogram happen inside the use case, exactly once per tenant.
+//
+// The 404 on this route is load-bearing and is NOT a missing-resource error in
+// the usual sense: #438 criterion 8 requires that a reveal which would render
+// empty produces an explicit error state and records NOTHING. Answering 200 with
+// zeros would turn a rendering failure into a green launch-gate metric.
+func (h *ActivationHandler) GetPosture(c *fiber.Ctx) error {
+	tenantID, userID, ok := h.identity(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+	if h.posture == nil {
+		return c.Status(fiber.StatusServiceUnavailable).
+			JSON(fiber.Map{"error": "Posture is not available on this deployment"})
+	}
+
+	summary, err := h.posture.Execute(c.UserContext(), tenantID, userID)
+	if err != nil {
+		return writeAppError(c, err)
+	}
+	return c.JSON(summary)
+}
+
+// GetRecognition GET /onboarding/recognition
+//
+// What OpenRisk already knows about a tenant that was configured before the
+// tunnel existed (#438 criterion 9). The SERVER decides whether the tunnel is
+// skipped: a client that could choose would be a client that can skip it.
+func (h *ActivationHandler) GetRecognition(c *fiber.Ctx) error {
+	tenantID, userID, ok := h.identity(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+	if h.recognition == nil {
+		return c.Status(fiber.StatusServiceUnavailable).
+			JSON(fiber.Map{"error": "Recognition is not available on this deployment"})
+	}
+
+	recognition, err := h.recognition.Execute(c.UserContext(), tenantID, userID)
+	if err != nil {
+		return writeAppError(c, err)
+	}
+	return c.JSON(recognition)
 }
 
 // identity resolves (tenant, user) from the request context.

--- a/backend/internal/infrastructure/repository/gorm_posture_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_posture_repository.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// GormPostureRepository is the read side of the Posture Reveal and the
+// recognition screen (#438).
+//
+// ONE RULE GOVERNS EVERY QUERY IN THIS FILE: `tenant_id = ?`, on the table's own
+// tenant column, with no join that could reach a row belonging to somebody else.
+// This is #438 criterion 10 and ABSOLUTE RULE #2, and it matters more here than
+// almost anywhere else in the codebase — the reveal is the screen a brand-new
+// customer forwards to their CISO, so a leak here is a leak into an email.
+//
+// Models are domain structs rather than table names so GORM applies the
+// soft-delete scope: a tenant whose only risk was deleted has not created a
+// risk, and raw SQL would silently have counted the tombstone.
+type GormPostureRepository struct {
+	db *gorm.DB
+}
+
+// NewGormPostureRepository builds the repository.
+func NewGormPostureRepository(db *gorm.DB) *GormPostureRepository {
+	return &GormPostureRepository{db: db}
+}
+
+// Compile-time proof that this satisfies both ports. Without these, a signature
+// drift would only surface at wiring time in main.go.
+var (
+	_ domain.PostureReader       = (*GormPostureRepository)(nil)
+	_ domain.RecognitionReader   = (*GormPostureRepository)(nil)
+	_ domain.OnboardingStepProbe = (*GormPostureRepository)(nil)
+)
+
+// RiskCounts returns the tenant's register in numbers, banded by the Score
+// Engine's own criticality column — the reveal never invents a banding.
+func (r *GormPostureRepository) RiskCounts(ctx context.Context, tenantID uuid.UUID) (domain.PostureRiskCounts, error) {
+	out := domain.PostureRiskCounts{ByLevel: map[string]int{}}
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to count risks")
+	}
+
+	var rows []struct {
+		Criticality string
+		N           int64
+	}
+	if err := r.db.WithContext(ctx).
+		Model(&domain.Risk{}).
+		Select("criticality, COUNT(*) AS n").
+		Where("tenant_id = ?", tenantID).
+		Group("criticality").
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to count risks: %w", err)
+	}
+
+	for _, row := range rows {
+		out.ByLevel[row.Criticality] = int(row.N)
+		out.Total += int(row.N)
+	}
+	return out, nil
+}
+
+// TopRisks returns the tenant's most exposed risks, highest Score Engine score
+// first. `Risk.Score` is read, never recomputed: it is frozen.
+func (r *GormPostureRepository) TopRisks(ctx context.Context, tenantID uuid.UUID, limit int) ([]domain.PostureRisk, error) {
+	if tenantID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant is required to read risks")
+	}
+	if limit <= 0 {
+		limit = domain.TopRiskLimit
+	}
+
+	var risks []domain.Risk
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ?", tenantID).
+		Order("score DESC, created_at ASC").
+		Limit(limit).
+		Find(&risks).Error; err != nil {
+		return nil, fmt.Errorf("failed to read top risks: %w", err)
+	}
+
+	out := make([]domain.PostureRisk, 0, len(risks))
+	for _, risk := range risks {
+		title := risk.Title
+		if title == "" {
+			title = risk.Name
+		}
+		out = append(out, domain.PostureRisk{
+			ID:       risk.ID,
+			Title:    title,
+			Inherent: risk.Score,
+			Level:    string(risk.Criticality),
+		})
+	}
+	return out, nil
+}
+
+// ControlCounts returns the tenant's compliance position. Statuses are counted
+// separately rather than reduced here, because coverage and residual credit
+// treat `in_progress` and `not_applicable` differently (ADR 0003).
+func (r *GormPostureRepository) ControlCounts(ctx context.Context, tenantID uuid.UUID) (domain.PostureControlCounts, error) {
+	var out domain.PostureControlCounts
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to count controls")
+	}
+
+	var rows []struct {
+		Status string
+		N      int64
+	}
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceControl{}).
+		Select("status, COUNT(*) AS n").
+		Where("tenant_id = ?", tenantID).
+		Group("status").
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to count controls: %w", err)
+	}
+
+	for _, row := range rows {
+		n := int(row.N)
+		out.Total += n
+		switch domain.ControlStatus(row.Status) {
+		case domain.ControlStatusImplemented:
+			out.Implemented += n
+		case domain.ControlStatusInProgress:
+			out.InProgress += n
+		case domain.ControlStatusNotApplicable:
+			out.NotApplicable += n
+		}
+	}
+
+	var frameworks int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceFramework{}).
+		Where("tenant_id = ?", tenantID).
+		Count(&frameworks).Error; err != nil {
+		return out, fmt.Errorf("failed to count frameworks: %w", err)
+	}
+	out.Frameworks = int(frameworks)
+
+	return out, nil
+}
+
+// ControlCreditsByRisk returns, per risk, the credits ADR 0003 consumes.
+//
+// Two tenancy guards, not one. The WHERE pins `risk_control_mappings.tenant_id`,
+// AND the join to `compliance_controls` carries `c.tenant_id = m.tenant_id`, so
+// a mapping row that pointed at another tenant's control (a corrupted row, a bad
+// import) still cannot pull that control's status into this tenant's score.
+//
+// HasEvidence is filled from the evidence library on the same terms the
+// compliance repository uses — accepted review, not expired. Getting this wrong
+// is silent: every implemented control would earn 0.70 instead of 1.00 and the
+// reveal would under-report the tenant's own posture.
+func (r *GormPostureRepository) ControlCreditsByRisk(ctx context.Context, tenantID uuid.UUID, riskIDs []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error) {
+	out := map[uuid.UUID][]scoring.ControlCredit{}
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to read control mappings")
+	}
+	if len(riskIDs) == 0 {
+		return out, nil
+	}
+
+	var rows []struct {
+		RiskID        uuid.UUID
+		Status        string
+		EvidenceCount int64
+	}
+	if err := r.db.WithContext(ctx).
+		Table("risk_control_mappings m").
+		Select(`m.risk_id AS risk_id,
+		        c.status AS status,
+		        (SELECT COUNT(*)
+		           FROM evidence_control_links l
+		           JOIN evidences e
+		             ON e.id = l.evidence_id
+		            AND e.tenant_id = l.tenant_id
+		            AND e.deleted_at IS NULL
+		          WHERE l.tenant_id = m.tenant_id
+		            AND l.control_id = c.id
+		            AND e.review = ?
+		            AND (e.valid_until IS NULL OR e.valid_until > ?)
+		        ) AS evidence_count`,
+			domain.EvidenceReviewAccepted, time.Now()).
+		Joins("JOIN compliance_controls c ON c.id = m.control_id AND c.tenant_id = m.tenant_id AND c.deleted_at IS NULL").
+		Where("m.tenant_id = ? AND m.risk_id IN ? AND m.deleted_at IS NULL", tenantID, riskIDs).
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to read control mappings: %w", err)
+	}
+
+	for _, row := range rows {
+		out[row.RiskID] = append(out[row.RiskID], scoring.ControlCredit{
+			Status:      scoring.ParseControlCoverageStatus(row.Status),
+			HasEvidence: row.EvidenceCount > 0,
+		})
+	}
+	return out, nil
+}
+
+// RecognitionCounts answers "what does OpenRisk already know about us" for the
+// tenant configured before any of this shipped (criterion 9).
+//
+// Members are counted on `organization_id`, which is that table's own tenant
+// column — the same choice the activation backfill makes for the `team` step,
+// and deliberately not `tenant_id`, which `organization_members` does not have.
+func (r *GormPostureRepository) RecognitionCounts(ctx context.Context, tenantID uuid.UUID) (domain.RecognitionCounts, error) {
+	var out domain.RecognitionCounts
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to read a recognition")
+	}
+
+	counts := []struct {
+		model  any
+		column string
+		into   *int
+	}{
+		{&domain.Risk{}, "tenant_id", &out.Risks},
+		{&domain.ComplianceFramework{}, "tenant_id", &out.Frameworks},
+		{&domain.ComplianceControl{}, "tenant_id", &out.Controls},
+		{&domain.Asset{}, "tenant_id", &out.Assets},
+		{&domain.OrganizationMember{}, "organization_id", &out.Members},
+	}
+
+	for _, c := range counts {
+		var n int64
+		if err := r.db.WithContext(ctx).
+			Model(c.model).
+			Where(c.column+" = ?", tenantID).
+			Count(&n).Error; err != nil {
+			return out, fmt.Errorf("failed to count %T: %w", c.model, err)
+		}
+		*c.into = int(n)
+	}
+	return out, nil
+}
+
+// OnboardingStepData resolves the tunnel's auto-skip decisions in one pass
+// (#438 criteria 2 and 3). Called ONCE per GET /onboarding/state; no step may
+// probe on mount.
+//
+// Tenant-scoped like everything else in this file, and user-scoped where the
+// question is about a person: the profile step belongs to the individual, so a
+// colleague having filled theirs in must not skip this user's.
+func (r *GormPostureRepository) OnboardingStepData(ctx context.Context, tenantID, userID uuid.UUID) (domain.OnboardingStepData, error) {
+	var out domain.OnboardingStepData
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant and a user are required to resolve onboarding steps")
+	}
+
+	// The organisation step asks for an industry and a size. Both must already be
+	// present to skip it: an organisation with a name and nothing else has not
+	// answered the question the step actually asks.
+	var org domain.Organization
+	if err := r.db.WithContext(ctx).
+		Select("industry", "size").
+		Where("id = ?", tenantID).
+		First(&org).Error; err != nil && err != gorm.ErrRecordNotFound {
+		return out, fmt.Errorf("failed to read the organization profile: %w", err)
+	}
+	out.HasOrganizationProfile = strings.TrimSpace(org.Industry) != "" && strings.TrimSpace(string(org.Size)) != ""
+
+	// The profile step asks for a name and a function. `job_title` is stored in
+	// User.Department — see onboarding_profile_writes.go, which is the writer this
+	// probe has to agree with. Reading a different column here would skip a step
+	// the wizard never filled, or ask again for one it did.
+	var user domain.User
+	if err := r.db.WithContext(ctx).
+		Select("full_name", "department").
+		Where("id = ?", userID).
+		First(&user).Error; err != nil && err != gorm.ErrRecordNotFound {
+		return out, fmt.Errorf("failed to read the user profile: %w", err)
+	}
+	out.HasUserProfile = strings.TrimSpace(user.FullName) != "" && strings.TrimSpace(user.Department) != ""
+
+	var frameworks int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceFramework{}).
+		Where("tenant_id = ?", tenantID).
+		Count(&frameworks).Error; err != nil {
+		return out, fmt.Errorf("failed to count frameworks: %w", err)
+	}
+	out.HasFramework = frameworks > 0
+
+	// More than the founding member. Exactly one member is every brand-new
+	// tenant, so `> 0` here would skip the team step for everybody.
+	var members int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.OrganizationMember{}).
+		Where("organization_id = ?", tenantID).
+		Count(&members).Error; err != nil {
+		return out, fmt.Errorf("failed to count members: %w", err)
+	}
+	out.HasTeam = members > 1
+
+	return out, nil
+}

--- a/backend/pkg/onboarding/starter.go
+++ b/backend/pkg/onboarding/starter.go
@@ -1,0 +1,533 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package onboarding
+
+import "sort"
+
+// ---------------------------------------------------------------------------
+// Starter risk catalogue — step 2 of the guided tunnel (#438).
+//
+// Deliberately NOT an extension of RiskSuggestion. Three things differ and each
+// one matters:
+//
+//   - It is BILINGUAL. RiskSuggestion carries French-only Title/Description, and
+//     widening it would touch every existing consumer for no benefit to them.
+//   - It is scoped by sector AND country, not sector alone.
+//   - StarterRisksFor always returns EXACTLY EightStarterRisks, because step 2's
+//     screen shows eight cards and asks the user to pick three. A screen whose
+//     card count depends on the sector is a screen that reflows.
+//
+// These statements become REAL ROWS in a customer's register, written with
+// domain.SourceStarter (D-012). That is why the copy is deliberately generic
+// about the organisation and specific about the mechanism: a statement the user
+// must edit before it is true would poison the register it lands in.
+//
+// Nothing here is a compliance claim. The sector scoping is an activation
+// device — it must never be worded as "your regulator requires this".
+// ---------------------------------------------------------------------------
+
+// EightStarterRisks is the size of the set step 2 renders. Named because the
+// number is a UI contract, not an arbitrary truncation.
+const EightStarterRisks = 8
+
+// StarterRisk is one pre-written risk statement the user may adopt.
+//
+// Probability is on [0,1] and Impact on [0,10] — the Score Engine's own scales,
+// so the number the user sees in step 4's matrix is the number that gets scored.
+type StarterRisk struct {
+	Key             string            `json:"key"`
+	TitleI18n       map[string]string `json:"title_i18n"`
+	DescriptionI18n map[string]string `json:"description_i18n"`
+	Probability     float64           `json:"probability"`
+	Impact          float64           `json:"impact"`
+	Category        string            `json:"category"`
+	Tags            []string          `json:"tags,omitempty"`
+	// Scope says where this statement came from, so the screen can group
+	// "typical of your sector" above "applies to any organisation" instead of
+	// showing eight equally weighted cards in storage order.
+	Scope StarterScope `json:"scope"`
+}
+
+// StarterScope is why a statement is in the set.
+type StarterScope string
+
+const (
+	ScopeSector  StarterScope = "sector"
+	ScopeRegion  StarterScope = "region"
+	ScopeGeneric StarterScope = "generic"
+)
+
+// Title returns the statement in the requested language, falling back to French
+// then to any available string. Never empty for a catalogue entry.
+func (s StarterRisk) Title(lang string) string { return pick(s.TitleI18n, lang) }
+
+// Description returns the body in the requested language, same fallback.
+func (s StarterRisk) Description(lang string) string { return pick(s.DescriptionI18n, lang) }
+
+func pick(m map[string]string, lang string) string {
+	if v, ok := m[lang]; ok && v != "" {
+		return v
+	}
+	if v, ok := m["fr"]; ok && v != "" {
+		return v
+	}
+	for _, v := range m {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Generic pool — true of any organisation with a network and employees.
+// Six entries, so the padding below can always reach eight.
+// ---------------------------------------------------------------------------
+
+var starterGeneric = []StarterRisk{
+	{
+		Key: "starter_admin_credentials",
+		TitleI18n: map[string]string{
+			"fr": "Compromission d'un compte à privilèges",
+			"en": "Compromise of a privileged account",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Un compte administrateur est compromis par hameçonnage, mot de passe réutilisé ou absence de second facteur, ouvrant un accès étendu au système d'information.",
+			"en": "An administrator account is compromised through phishing, a reused password or a missing second factor, opening broad access to the information system.",
+		},
+		Probability: 0.35, Impact: 8.5, Category: "access_control",
+		Tags: []string{"identity", "privilege"},
+	},
+	{
+		Key: "starter_ransomware",
+		TitleI18n: map[string]string{
+			"fr": "Chiffrement des systèmes par rançongiciel",
+			"en": "Systems encrypted by ransomware",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Un rançongiciel chiffre les serveurs de production et les sauvegardes accessibles depuis le réseau, interrompant l'activité jusqu'à une restauration complète.",
+			"en": "Ransomware encrypts production servers and any backups reachable from the network, halting operations until a full restore completes.",
+		},
+		Probability: 0.30, Impact: 9.5, Category: "availability",
+		Tags: []string{"ransomware", "continuity"},
+	},
+	{
+		Key: "starter_customer_data_leak",
+		TitleI18n: map[string]string{
+			"fr": "Fuite de données personnelles de clients",
+			"en": "Leak of customer personal data",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Des données personnelles de clients sont exposées ou exfiltrées, déclenchant une obligation de notification et une atteinte durable à la réputation.",
+			"en": "Customer personal data is exposed or exfiltrated, triggering a notification obligation and lasting reputational damage.",
+		},
+		Probability: 0.30, Impact: 9.0, Category: "data_protection",
+		Tags: []string{"personal data", "confidentiality"},
+	},
+	{
+		Key: "starter_third_party_outage",
+		TitleI18n: map[string]string{
+			"fr": "Défaillance d'un prestataire critique",
+			"en": "Failure of a critical third party",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Un fournisseur dont dépend un service essentiel devient indisponible ou est compromis, sans solution de repli immédiate.",
+			"en": "A supplier an essential service depends on becomes unavailable or is compromised, with no immediate fallback.",
+		},
+		Probability: 0.25, Impact: 7.5, Category: "third_party",
+		Tags: []string{"supplier", "dependency"},
+	},
+	{
+		Key: "starter_departing_employee",
+		TitleI18n: map[string]string{
+			"fr": "Accès maintenu après un départ",
+			"en": "Access left active after a departure",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Les accès d'une personne ayant quitté l'organisation restent actifs faute de procédure de sortie appliquée, laissant une porte ouverte que personne ne surveille.",
+			"en": "A departed person's access stays active because the offboarding procedure was not applied, leaving an open door nobody is watching.",
+		},
+		Probability: 0.40, Impact: 6.0, Category: "access_control",
+		Tags: []string{"offboarding", "identity"},
+	},
+	{
+		Key: "starter_backup_never_restored",
+		TitleI18n: map[string]string{
+			"fr": "Sauvegardes jamais testées en restauration",
+			"en": "Backups never tested by restoring them",
+		},
+		DescriptionI18n: map[string]string{
+			"fr": "Les sauvegardes existent mais aucune restauration complète n'a été éprouvée : leur validité n'est découverte qu'au moment où l'on en a besoin.",
+			"en": "Backups exist but no full restore has ever been exercised: whether they work is discovered at the moment they are needed.",
+		},
+		Probability: 0.45, Impact: 8.0, Category: "availability",
+		Tags: []string{"backup", "continuity"},
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Sector pool — three per sector, so sector ∪ region ∪ generic ≥ 8 always.
+// ---------------------------------------------------------------------------
+
+var starterBySector = map[string][]StarterRisk{
+	"banking": {
+		st("starter_core_banking_outage",
+			"Indisponibilité du système bancaire central", "Core banking system outage",
+			"Le core banking devient indisponible : opérations clients bloquées, obligation de déclaration au superviseur et exposition à des pénalités.",
+			"The core banking platform becomes unavailable: customer operations stop, the supervisor must be notified and penalties become possible.",
+			0.20, 9.5, "availability", "core banking", "continuity"),
+		st("starter_fraudulent_transfer",
+			"Virement frauduleux exécuté", "Fraudulent transfer executed",
+			"Un ordre de virement frauduleux est exécuté après usurpation du donneur d'ordre ou compromission d'un poste, entraînant une perte financière directe.",
+			"A fraudulent transfer order is executed after impersonation of the originator or compromise of a workstation, causing a direct financial loss.",
+			0.30, 8.0, "fraud", "fraud", "payment"),
+		st("starter_aml_screening_gap",
+			"Défaut de filtrage sur une relation d'affaires", "Screening gap on a business relationship",
+			"Une relation d'affaires entre en portefeuille sans que les contrôles d'entrée en relation aient été complets, exposant à une remédiation coûteuse.",
+			"A business relationship is onboarded without the entry controls having been completed, exposing the firm to costly remediation.",
+			0.25, 7.5, "compliance", "onboarding", "screening"),
+	},
+	"insurance": {
+		st("starter_claims_platform_outage",
+			"Indisponibilité de la plateforme de sinistres", "Claims platform outage",
+			"La plateforme de gestion des sinistres est indisponible : les déclarations s'accumulent et les délais contractuels de traitement sont dépassés.",
+			"The claims platform is unavailable: filings pile up and contractual handling deadlines are missed.",
+			0.25, 8.0, "availability", "claims", "continuity"),
+		st("starter_actuarial_data_integrity",
+			"Altération des données de tarification", "Corruption of pricing data",
+			"Les données alimentant la tarification sont altérées ou incomplètes, produisant des primes fausses sur un portefeuille entier avant détection.",
+			"Data feeding pricing is corrupted or incomplete, producing wrong premiums across a whole portfolio before anyone notices.",
+			0.20, 8.5, "data_integrity", "pricing", "data quality"),
+		st("starter_broker_portal_exposure",
+			"Exposition du portail courtiers", "Broker portal exposure",
+			"Le portail ouvert aux courtiers expose, par un défaut de cloisonnement, des dossiers appartenant à d'autres intermédiaires.",
+			"The broker-facing portal exposes, through a segregation flaw, files belonging to other intermediaries.",
+			0.20, 8.0, "data_protection", "portal", "segregation"),
+	},
+	"telecom": {
+		st("starter_network_core_outage",
+			"Panne du cœur de réseau", "Core network outage",
+			"Une défaillance du cœur de réseau interrompt le service pour une région entière, avec des engagements de qualité de service à honorer.",
+			"A core network failure interrupts service for an entire region, against quality-of-service commitments that still stand.",
+			0.20, 9.5, "availability", "network", "continuity"),
+		st("starter_sim_swap",
+			"Détournement de carte SIM", "SIM swap fraud",
+			"Un attaquant obtient le transfert d'un numéro vers une carte qu'il contrôle et intercepte les codes d'authentification de l'abonné.",
+			"An attacker has a number transferred to a card they control and intercepts the subscriber's authentication codes.",
+			0.35, 7.5, "fraud", "sim", "identity"),
+		st("starter_cdr_retention",
+			"Conservation excessive des données de trafic", "Excessive retention of traffic data",
+			"Les données de trafic sont conservées au-delà de la durée nécessaire, augmentant la surface exposée en cas d'intrusion.",
+			"Traffic data is kept beyond the necessary period, enlarging the surface exposed if an intrusion occurs.",
+			0.35, 6.5, "data_protection", "retention", "privacy"),
+	},
+	"health": {
+		st("starter_patient_record_exposure",
+			"Exposition de dossiers patients", "Exposure of patient records",
+			"Des dossiers médicaux sont accessibles à des personnes non habilitées, faute de cloisonnement par service ou par motif de consultation.",
+			"Medical records are reachable by people who should not see them, for want of segregation by department or by reason for access.",
+			0.30, 9.5, "data_protection", "health data", "confidentiality"),
+		st("starter_biomedical_device_offline",
+			"Indisponibilité d'un équipement biomédical connecté", "Connected biomedical device unavailable",
+			"Un équipement biomédical connecté devient inutilisable après une panne réseau ou une mise à jour, interrompant une activité de soins.",
+			"A connected biomedical device becomes unusable after a network failure or an update, interrupting clinical activity.",
+			0.25, 9.0, "availability", "medical device", "continuity"),
+		st("starter_shared_clinical_account",
+			"Comptes cliniques partagés", "Shared clinical accounts",
+			"Un compte est partagé au sein d'un service : aucune action n'est imputable à une personne, ce qui rend toute investigation impossible.",
+			"An account is shared inside a department: no action is attributable to a person, which makes any investigation impossible.",
+			0.45, 7.0, "access_control", "traceability", "identity"),
+	},
+	"public": {
+		st("starter_citizen_service_outage",
+			"Interruption d'un téléservice", "Citizen service outage",
+			"Un téléservice devient indisponible pendant une période de forte affluence, sans procédure de repli pour les usagers.",
+			"An online public service becomes unavailable during a peak period, with no fallback procedure for citizens.",
+			0.30, 8.0, "availability", "public service", "continuity"),
+		st("starter_records_tampering",
+			"Altération d'un registre administratif", "Tampering with an administrative record",
+			"Une donnée d'un registre administratif est modifiée sans trace exploitable, rendant la version faisant foi indéterminable.",
+			"A record in an administrative register is altered with no usable trace, making the authoritative version impossible to establish.",
+			0.20, 8.5, "data_integrity", "records", "traceability"),
+		st("starter_legacy_unpatched",
+			"Application héritée sans correctifs", "Unpatched legacy application",
+			"Une application héritée reste en production sans correctifs disponibles, son remplacement étant reporté d'exercice en exercice.",
+			"A legacy application stays in production with no patches available, its replacement deferred from one budget year to the next.",
+			0.45, 7.5, "vulnerability", "legacy", "patching"),
+	},
+	"energy": {
+		st("starter_ot_it_bridge",
+			"Passerelle non maîtrisée entre bureautique et industriel", "Uncontrolled bridge between office and industrial networks",
+			"Une liaison non maîtrisée entre le réseau bureautique et le réseau industriel permet à une compromission bureautique d'atteindre la conduite.",
+			"An uncontrolled link between the office network and the industrial network lets an office compromise reach operational control.",
+			0.25, 9.5, "network", "OT", "segregation"),
+		st("starter_scada_credentials",
+			"Identifiants par défaut sur un équipement de conduite", "Default credentials on a control device",
+			"Un équipement de conduite conserve ses identifiants d'usine, documentés publiquement par le constructeur.",
+			"A control device keeps its factory credentials, publicly documented by the manufacturer.",
+			0.35, 9.0, "access_control", "SCADA", "credentials"),
+		st("starter_grid_data_loss",
+			"Perte des données de comptage", "Loss of metering data",
+			"Les données de comptage d'une période sont perdues, empêchant la facturation et la reconstitution des consommations.",
+			"Metering data for a period is lost, preventing billing and any reconstruction of consumption.",
+			0.20, 7.5, "data_integrity", "metering", "billing"),
+	},
+	"retail": {
+		st("starter_pos_compromise",
+			"Compromission des terminaux de paiement", "Point-of-sale compromise",
+			"Les terminaux de paiement en magasin sont compromis et les données de carte capturées pendant plusieurs semaines avant détection.",
+			"In-store payment terminals are compromised and card data is captured for weeks before detection.",
+			0.25, 9.0, "fraud", "payment", "PCI"),
+		st("starter_peak_traffic_outage",
+			"Effondrement du site en période de pointe", "Storefront collapse under peak traffic",
+			"Le site de vente s'effondre lors d'un pic commercial : le chiffre d'affaires de la journée est perdu et ne se rattrape pas.",
+			"The storefront collapses during a commercial peak: the day's revenue is lost and is not recovered later.",
+			0.35, 8.0, "availability", "peak", "revenue"),
+		st("starter_supplier_data_sharing",
+			"Partage excessif de données avec un prestataire", "Excessive data sharing with a provider",
+			"Un prestataire marketing reçoit plus de données clients que sa mission ne le justifie, sans encadrement contractuel correspondant.",
+			"A marketing provider receives more customer data than its mandate justifies, with no matching contractual framing.",
+			0.40, 6.5, "third_party", "supplier", "minimisation"),
+	},
+	"tech": {
+		st("starter_secret_in_repository",
+			"Secret exposé dans un dépôt de code", "Secret exposed in a code repository",
+			"Une clé d'API ou un identifiant de production est commité dans un dépôt et reste exploitable dans l'historique après suppression.",
+			"An API key or production credential is committed to a repository and stays usable in the history after deletion.",
+			0.45, 8.5, "access_control", "secrets", "source code"),
+		st("starter_tenant_isolation_flaw",
+			"Défaut d'isolation entre clients", "Tenant isolation flaw",
+			"Un défaut d'isolation permet à un client d'atteindre les données d'un autre, ce qui met en cause le produit lui-même et non une donnée isolée.",
+			"An isolation flaw lets one customer reach another's data, which calls the product itself into question rather than one record.",
+			0.20, 9.5, "data_protection", "multi-tenant", "isolation"),
+		st("starter_dependency_supply_chain",
+			"Dépendance tierce compromise", "Compromised third-party dependency",
+			"Une dépendance open source intégrée au produit est compromise en amont et distribuée à tous les clients avec la version suivante.",
+			"An open-source dependency built into the product is compromised upstream and shipped to every customer with the next release.",
+			0.20, 9.0, "third_party", "supply chain", "dependency"),
+	},
+	"industry": {
+		st("starter_production_line_halt",
+			"Arrêt d'une ligne de production", "Production line halt",
+			"Une ligne de production s'arrête sur défaillance du système de pilotage, avec un coût par heure d'arrêt et des engagements de livraison à tenir.",
+			"A production line stops on a control-system failure, at a cost per hour of downtime and against delivery commitments that still stand.",
+			0.25, 9.0, "availability", "production", "continuity"),
+		st("starter_warehouse_stock_integrity",
+			"Écart entre stock physique et stock système", "Gap between physical and system stock",
+			"Le stock enregistré diverge du stock réel sans réconciliation, faussant les engagements commerciaux et les approvisionnements.",
+			"Recorded stock diverges from actual stock with no reconciliation, distorting both commercial commitments and replenishment.",
+			0.40, 6.5, "data_integrity", "stock", "logistics"),
+		st("starter_design_theft",
+			"Exfiltration de plans industriels", "Exfiltration of industrial designs",
+			"Des plans ou spécifications de fabrication sont exfiltrés, transférant un avantage concurrentiel construit sur plusieurs années.",
+			"Manufacturing designs or specifications are exfiltrated, transferring a competitive advantage built over years.",
+			0.20, 8.5, "data_protection", "intellectual property", "confidentiality"),
+	},
+	"other": {
+		st("starter_no_asset_inventory",
+			"Absence d'inventaire des actifs", "No asset inventory",
+			"Aucun inventaire à jour des systèmes et des données n'existe : la surface à protéger n'est pas connue, donc pas protégeable.",
+			"No up-to-date inventory of systems and data exists: the surface to protect is not known, so it cannot be protected.",
+			0.50, 7.0, "governance", "inventory", "visibility"),
+		st("starter_no_incident_procedure",
+			"Absence de procédure d'incident", "No incident procedure",
+			"Aucune procédure de réponse n'est écrite : le premier incident se gère par improvisation, au moment le plus coûteux pour improviser.",
+			"No response procedure is written down: the first incident is handled by improvisation, at the most expensive possible moment to improvise.",
+			0.45, 7.5, "governance", "incident", "readiness"),
+		st("starter_shadow_it",
+			"Outils non validés en usage courant", "Unvetted tools in everyday use",
+			"Des outils non validés traitent des données de l'organisation, hors de toute revue de sécurité et de tout contrat.",
+			"Unvetted tools process organisational data, outside any security review and any contract.",
+			0.50, 6.5, "governance", "shadow IT", "third_party"),
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Region pool — two per regulatory region, keyed to the markets OpenRisk serves.
+//
+// These are worded as OPERATIONAL exposures, never as "your regulator requires
+// X". The sector and country scoping is an activation device; the compliance
+// claim belongs to the framework catalogue and to nothing else (#438).
+// ---------------------------------------------------------------------------
+
+var starterByRegion = map[string][]StarterRisk{
+	"cemac_uemoa": {
+		st("starter_supervisor_reporting_delay",
+			"Retard dans un reporting au superviseur", "Delay in a report to the supervisor",
+			"Un état périodique destiné au superviseur est produit en retard ou incomplet, faute de collecte fiable à la source.",
+			"A periodic return owed to the supervisor is produced late or incomplete, for want of reliable collection at the source.",
+			0.35, 7.5, "compliance", "reporting", "supervision"),
+		st("starter_cross_border_data",
+			"Hébergement de données hors du pays d'exercice", "Data hosted outside the country of operation",
+			"Des données d'exploitation sont hébergées hors du pays d'exercice sans que les conditions de cet hébergement aient été établies.",
+			"Operational data is hosted outside the country of operation without the conditions of that hosting having been established.",
+			0.30, 7.0, "data_protection", "hosting", "cross-border"),
+	},
+	"eu": {
+		st("starter_breach_notification_delay",
+			"Notification de violation hors délai", "Breach notification out of time",
+			"Une violation de données est qualifiée trop tard pour que la notification parte dans le délai attendu, faute de détection et de chaîne de décision.",
+			"A data breach is qualified too late for the notification to leave within the expected window, for want of detection and a decision chain.",
+			0.30, 8.0, "data_protection", "notification", "detection"),
+		st("starter_processor_oversight",
+			"Sous-traitant non suivi", "Unmonitored processor",
+			"Un sous-traitant traite des données personnelles sans revue périodique ni preuve de ses propres mesures.",
+			"A processor handles personal data with no periodic review and no evidence of its own measures.",
+			0.40, 6.5, "third_party", "processor", "oversight"),
+	},
+	"maghreb": {
+		st("starter_local_hosting_requirement",
+			"Localisation des données non établie", "Data location not established",
+			"L'organisation ne sait pas établir où sont hébergées certaines de ses données, ce qui empêche toute réponse à une demande d'un tiers habilité.",
+			"The organisation cannot establish where some of its data is hosted, which makes any answer to an authorised third party impossible.",
+			0.35, 7.0, "data_protection", "hosting", "traceability"),
+		st("starter_bilingual_records",
+			"Documentation non disponible en langue locale", "Documentation unavailable in the local language",
+			"La documentation de sécurité n'existe que dans une langue, ce qui la rend inutilisable par une partie des équipes qui doivent l'appliquer.",
+			"Security documentation exists in one language only, making it unusable by part of the teams expected to apply it.",
+			0.40, 5.5, "governance", "documentation", "language"),
+	},
+	"north_america": {
+		st("starter_state_breach_patchwork",
+			"Obligations de notification hétérogènes", "Heterogeneous notification obligations",
+			"L'organisation opère dans plusieurs juridictions aux obligations de notification différentes, sans cartographie de celles qui s'appliquent.",
+			"The organisation operates across jurisdictions with differing notification obligations, with no map of which ones apply.",
+			0.35, 7.0, "compliance", "notification", "multi-jurisdiction"),
+		st("starter_vendor_soc2_gap",
+			"Absence d'assurance indépendante sur un prestataire", "No independent assurance on a provider",
+			"Un prestataire hébergeant des données sensibles ne fournit aucune assurance indépendante sur ses contrôles.",
+			"A provider hosting sensitive data supplies no independent assurance over its controls.",
+			0.35, 6.5, "third_party", "assurance", "supplier"),
+	},
+}
+
+// countryRegion maps an ISO-3166 alpha-2 country to its starter region.
+var countryRegion = map[string]string{
+	// CEMAC
+	"CM": "cemac_uemoa", "GA": "cemac_uemoa", "CG": "cemac_uemoa",
+	"TD": "cemac_uemoa", "CF": "cemac_uemoa", "GQ": "cemac_uemoa",
+	// UEMOA
+	"SN": "cemac_uemoa", "CI": "cemac_uemoa", "BJ": "cemac_uemoa",
+	"BF": "cemac_uemoa", "ML": "cemac_uemoa", "NE": "cemac_uemoa",
+	"TG": "cemac_uemoa", "GW": "cemac_uemoa",
+	// Maghreb
+	"MA": "maghreb", "DZ": "maghreb", "TN": "maghreb",
+	// North America
+	"CA": "north_america", "US": "north_america",
+}
+
+// regionFor resolves a country to its starter region, "" when unknown. EU
+// membership is read from the existing euCountries map rather than duplicated.
+func regionFor(country string) string {
+	c := normaliseCountry(country)
+	if r, ok := countryRegion[c]; ok {
+		return r
+	}
+	if euCountries[c] {
+		return "eu"
+	}
+	return ""
+}
+
+// StarterRisksFor returns EXACTLY EightStarterRisks statements for a (sector,
+// country) pair, most specific first: the sector's own, then the region's, then
+// the generic pool as padding.
+//
+// Deterministic and de-duplicated by key. An unknown sector falls back to
+// "other" — never to an empty screen, because step 2 has no empty state that
+// makes sense: a tunnel that asks the user to pick three of nothing is broken.
+func StarterRisksFor(sector, country string) []StarterRisk {
+	out := make([]StarterRisk, 0, EightStarterRisks)
+	seen := map[string]bool{}
+
+	add := func(pool []StarterRisk, scope StarterScope) {
+		for _, r := range pool {
+			if len(out) >= EightStarterRisks || seen[r.Key] {
+				continue
+			}
+			seen[r.Key] = true
+			r.Scope = scope
+			out = append(out, r)
+		}
+	}
+
+	sectorPool, ok := starterBySector[sector]
+	if !ok {
+		sectorPool = starterBySector["other"]
+	}
+	add(sectorPool, ScopeSector)
+	add(starterByRegion[regionFor(country)], ScopeRegion)
+	add(starterGeneric, ScopeGeneric)
+	// The generic pool alone cannot be short: sector (3) + generic (6) = 9 ≥ 8
+	// even with no region. The loop above is the only truncation.
+	return out
+}
+
+// StarterRiskByKey looks one statement up across every pool. Used by the write
+// path to re-read the canonical statement rather than trusting the client's copy
+// of it — a client that could post arbitrary text would be an unvalidated write
+// into a customer's risk register.
+func StarterRiskByKey(key string) (StarterRisk, bool) {
+	for _, pool := range starterBySector {
+		for _, r := range pool {
+			if r.Key == key {
+				r.Scope = ScopeSector
+				return r, true
+			}
+		}
+	}
+	for _, pool := range starterByRegion {
+		for _, r := range pool {
+			if r.Key == key {
+				r.Scope = ScopeRegion
+				return r, true
+			}
+		}
+	}
+	for _, r := range starterGeneric {
+		if r.Key == key {
+			r.Scope = ScopeGeneric
+			return r, true
+		}
+	}
+	return StarterRisk{}, false
+}
+
+// KnownStarterSectorKeys returns the sector keys carrying a bespoke starter set,
+// sorted. Used by the tests; nothing depends on it at runtime.
+func KnownStarterSectorKeys() []string {
+	keys := make([]string, 0, len(starterBySector))
+	for k := range starterBySector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// KnownStarterRegionKeys returns the region keys, sorted. Tests only.
+func KnownStarterRegionKeys() []string {
+	keys := make([]string, 0, len(starterByRegion))
+	for k := range starterByRegion {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// st builds a StarterRisk from positional arguments. A constructor rather than
+// literals because the catalogue is long and the bilingual maps triple its
+// height; the field order here is (key, fr title, en title, fr body, en body).
+func st(key, frTitle, enTitle, frBody, enBody string, p, i float64, category string, tags ...string) StarterRisk {
+	return StarterRisk{
+		Key:             key,
+		TitleI18n:       map[string]string{"fr": frTitle, "en": enTitle},
+		DescriptionI18n: map[string]string{"fr": frBody, "en": enBody},
+		Probability:     p,
+		Impact:          i,
+		Category:        category,
+		Tags:            tags,
+	}
+}

--- a/backend/pkg/onboarding/starter_test.go
+++ b/backend/pkg/onboarding/starter_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package onboarding
+
+import (
+	"strings"
+	"testing"
+)
+
+// Step 2 renders eight cards and asks for three. A set whose size depends on the
+// sector is a screen that reflows, so the count is a contract, not a hope.
+func TestStarterRisksFor_AlwaysReturnsExactlyEight(t *testing.T) {
+	countries := []string{"CM", "SN", "FR", "BE", "MA", "CA", "US", "ZZ", "", "cm", "fr"}
+	sectors := append(KnownStarterSectorKeys(), "unknown_sector", "")
+
+	for _, sector := range sectors {
+		for _, country := range countries {
+			got := StarterRisksFor(sector, country)
+			if len(got) != EightStarterRisks {
+				t.Errorf("StarterRisksFor(%q, %q) returned %d, want %d",
+					sector, country, len(got), EightStarterRisks)
+			}
+			seen := map[string]bool{}
+			for _, r := range got {
+				if seen[r.Key] {
+					t.Errorf("StarterRisksFor(%q, %q) repeated %q", sector, country, r.Key)
+				}
+				seen[r.Key] = true
+			}
+		}
+	}
+}
+
+// Most specific first: a banker must not have to scroll past six generic
+// statements to find the one about their core banking platform.
+func TestStarterRisksFor_OrdersSectorThenRegionThenGeneric(t *testing.T) {
+	got := StarterRisksFor("banking", "CM")
+
+	rank := map[StarterScope]int{ScopeSector: 0, ScopeRegion: 1, ScopeGeneric: 2}
+	last := -1
+	for _, r := range got {
+		cur, ok := rank[r.Scope]
+		if !ok {
+			t.Fatalf("%q carries no scope", r.Key)
+		}
+		if cur < last {
+			t.Errorf("%q (%s) appears after a wider scope", r.Key, r.Scope)
+		}
+		last = cur
+	}
+
+	if got[0].Scope != ScopeSector {
+		t.Errorf("first card is %s, want the sector's own", got[0].Scope)
+	}
+	// CM is CEMAC, so a region statement must be present.
+	var regions int
+	for _, r := range got {
+		if r.Scope == ScopeRegion {
+			regions++
+		}
+	}
+	if regions == 0 {
+		t.Error("a CEMAC country produced no region-scoped statement")
+	}
+}
+
+// The country actually changes the set — otherwise the scoping is decoration.
+func TestStarterRisksFor_CountryChangesTheSet(t *testing.T) {
+	cm := keysOf(StarterRisksFor("banking", "CM"))
+	fr := keysOf(StarterRisksFor("banking", "FR"))
+	if cm == fr {
+		t.Error("CM and FR produced the same eight statements; the region scoping does nothing")
+	}
+
+	// An unknown country still works, and falls back to sector + generic.
+	unknown := StarterRisksFor("banking", "ZZ")
+	for _, r := range unknown {
+		if r.Scope == ScopeRegion {
+			t.Errorf("unknown country produced a region statement: %q", r.Key)
+		}
+	}
+}
+
+// Step 2 has no empty state that makes sense: "pick three of nothing" is broken.
+func TestStarterRisksFor_UnknownSectorFallsBackNotEmpty(t *testing.T) {
+	got := StarterRisksFor("aerospace_mining_whatever", "")
+	if len(got) != EightStarterRisks {
+		t.Fatalf("unknown sector returned %d statements", len(got))
+	}
+	other := keysOf(StarterRisksFor("other", ""))
+	if keysOf(got) != other {
+		t.Errorf("unknown sector did not fall back to \"other\"")
+	}
+}
+
+// DoD: seeded FR + EN. These rows land in a customer's register, so a missing
+// translation would write a French statement into an English tenant's data.
+func TestStarterCatalogue_IsCompleteInBothLanguages(t *testing.T) {
+	check := func(label string, pool []StarterRisk) {
+		for _, r := range pool {
+			if r.Key == "" || !strings.HasPrefix(r.Key, "starter_") {
+				t.Errorf("%s: key %q must be prefixed starter_", label, r.Key)
+			}
+			for _, lang := range []string{"fr", "en"} {
+				if strings.TrimSpace(r.TitleI18n[lang]) == "" {
+					t.Errorf("%s/%s: missing %s title", label, r.Key, lang)
+				}
+				if strings.TrimSpace(r.DescriptionI18n[lang]) == "" {
+					t.Errorf("%s/%s: missing %s description", label, r.Key, lang)
+				}
+			}
+			if r.Probability < 0 || r.Probability > 1 {
+				t.Errorf("%s/%s: probability %v outside [0,1]", label, r.Key, r.Probability)
+			}
+			if r.Impact < 0 || r.Impact > 10 {
+				t.Errorf("%s/%s: impact %v outside [0,10]", label, r.Key, r.Impact)
+			}
+			if r.Category == "" {
+				t.Errorf("%s/%s: no category", label, r.Key)
+			}
+		}
+	}
+
+	for _, k := range KnownStarterSectorKeys() {
+		check("sector:"+k, starterBySector[k])
+		if len(starterBySector[k]) < 3 {
+			t.Errorf("sector %q has %d statements; 3 are needed to reach eight without padding-only sets",
+				k, len(starterBySector[k]))
+		}
+	}
+	for _, k := range KnownStarterRegionKeys() {
+		check("region:"+k, starterByRegion[k])
+	}
+	check("generic", starterGeneric)
+
+	if len(starterGeneric) < EightStarterRisks-3 {
+		t.Errorf("generic pool holds %d; sector(3) + generic must reach %d",
+			len(starterGeneric), EightStarterRisks)
+	}
+}
+
+// Every sector offered in the wizard must have a starter set, or a user picks a
+// sector in step 1 and gets somebody else's risks in step 2.
+func TestStarterCatalogue_CoversEverySelectableSector(t *testing.T) {
+	for _, s := range Sectors() {
+		if _, ok := starterBySector[s.Key]; !ok {
+			t.Errorf("sector %q is selectable but has no starter set", s.Key)
+		}
+	}
+}
+
+// Keys must be globally unique: StarterRiskByKey is the write path's guard
+// against a client posting arbitrary text into a risk register, and a duplicate
+// key would make it ambiguous.
+func TestStarterRiskByKey_UniqueAndResolvable(t *testing.T) {
+	seen := map[string]string{}
+	var all []StarterRisk
+	for _, k := range KnownStarterSectorKeys() {
+		all = append(all, starterBySector[k]...)
+	}
+	for _, k := range KnownStarterRegionKeys() {
+		all = append(all, starterByRegion[k]...)
+	}
+	all = append(all, starterGeneric...)
+
+	for _, r := range all {
+		if where, dup := seen[r.Key]; dup {
+			t.Errorf("key %q appears twice (%s)", r.Key, where)
+		}
+		seen[r.Key] = r.Key
+
+		got, ok := StarterRiskByKey(r.Key)
+		if !ok {
+			t.Errorf("StarterRiskByKey(%q) did not resolve", r.Key)
+			continue
+		}
+		if got.Title("fr") != r.Title("fr") {
+			t.Errorf("StarterRiskByKey(%q) returned a different statement", r.Key)
+		}
+	}
+
+	if _, ok := StarterRiskByKey("starter_does_not_exist"); ok {
+		t.Error("an unknown key must not resolve — that is the write path's guard")
+	}
+}
+
+func TestStarterRisk_LanguageFallback(t *testing.T) {
+	r := StarterRisk{
+		TitleI18n:       map[string]string{"fr": "Titre", "en": "Title"},
+		DescriptionI18n: map[string]string{"fr": "Corps"},
+	}
+	if got := r.Title("en"); got != "Title" {
+		t.Errorf("Title(en) = %q", got)
+	}
+	if got := r.Title("de"); got != "Titre" {
+		t.Errorf("Title(de) must fall back to French, got %q", got)
+	}
+	if got := r.Description("en"); got != "Corps" {
+		t.Errorf("Description(en) must fall back to French, got %q", got)
+	}
+	if got := (StarterRisk{}).Title("fr"); got != "" {
+		t.Errorf("an empty statement must yield an empty title, got %q", got)
+	}
+}
+
+func keysOf(rs []StarterRisk) string {
+	parts := make([]string, len(rs))
+	for i, r := range rs {
+		parts[i] = r.Key
+	}
+	return strings.Join(parts, ",")
+}

--- a/backend/pkg/scoring/residual.go
+++ b/backend/pkg/scoring/residual.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package scoring
+
+import "math"
+
+// ---------------------------------------------------------------------------
+// Residual risk from control coverage — ADR 0003, decided by D-013.
+//
+// ADDITIVE, like SmartScore. `Risk.Score` and the P×I×AC engine above are frozen
+// and appear nowhere in this file's output path: this computes how much of an
+// already-computed inherent score the tenant's implemented controls have earned
+// back, and nothing else.
+//
+// Pure and stdlib-only on purpose. It takes credits the caller has already
+// fetched, so TENANT ISOLATION IS THE CALLER'S DUTY — `risk_control_mappings`
+// carries `tenant_id` and sits behind a tenant-scoped port, and a formula that
+// took a repository could not be tested by hand the way this one can.
+// ---------------------------------------------------------------------------
+
+// ResidualFormulaVersion is stamped on every result and must be persisted
+// alongside any stored residual. A later formula gets "residual-v2"; a stored
+// v1 figure is never silently reinterpreted under v2 rules.
+const ResidualFormulaVersion = "residual-v1"
+
+// MaxEffectiveness caps how much of the inherent score a complete control set
+// can remove. It is a FLOOR ON THE RESIDUAL, not a cap on ambition: a fully
+// covered risk keeps 20% of its exposure, because a product that lets paperwork
+// drive a risk to zero teaches its users something false.
+const MaxEffectiveness = 0.80
+
+// ControlCoverageStatus is the implementation state of one mapped control. The
+// values mirror `domain.ControlStatus` deliberately as plain strings: `pkg` must
+// not import `internal/domain`, and the parse below is the seam.
+type ControlCoverageStatus string
+
+const (
+	ControlNotImplemented ControlCoverageStatus = "not_implemented"
+	ControlInProgress     ControlCoverageStatus = "in_progress"
+	ControlImplemented    ControlCoverageStatus = "implemented"
+	ControlNotApplicable  ControlCoverageStatus = "not_applicable"
+)
+
+// ParseControlCoverageStatus maps a raw status onto the vocabulary above.
+// Anything unrecognised is treated as NOT implemented: an unknown state is not
+// evidence of control, and the dangerous failure mode for a security score is
+// reading an absent signal as a good one.
+func ParseControlCoverageStatus(raw string) ControlCoverageStatus {
+	switch ControlCoverageStatus(raw) {
+	case ControlImplemented:
+		return ControlImplemented
+	case ControlInProgress:
+		return ControlInProgress
+	case ControlNotApplicable:
+		return ControlNotApplicable
+	default:
+		return ControlNotImplemented
+	}
+}
+
+// ControlCredit is one control mapped to the risk being scored.
+type ControlCredit struct {
+	Status ControlCoverageStatus
+	// HasEvidence discounts a control that is claimed but not proven. An auditor
+	// discounts it; so does this.
+	HasEvidence bool
+}
+
+// Credit is this control's contribution in [0,1]. A not-applicable control has
+// no credit AND no weight — see Coverage.
+func (c ControlCredit) Credit() float64 {
+	switch c.Status {
+	case ControlImplemented:
+		if c.HasEvidence {
+			return 1.0
+		}
+		return 0.70
+	case ControlInProgress:
+		return 0.30
+	default:
+		return 0.0
+	}
+}
+
+// Coverage is how much of the risk the mapped controls answer for.
+type Coverage struct {
+	// Measured is false when no APPLICABLE control is mapped. Effectiveness is
+	// then zero and the residual equals the inherent score — an absent signal
+	// must never read as a good one.
+	Measured bool `json:"measured"`
+	// Ratio ∈ [0,1] is Σ credit / applicable controls.
+	Ratio float64 `json:"ratio"`
+	// Effectiveness ∈ [0, MaxEffectiveness] is Ratio scaled by the cap.
+	Effectiveness float64 `json:"effectiveness"`
+	// Applicable and Total let a caller say "3 of 5 controls, 2 scoped out"
+	// without recounting the slice.
+	Applicable int `json:"applicable"`
+	Total      int `json:"total"`
+}
+
+// CoverageEffectiveness reduces a risk's mapped controls to one effectiveness.
+//
+// `not_applicable` is removed from the numerator AND the denominator: scoring a
+// deliberately scoped-out control as an uncovered one would punish a tenant for
+// scoping its framework correctly.
+func CoverageEffectiveness(credits []ControlCredit) Coverage {
+	cov := Coverage{Total: len(credits)}
+
+	var sum float64
+	for _, c := range credits {
+		if c.Status == ControlNotApplicable {
+			continue
+		}
+		cov.Applicable++
+		sum += c.Credit()
+	}
+	if cov.Applicable == 0 {
+		return cov
+	}
+
+	cov.Measured = true
+	cov.Ratio = clampUnit(sum / float64(cov.Applicable))
+	cov.Effectiveness = round3(MaxEffectiveness * cov.Ratio)
+	return cov
+}
+
+// Residual is one computed residual, on the Score Engine's own scale.
+type Residual struct {
+	// Inherent is the score handed in, echoed so a caller never has to hold two
+	// numbers to render "16 → 6".
+	Inherent float64 `json:"inherent"`
+	// Value is the residual, on the SAME scale and banded by the SAME thresholds
+	// as `Risk.Score`, so a residual and a score are always comparable.
+	Value float64          `json:"value"`
+	Level CriticalityLevel `json:"level"`
+	// Reduction is Inherent − Value, the number the reveal actually celebrates.
+	Reduction      float64  `json:"reduction"`
+	Coverage       Coverage `json:"coverage"`
+	FormulaVersion string   `json:"formula_version"`
+}
+
+// ResidualFromInherent applies a coverage to an inherent score.
+//
+// A negative inherent is clamped to zero rather than propagated: it cannot be
+// produced by the engine, and returning a negative residual would band as "low"
+// and read as good news.
+func ResidualFromInherent(inherent float64, cov Coverage) Residual {
+	if inherent < 0 {
+		inherent = 0
+	}
+	inherent = round3(inherent)
+
+	value := round3(inherent * (1 - cov.Effectiveness))
+	return Residual{
+		Inherent:       inherent,
+		Value:          value,
+		Level:          residualCriticality(value),
+		Reduction:      round3(inherent - value),
+		Coverage:       cov,
+		FormulaVersion: ResidualFormulaVersion,
+	}
+}
+
+// ComputeResidual is the one-call form: credits in, residual out.
+func ComputeResidual(inherent float64, credits []ControlCredit) Residual {
+	return ResidualFromInherent(inherent, CoverageEffectiveness(credits))
+}
+
+// residualCriticality bands a residual with the Score Engine's OWN thresholds.
+// Deliberately not `smartCriticality` (0–100 bands): a residual lives on the
+// P×I×AC scale, and banding it on the wrong scale would call every residual low.
+func residualCriticality(score float64) CriticalityLevel {
+	score = round3(score)
+	switch {
+	case score >= 7.000:
+		return CriticalityCritical
+	case score >= 4.000:
+		return CriticalityHigh
+	case score >= 2.000:
+		return CriticalityMedium
+	default:
+		return CriticalityLow
+	}
+}
+
+func round3(v float64) float64 { return math.Round(v*1000) / 1000 }

--- a/backend/pkg/scoring/residual_test.go
+++ b/backend/pkg/scoring/residual_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scoring
+
+import "testing"
+
+func TestCoverageEffectiveness_CreditTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		credit ControlCredit
+		want   float64
+	}{
+		{"implemented with evidence", ControlCredit{ControlImplemented, true}, 1.0},
+		{"implemented without evidence", ControlCredit{ControlImplemented, false}, 0.70},
+		{"in progress", ControlCredit{ControlInProgress, false}, 0.30},
+		{"not implemented", ControlCredit{ControlNotImplemented, false}, 0.0},
+		{"not applicable", ControlCredit{ControlNotApplicable, false}, 0.0},
+	}
+	for _, tc := range cases {
+		if got := tc.credit.Credit(); got != tc.want {
+			t.Errorf("%s: credit = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// not_applicable leaves the denominator as well as the numerator: a tenant that
+// scopes its framework correctly must not be scored as if it had failed.
+func TestCoverageEffectiveness_NotApplicableIsExcludedFromBothSides(t *testing.T) {
+	withScopeOuts := CoverageEffectiveness([]ControlCredit{
+		{ControlImplemented, true},
+		{ControlNotApplicable, false},
+		{ControlNotApplicable, false},
+	})
+	alone := CoverageEffectiveness([]ControlCredit{{ControlImplemented, true}})
+
+	if withScopeOuts.Ratio != alone.Ratio {
+		t.Errorf("scoped-out controls changed the ratio: %v vs %v", withScopeOuts.Ratio, alone.Ratio)
+	}
+	if withScopeOuts.Applicable != 1 || withScopeOuts.Total != 3 {
+		t.Errorf("applicable/total = %d/%d, want 1/3", withScopeOuts.Applicable, withScopeOuts.Total)
+	}
+	if withScopeOuts.Effectiveness != MaxEffectiveness {
+		t.Errorf("full coverage effectiveness = %v, want %v", withScopeOuts.Effectiveness, MaxEffectiveness)
+	}
+}
+
+// The rule that matters most in a security score: an absent signal must never
+// read as a good one.
+func TestCoverageEffectiveness_NoApplicableControlIsNotGoodNews(t *testing.T) {
+	for _, credits := range [][]ControlCredit{
+		nil,
+		{},
+		{{ControlNotApplicable, false}},
+	} {
+		cov := CoverageEffectiveness(credits)
+		if cov.Measured {
+			t.Errorf("%v: coverage must not be reported as measured", credits)
+		}
+		if cov.Effectiveness != 0 {
+			t.Errorf("%v: effectiveness = %v, want 0", credits, cov.Effectiveness)
+		}
+
+		res := ResidualFromInherent(16, cov)
+		if res.Value != 16 {
+			t.Errorf("%v: residual = %v, want the inherent 16 untouched", credits, res.Value)
+		}
+		if res.Reduction != 0 {
+			t.Errorf("%v: reduction = %v, want 0", credits, res.Reduction)
+		}
+	}
+}
+
+// MaxEffectiveness is a floor on the residual. Full coverage must not reach zero,
+// whatever the inherent score is.
+func TestResidual_FullCoverageNeverReachesZero(t *testing.T) {
+	full := CoverageEffectiveness([]ControlCredit{
+		{ControlImplemented, true},
+		{ControlImplemented, true},
+	})
+	if full.Ratio != 1 {
+		t.Fatalf("precondition: ratio = %v, want 1", full.Ratio)
+	}
+
+	for _, inherent := range []float64{30, 16, 7.5, 2, 0.5} {
+		res := ResidualFromInherent(inherent, full)
+		if res.Value <= 0 && inherent > 0 {
+			t.Errorf("inherent %v: residual reached %v — the floor is gone", inherent, res.Value)
+		}
+		want := round3(inherent * (1 - MaxEffectiveness))
+		if res.Value != want {
+			t.Errorf("inherent %v: residual = %v, want %v", inherent, res.Value, want)
+		}
+	}
+}
+
+// A residual lives on the Score Engine's scale and must band on the Score
+// Engine's thresholds — banding it on the 0–100 SmartScore scale would call
+// every residual "low".
+func TestResidual_BandsOnTheScoreEngineThresholds(t *testing.T) {
+	none := Coverage{}
+	cases := []struct {
+		inherent float64
+		want     CriticalityLevel
+	}{
+		{7.0, CriticalityCritical},
+		{6.999, CriticalityHigh},
+		{4.0, CriticalityHigh},
+		{3.999, CriticalityMedium},
+		{2.0, CriticalityMedium},
+		{1.999, CriticalityLow},
+		{0, CriticalityLow},
+	}
+	for _, tc := range cases {
+		if got := ResidualFromInherent(tc.inherent, none).Level; got != tc.want {
+			t.Errorf("residual %v banded %q, want %q", tc.inherent, got, tc.want)
+		}
+	}
+}
+
+// The arithmetic a reader of the reveal must be able to check by hand.
+func TestComputeResidual_IsCheckableByHand(t *testing.T) {
+	// Two controls, one implemented and evidenced (1.0), one in progress (0.30).
+	// ratio = 1.30 / 2 = 0.65 · effectiveness = 0.80 × 0.65 = 0.52
+	// residual = 16 × (1 − 0.52) = 7.68
+	res := ComputeResidual(16, []ControlCredit{
+		{ControlImplemented, true},
+		{ControlInProgress, false},
+	})
+
+	if res.Coverage.Ratio != 0.65 {
+		t.Errorf("ratio = %v, want 0.65", res.Coverage.Ratio)
+	}
+	if res.Coverage.Effectiveness != 0.52 {
+		t.Errorf("effectiveness = %v, want 0.52", res.Coverage.Effectiveness)
+	}
+	if res.Value != 7.68 {
+		t.Errorf("residual = %v, want 7.68", res.Value)
+	}
+	if res.Reduction != 8.32 {
+		t.Errorf("reduction = %v, want 8.32", res.Reduction)
+	}
+	if res.Inherent != 16 {
+		t.Errorf("inherent echoed as %v, want 16", res.Inherent)
+	}
+	if res.FormulaVersion != ResidualFormulaVersion {
+		t.Errorf("formula version = %q, want %q", res.FormulaVersion, ResidualFormulaVersion)
+	}
+}
+
+// An unknown status is not evidence of control.
+func TestParseControlCoverageStatus_UnknownIsNotImplemented(t *testing.T) {
+	for _, raw := range []string{"", "IMPLEMENTED", "partially", "waived", "unknown"} {
+		if got := ParseControlCoverageStatus(raw); got != ControlNotImplemented {
+			t.Errorf("ParseControlCoverageStatus(%q) = %q, want %q", raw, got, ControlNotImplemented)
+		}
+	}
+	for _, raw := range []ControlCoverageStatus{
+		ControlImplemented, ControlInProgress, ControlNotApplicable, ControlNotImplemented,
+	} {
+		if got := ParseControlCoverageStatus(string(raw)); got != raw {
+			t.Errorf("ParseControlCoverageStatus(%q) = %q", raw, got)
+		}
+	}
+}
+
+// A negative inherent cannot come from the engine, but if one ever arrives it
+// must not band as "low" and read as good news.
+func TestResidual_NegativeInherentIsClamped(t *testing.T) {
+	res := ResidualFromInherent(-5, Coverage{})
+	if res.Inherent != 0 || res.Value != 0 {
+		t.Errorf("negative inherent produced %+v, want zeros", res)
+	}
+}
+
+// Risk.Score is frozen: nothing here may change what the engine returns.
+func TestResidual_LeavesTheScoreEngineUntouched(t *testing.T) {
+	e := NewEngine()
+	before, err := e.Calculate(0.8, 8, 2.5)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+
+	ComputeResidual(before, []ControlCredit{{ControlImplemented, true}})
+
+	after, err := e.Calculate(0.8, 8, 2.5)
+	if err != nil || after != before {
+		t.Errorf("engine moved from %v to %v (err %v)", before, after, err)
+	}
+}

--- a/docs/adr/0003-residual-risk-from-control-coverage.md
+++ b/docs/adr/0003-residual-risk-from-control-coverage.md
@@ -1,0 +1,152 @@
+# 0003 — Residual risk is derived from control coverage, additively
+
+Status: proposed — the approach is decided, the **constants need your sign-off**
+Proposed: 2026-09-10, on #438 (W1-05, PR 2)
+Decided by: D-013 (`docs/DECISIONS.md`), Option A
+Implemented by: #438
+
+## Context
+
+#438 replaces the post-wizard activation cliff with a guided tunnel whose last
+step shows the user something a spreadsheet cannot produce: *accept this control,
+and watch your exposure fall*. That requires a residual number, and D-013 decided
+it comes from `risk_control_mappings` rather than from a portfolio money figure.
+
+D-013 also fixed the shape of the answer: **additive, in the SmartScore mould.**
+`Risk.Score` from `pkg/scoring/engine.go` is frozen and is not in the output path
+of anything below.
+
+Three things were read rather than assumed, and two of them change the design the
+brief implied.
+
+**1. A residual already exists, and it is not the same one.**
+`internal/domain/scoring` (`compute.go`, `model.go`) already returns `Residual`,
+`ResidualBand` and `MitigationEffectiveness` on every `Result`. But it does not
+compute effectiveness — it *receives* it:
+
+```go
+// internal/domain/scoring/compute.go
+type RiskInput struct {
+    ...
+    // MitigationEffectiveness ∈ [0,1] drives the residual score.
+    MitigationEffectiveness float64
+}
+```
+
+Nothing in the codebase fills that field from control mappings. So the gap is not
+"there is no residual", it is **"nothing knows what effectiveness the tenant's
+controls have earned"**. Writing a second, competing residual number would give
+the product two answers to one question, which for a GRC tool is worse than
+having none.
+
+**2. There are two scales, and they must not be mixed.**
+`internal/domain/scoring` works on a canonical 0–100 scale where 100 is worst.
+`Risk.Score` and `Risk.ResidualRisk` (`internal/domain/risk.go:267`,
+`numeric(8,3)`) are on the Score Engine's own scale: `P × I × AC`, so 0–30. The
+tunnel's illustration in #438 — "16 down to 6" — is on the Score Engine scale;
+16 is not expressible on a 0–10 scale and is not a plausible 0–100 posture.
+
+**3. `not_applicable` exists and is not a failure.**
+`domain.ControlStatus` has four values (`internal/domain/compliance.go:19-22`):
+`not_implemented`, `in_progress`, `implemented`, `not_applicable`. Scoring a
+scoped-out control as an uncovered one would punish a tenant for correctly
+scoping its framework, which is the opposite of what a GRC product should teach.
+
+## Decision
+
+**A new pure function in `pkg/scoring` computes an effectiveness from control
+coverage, and the existing residual machinery consumes it.** We add an input to a
+model that already has a residual; we do not add a second residual.
+
+```go
+// pkg/scoring/residual.go — stdlib only, deterministic, no GORM, no Fiber.
+func CoverageEffectiveness(credits []ControlCredit) Coverage
+func ResidualFromInherent(inherent float64, c Coverage) Residual
+```
+
+### The formula
+
+Per mapped control, a credit in `[0,1]`:
+
+| Control status | Evidence attached | Credit | Why |
+|---|---|---|---|
+| `implemented` | yes | **1.00** | Implemented and provable |
+| `implemented` | no | **0.70** | Claimed, not evidenced — an auditor discounts it, so do we |
+| `in_progress` | — | **0.30** | Work started reduces exposure; it does not remove it |
+| `not_implemented` | — | **0.00** | — |
+| `not_applicable` | — | *excluded* | Removed from numerator **and** denominator |
+
+```
+coverage      = Σ credit / count(applicable controls)      ∈ [0,1]
+effectiveness = MaxEffectiveness × coverage                ∈ [0, 0.80]
+residual      = round(inherent × (1 − effectiveness), 3)
+```
+
+`MaxEffectiveness = 0.80` is a **floor on the residual, not a cap on ambition**: a
+fully covered risk keeps 20% of its inherent exposure. A product that lets a
+control set drive a risk to zero teaches its users that paperwork eliminates
+risk, and that is a lie a GRC tool must not tell. Twenty per cent is the constant
+this ADR asks you to accept or move.
+
+`residual` is on the **Score Engine's scale** and is banded by the Score Engine's
+own thresholds (`critical ≥ 7.0 · high ≥ 4.0 · medium ≥ 2.0 · low < 2.0`), so a
+residual and a score are always comparable and never need a conversion.
+
+With no applicable control mapped, `coverage` is undefined: `Coverage.Measured`
+is `false`, effectiveness is `0`, and **`residual == inherent`**. An absent
+signal must never read as a good one — the same rule `combine()` already applies
+by renormalising unavailable factors.
+
+### What stays frozen
+
+* `Risk.Score` and `pkg/scoring/engine.go` — untouched, not read by, not written
+  by anything here.
+* `SmartScore` and `pkg/scoring/smart.go` — untouched. Residual is a third,
+  independent additive view, exactly as SmartScore is a second.
+* `internal/domain/scoring`'s formula — untouched. It gains a *caller* that fills
+  `MitigationEffectiveness` honestly; its arithmetic does not change.
+
+### Versioning
+
+`ResidualFormulaVersion = "residual-v1"` is stamped on every computed result and
+persisted alongside any stored value. A later formula gets `residual-v2`; a
+stored `residual-v1` figure is never silently reinterpreted under v2 rules.
+
+## Consequences
+
+* **Reversible only until the first write.** D-013 says it and it is the reason
+  this ADR is `proposed`: once tenant rows carry `Risk.ResidualRisk`, changing
+  `MaxEffectiveness` or a credit weight silently restates their history. **#438's
+  PR 2 computes and returns the residual but does NOT persist it to
+  `Risk.ResidualRisk` until this ADR is accepted.** The reveal reads a computed
+  value; nothing is stored.
+* Evidence becomes load-bearing. `implemented` without evidence earning 0.70 will
+  visibly cost tenants points, which is the intended teaching and will also be
+  the first thing someone asks about. It is worth saying plainly in the UI copy
+  rather than letting them discover it.
+* The function is pure and takes already-fetched credits, so tenant isolation is
+  the caller's duty, not the formula's. `risk_control_mappings` carries
+  `tenant_id` (`internal/domain/risk_taxonomy.go:161`) and is already behind a
+  tenant-scoped repository port; every call site must filter on it, and #438's
+  acceptance criterion 10 is what proves it.
+
+## Alternatives rejected
+
+**A second residual number of its own, on the 0–100 scale.** Rejected: two
+residuals for one risk, differing by scale, is a support ticket generator and an
+audit finding. The existing `Result.Residual` is the place this belongs.
+
+**Effectiveness from mitigation plans instead of controls.** Rejected for this
+issue: D-013 chose controls, and the tunnel's step 5 is explicitly "accept the
+proposed control". Mitigation-driven effectiveness is a legitimate second source
+and can be combined later — the function signature takes a slice of credits
+precisely so a second source can contribute credits without a formula change.
+
+**Binary coverage (any implemented control ⇒ fully mitigated).** Rejected: it
+makes the reveal's number a step function, which looks broken the moment a tenant
+adds their second control and the number does not move.
+
+**Weighting credits by control importance.** Rejected for v1: nothing in the
+catalogue currently carries an importance or a weight, so any weighting would be
+invented rather than sourced — RULE #12. If the framework catalogues later carry
+one, that is `residual-v2`.


### PR DESCRIPTION
Part of #438 — **PR 2 of 4**. Domain and `pkg` only: no endpoint, no handler, no persisted
value, no UI. **Stacked on #622** (PR 1/4), so review that one first; this branch is cut from
its head.

Does **not** close #438.

## ADR 0003 — the long pole D-013 named

`docs/adr/0003-residual-risk-from-control-coverage.md`. D-013 requires the formula to be fixed
**before** a single row persists to `Risk.ResidualRisk`, because after that a formula change
silently restates tenant history. Three findings changed the design the brief implied, each
read from the code rather than assumed:

1. **A residual already exists, and it is not the same one.** `internal/domain/scoring`
   already returns `Residual`, `ResidualBand` and `MitigationEffectiveness` on every `Result` —
   but it *receives* the effectiveness (`compute.go`, `RiskInput.MitigationEffectiveness`) and
   nothing in the codebase fills it from control mappings. So the gap is not "there is no
   residual", it is "nothing knows what effectiveness the tenant's controls have earned". This
   PR adds the missing input. Writing a second, competing residual would give a GRC product
   two answers to one question.
2. **Two scales exist and must not be mixed.** `internal/domain/scoring` is 0–100 (100 worst);
   `Risk.Score` and `Risk.ResidualRisk` (`internal/domain/risk.go:267`, `numeric(8,3)`) are on
   the Score Engine's `P × I × AC`, so 0–30. #438's own illustration — "16 down to 6" — is on
   the Score Engine scale. The residual is therefore banded on the **Score Engine's own
   thresholds**, so a score and a residual are always comparable and never need converting.
3. **`not_applicable` is not a failure.** It leaves the numerator **and** the denominator.
   Scoring a deliberately scoped-out control as an uncovered one punishes a tenant for scoping
   its framework correctly.

The ADR is **`proposed`, not accepted**: the approach is D-013's decision, but the constants
are mine and they need sign-off. See remainders.

## `pkg/scoring/residual.go`

Pure, stdlib-only, no GORM, no Fiber — it takes credits the caller has already fetched, so
tenant isolation stays the caller's duty (criterion 10 proves it at the call site in PR 3).

| Control status | Evidence | Credit |
|---|---|---|
| `implemented` | yes | 1.00 |
| `implemented` | no | 0.70 |
| `in_progress` | — | 0.30 |
| `not_implemented` | — | 0.00 |
| `not_applicable` | — | *excluded from both sides* |

```
coverage      = Σ credit / applicable
effectiveness = 0.80 × coverage
residual      = round(inherent × (1 − effectiveness), 3)
```

`MaxEffectiveness = 0.80` is a **floor on the residual**, not a cap on ambition: a fully
covered risk keeps 20% of its inherent exposure, because a product that lets a control set
drive a risk to zero teaches its users that paperwork eliminates risk.

With no applicable control mapped, `Coverage.Measured` is false and **residual == inherent**.
An absent signal must never read as a good one — the same rule `combine()` already applies by
renormalising unavailable factors.

`Risk.Score` and `pkg/scoring/engine.go` are untouched and a test asserts the engine still
returns the same value after a residual is computed.

## `pkg/onboarding/starter.go`

The bilingual catalogue step 2 renders. `StarterRisksFor(sector, country)` returns **exactly
eight**, most specific first: the sector's three, then the region's two, then generic padding.
Eight is a UI contract — step 2 shows eight cards and asks for three, and a set whose size
depends on the sector is a screen that reflows.

Deliberately a **new type**, not a widened `RiskSuggestion`: that one is French-only and
sector-only, and widening it would touch every existing consumer for no benefit to them.

Regions cover the markets in CLAUDE.md: CEMAC/UEMOA, EU, Maghreb, North America. Per #438's
regulatory-anchor note, **no statement is worded as a compliance claim** — they are operational
exposures, and the sector scoping is an activation device.

`StarterRiskByKey` exists so the PR 3 write path re-reads the canonical statement instead of
trusting the client's copy: a client that could post arbitrary text would be an unvalidated
write into a customer's risk register.

## D-012 — `SourceStarter`

Added to the enum and to `ParseRiskSource` (`internal/domain/risk.go`). The column is already
`varchar(20)`, so **no migration**, and a test asserts the value fits it — a longer value would
be silently truncated by Postgres and break the provenance query PR 4 depends on.

## Verification

```
$ go build ./...
(no output — success)

$ go vet ./pkg/scoring/ ./pkg/onboarding/ ./internal/domain/
(no output — success)

$ go test ./pkg/scoring/ -run 'Residual|Coverage|ParseControl' -v
=== RUN   TestCoverageEffectiveness_CreditTable
--- PASS: TestCoverageEffectiveness_CreditTable (0.00s)
=== RUN   TestCoverageEffectiveness_NotApplicableIsExcludedFromBothSides
--- PASS: TestCoverageEffectiveness_NotApplicableIsExcludedFromBothSides (0.00s)
=== RUN   TestCoverageEffectiveness_NoApplicableControlIsNotGoodNews
--- PASS: TestCoverageEffectiveness_NoApplicableControlIsNotGoodNews (0.00s)
=== RUN   TestResidual_FullCoverageNeverReachesZero
--- PASS: TestResidual_FullCoverageNeverReachesZero (0.00s)
=== RUN   TestResidual_BandsOnTheScoreEngineThresholds
--- PASS: TestResidual_BandsOnTheScoreEngineThresholds (0.00s)
=== RUN   TestComputeResidual_IsCheckableByHand
--- PASS: TestComputeResidual_IsCheckableByHand (0.00s)
=== RUN   TestParseControlCoverageStatus_UnknownIsNotImplemented
--- PASS: TestParseControlCoverageStatus_UnknownIsNotImplemented (0.00s)
=== RUN   TestResidual_NegativeInherentIsClamped
--- PASS: TestResidual_NegativeInherentIsClamped (0.00s)
=== RUN   TestResidual_LeavesTheScoreEngineUntouched
--- PASS: TestResidual_LeavesTheScoreEngineUntouched (0.00s)
PASS
ok      github.com/opendefender/openrisk/pkg/scoring     0.004s

$ go test ./pkg/onboarding/ -run Starter -v
=== RUN   TestStarterRisksFor_AlwaysReturnsExactlyEight
--- PASS: TestStarterRisksFor_AlwaysReturnsExactlyEight (0.00s)
=== RUN   TestStarterRisksFor_OrdersSectorThenRegionThenGeneric
--- PASS: TestStarterRisksFor_OrdersSectorThenRegionThenGeneric (0.00s)
=== RUN   TestStarterRisksFor_CountryChangesTheSet
--- PASS: TestStarterRisksFor_CountryChangesTheSet (0.00s)
=== RUN   TestStarterRisksFor_UnknownSectorFallsBackNotEmpty
--- PASS: TestStarterRisksFor_UnknownSectorFallsBackNotEmpty (0.00s)
=== RUN   TestStarterCatalogue_IsCompleteInBothLanguages
--- PASS: TestStarterCatalogue_IsCompleteInBothLanguages (0.00s)
=== RUN   TestStarterCatalogue_CoversEverySelectableSector
--- PASS: TestStarterCatalogue_CoversEverySelectableSector (0.00s)
=== RUN   TestStarterRiskByKey_UniqueAndResolvable
--- PASS: TestStarterRiskByKey_UniqueAndResolvable (0.00s)
=== RUN   TestStarterRisk_LanguageFallback
--- PASS: TestStarterRisk_LanguageFallback (0.00s)
PASS
ok      github.com/opendefender/openrisk/pkg/onboarding  0.004s

$ go test ./pkg/onboarding/
ok      github.com/opendefender/openrisk/pkg/onboarding  0.005s

$ go test ./internal/domain/ -run ParseRiskSource -v
=== RUN   TestParseRiskSource_AcceptsStarter
--- PASS: TestParseRiskSource_AcceptsStarter (0.00s)
=== RUN   TestParseRiskSource_KnownValuesAndRejections
--- PASS: TestParseRiskSource_KnownValuesAndRejections (0.00s)
PASS
ok      github.com/opendefender/openrisk/internal/domain 0.024s
```

`go test ./internal/domain/` as a whole package is red on master and stays red — #616 / #576 /
#416, `TestBusinessRolesReferenceOnlyCatalogPermissions`. Not touched here; proof of
pre-existence is in #622.

## Security review

No DB query, no endpoint, no handler, no auth surface, no secret. Two things worth naming:

- `pkg/scoring/residual.go` takes credits rather than a repository, precisely so the formula
  cannot become a place where a tenant filter is forgotten. Every call site added in PR 3
  must filter `risk_control_mappings` on `tenant_id` (the column exists,
  `internal/domain/risk_taxonomy.go:161`), which is criterion 10.
- `ParseControlCoverageStatus` maps anything unrecognised to `not_implemented`, so an unknown
  or attacker-influenced status cannot earn credit.

## Honest remainders

- **The ADR is `proposed`, and PR 3 must not persist a residual until it is accepted.**
  `MaxEffectiveness = 0.80` and the four credit weights are my constants, not the owner's.
  D-013 makes this reversible only while nothing is stored, so PR 3 computes and returns the
  residual and writes nothing to `Risk.ResidualRisk`.
- **No `TestXxx_Success`/`_NotFound`/`_Unauthorized` trio.** ABSOLUTE RULE #4 is scoped to use
  cases and this PR still adds none — it is pure functions and one enum value. The trio lands
  with PR 3's `PostureSummary` use case.
- **`evidence` is not yet wired.** `ControlCredit.HasEvidence` is honoured by the formula but
  nothing fills it; PR 3's query must read the control's evidence count
  (`internal/domain/compliance.go:81` notes an evidence badge already exists) or every
  implemented control will silently earn 0.70 instead of 1.00.
- **Not in this PR:** `/posture`, `/onboarding/recognition`, the `posture.revealed` recording,
  the v2 histogram observation, the auto-skip in `GET /onboarding/state`, the blocking
  five-step tunnel, the closable checklist (criterion 15), E2E, a11y, `ROADMAP.md` 17.6, the
  `MARKETING_CLAIM_MATRIX.md` row and the `JOURNAL.md` entry. **None of #438's fifteen
  acceptance criteria is met by this PR** — they all describe surfaces that arrive in PRs 3
  and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
