### PR TITLE
feat(activation): posture reveal, recognition and tunnel auto-skip (#438, PR 3/4)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2859,15 +2859,24 @@ func main() {
 	// The only writes are (a) acknowledging that a celebration was shown, and
 	// (b) the wizard's own answers.
 	// =========================================================================
+	// The Posture Reveal's read side (#438). Every query it runs filters on
+	// tenant_id — criterion 10 — and the compile-time assertions in
+	// gorm_posture_repository.go are what keep its three ports honest.
+	postureRepo := repository.NewGormPostureRepository(database.DB)
 	onboardingUC := appactivation.NewOnboardingUseCase(activationRepo, activationRecorder).
 		WithOrgUpdater(orgRepo).
 		WithOrgCurrencyUpdater(orgRepo).
-		WithProfileUpdater(userRepo)
+		WithProfileUpdater(userRepo).
+		// Auto-skip (criteria 2 and 3): GET /onboarding/state resolves the whole
+		// tunnel in one call, skipped steps included.
+		WithStepProbe(postureRepo)
 	activationHandler := handlers.NewActivationHandler(
 		appactivation.NewGetStateUseCase(activationRepo),
 		appactivation.NewMarkCelebratedUseCase(activationRepo),
 		onboardingUC,
-	)
+	).
+		WithPosture(appactivation.NewPostureUseCase(postureRepo, activationRepo, activationRecorder)).
+		WithRecognition(appactivation.NewRecognitionUseCase(postureRepo))
 	// Readable by any authenticated member: the get-started panel is not a
 	// privileged view, and gating it behind a permission would hide the product's
 	// own instructions from exactly the people who need them most.
@@ -2882,7 +2891,13 @@ func main() {
 	protected.Get("/onboarding/state", activationHandler.GetOnboardingState)
 	protected.Get("/onboarding/suggestions", activationHandler.GetOnboardingSuggestions)
 	protected.Post("/onboarding/complete", activationHandler.CompleteOnboarding)
+	protected.Get("/onboarding/recognition", activationHandler.GetRecognition)
 	protected.Put("/onboarding/steps/:step", activationHandler.SaveOnboardingStep)
+
+	// The Posture Reveal (#438). Outside the /onboarding group on purpose: it is
+	// a product surface a user returns to, not a step of a wizard they complete
+	// once. A 404 here is criterion 8's explicit error state, not a bug.
+	protected.Get("/posture", activationHandler.GetPosture)
 
 	// The periodic sync worker (NVD 1h / CISA 6h + post-sync matching) runs in
 	// production. In dev it stays off by default to avoid hitting the feeds on every

--- a/backend/internal/application/activation/autoskip_test.go
+++ b/backend/internal/application/activation/autoskip_test.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// fakeProbe counts its calls: criterion 2 allows exactly ONE resolution per
+// GET /onboarding/state, and a probe that were called per step would be the
+// per-step status call the criterion forbids.
+type fakeProbe struct {
+	data  domain.OnboardingStepData
+	calls int
+	fail  bool
+}
+
+func (p *fakeProbe) OnboardingStepData(_ context.Context, _, _ uuid.UUID) (domain.OnboardingStepData, error) {
+	p.calls++
+	if p.fail {
+		return domain.OnboardingStepData{}, errors.New("probe down")
+	}
+	return p.data, nil
+}
+
+// Criterion 3: a step whose data exists is absent from the stepper count shown
+// to that user.
+func TestWizard_AutoSkippedStepsAreAbsentFromTheStepper(t *testing.T) {
+	repo := newFakeRepo()
+	probe := &fakeProbe{data: domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasFramework:           true,
+	}}
+	uc := newWizard(repo).WithStepProbe(probe)
+	tenant, user := uuid.New(), uuid.New()
+
+	state, err := uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+
+	if len(state.Steps) != 3 {
+		t.Errorf("stepper shows %d steps (%v), want 3", len(state.Steps), state.Steps)
+	}
+	for _, s := range state.Steps {
+		if s == string(domain.OnboardingStepOrganization) || s == string(domain.OnboardingStepFramework) {
+			t.Errorf("skipped step %q is still in the stepper", s)
+		}
+	}
+	if len(state.SkippedSteps) != 2 {
+		t.Errorf("skipped = %v, want organization and framework", state.SkippedSteps)
+	}
+	// The cursor must not land on a step the client is forbidden to render.
+	if state.CurrentStep == string(domain.OnboardingStepOrganization) {
+		t.Errorf("the cursor parked on a skipped step: %q", state.CurrentStep)
+	}
+}
+
+// Criterion 2: one call resolves the whole tunnel.
+func TestWizard_StateResolvesAutoSkipInASingleProbe(t *testing.T) {
+	repo := newFakeRepo()
+	probe := &fakeProbe{data: domain.OnboardingStepData{HasUserProfile: true}}
+	uc := newWizard(repo).WithStepProbe(probe)
+
+	if _, err := uc.GetState(context.Background(), uuid.New(), uuid.New()); err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if probe.calls != 1 {
+		t.Errorf("GET /onboarding/state probed %d times, want exactly 1", probe.calls)
+	}
+}
+
+// `goal` is a preference, not a record. Nothing stored can prove what a user
+// wants next, so skipping it would silently choose their landing page.
+func TestWizard_GoalIsNeverSkippable(t *testing.T) {
+	everything := domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasUserProfile:         true,
+		HasFramework:           true,
+		HasTeam:                true,
+	}
+
+	visible := everything.VisibleSteps()
+	if len(visible) != 1 || visible[0] != domain.OnboardingStepGoal {
+		t.Fatalf("visible steps = %v, want only the goal", visible)
+	}
+	if everything.SkipsStep(domain.OnboardingStepGoal) {
+		t.Error("the goal step must never be skipped")
+	}
+
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: everything})
+	state, err := uc.GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if len(state.Steps) != 1 || state.Steps[0] != string(domain.OnboardingStepGoal) {
+		t.Errorf("a fully configured user must still answer the goal, got %v", state.Steps)
+	}
+}
+
+// The cursor steps OVER hidden steps in both directions. Landing on one would
+// strand the user on a screen the client must not draw.
+func TestWizard_CursorStepsOverHiddenSteps(t *testing.T) {
+	repo := newFakeRepo()
+	// profile and framework hidden ⇒ visible: organization, goal, team
+	probe := &fakeProbe{data: domain.OnboardingStepData{HasUserProfile: true, HasFramework: true}}
+	uc := newWizard(repo).WithStepProbe(probe)
+	tenant, user := uuid.New(), uuid.New()
+
+	// Forward from organization: profile is hidden, so goal is next.
+	state, err := uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepOrganization,
+		Answers: domain.JSONMap{"industry": "banking", "country": "CM"},
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepGoal) {
+		t.Errorf("forward cursor = %q, want goal (profile is hidden)", state.CurrentStep)
+	}
+
+	// Forward from goal: framework is hidden, so team is next.
+	state, err = uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepGoal,
+		Answers: domain.JSONMap{"goal": "compliance"},
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepTeam) {
+		t.Errorf("forward cursor = %q, want team (framework is hidden)", state.CurrentStep)
+	}
+
+	// An explicit backwards Next naming a HIDDEN step is honoured as a direction:
+	// the cursor lands on the nearest visible step behind it, never on the hidden
+	// one and never staying put.
+	state, err = uc.SaveStep(context.Background(), tenant, user, SaveStepInput{
+		Step:    domain.OnboardingStepTeam,
+		Answers: domain.JSONMap{},
+		Next:    string(domain.OnboardingStepFramework),
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if state.CurrentStep != string(domain.OnboardingStepGoal) {
+		t.Errorf("backwards cursor = %q, want goal (framework is hidden)", state.CurrentStep)
+	}
+}
+
+// Criterion 5 in the presence of skips: the resumed cursor still reads as a
+// sensible "step N of M" rather than "step 0 of 3" or a negative index.
+func TestWizard_StepIndexIsRelativeToVisibleSteps(t *testing.T) {
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	repo.progress[user.String()] = &domain.OnboardingProgress{
+		TenantID:    tenant,
+		UserID:      user,
+		CurrentStep: domain.OnboardingStepTeam,
+	}
+	// organization hidden ⇒ visible: profile, goal, framework, team
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: domain.OnboardingStepData{HasOrganizationProfile: true}})
+
+	state, err := uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state.StepIndex != 3 || len(state.Steps) != 4 {
+		t.Errorf("step %d of %d, want 3 of 4", state.StepIndex, len(state.Steps))
+	}
+
+	// A stored cursor parked on a NOW-hidden step must not render as index −1.
+	repo.progress[user.String()].CurrentStep = domain.OnboardingStepOrganization
+	state, err = uc.GetState(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state.StepIndex < 0 || state.StepIndex >= len(state.Steps) {
+		t.Errorf("a cursor on a hidden step resolved to index %d of %d", state.StepIndex, len(state.Steps))
+	}
+}
+
+// A probe failure must show every step, not hide one whose data does not exist.
+// Showing a redundant step costs a click; hiding a needed one strands the user.
+func TestWizard_ProbeFailureShowsEveryStep(t *testing.T) {
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{fail: true})
+
+	state, err := uc.GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("a probe failure must not fail the wizard: %v", err)
+	}
+	if len(state.Steps) != len(domain.OnboardingStepOrder) {
+		t.Errorf("a failed probe hid %d steps", len(domain.OnboardingStepOrder)-len(state.Steps))
+	}
+	if len(state.SkippedSteps) != 0 {
+		t.Errorf("a failed probe reported skips: %v", state.SkippedSteps)
+	}
+}
+
+// No probe at all is the old behaviour, unchanged.
+func TestWizard_NoProbeShowsEveryStep(t *testing.T) {
+	state, err := newWizard(newFakeRepo()).GetState(context.Background(), uuid.New(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if len(state.Steps) != len(domain.OnboardingStepOrder) {
+		t.Errorf("steps = %v, want the full catalogue", state.Steps)
+	}
+}
+
+// Complete parks the cursor on the last step this user actually saw, not on the
+// catalogue's last step — which may be one they never walked.
+func TestWizard_CompleteParksOnTheLastVisibleStep(t *testing.T) {
+	repo := newFakeRepo()
+	uc := newWizard(repo).WithStepProbe(&fakeProbe{data: domain.OnboardingStepData{HasTeam: true}})
+	tenant, user := uuid.New(), uuid.New()
+
+	state, err := uc.Complete(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if state.CurrentStep == string(domain.OnboardingStepTeam) {
+		t.Error("the cursor parked on the hidden team step")
+	}
+	if state.CurrentStep != string(domain.OnboardingStepFramework) {
+		t.Errorf("cursor = %q, want the last visible step (framework)", state.CurrentStep)
+	}
+	if !state.Completed {
+		t.Error("Complete must complete")
+	}
+}
+
+func TestOnboardingStepData_SkipsStep(t *testing.T) {
+	full := domain.OnboardingStepData{
+		HasOrganizationProfile: true,
+		HasUserProfile:         true,
+		HasFramework:           true,
+		HasTeam:                true,
+	}
+	for step, want := range map[domain.OnboardingStepKey]bool{
+		domain.OnboardingStepOrganization: true,
+		domain.OnboardingStepProfile:      true,
+		domain.OnboardingStepFramework:    true,
+		domain.OnboardingStepTeam:         true,
+		domain.OnboardingStepGoal:         false,
+	} {
+		if got := full.SkipsStep(step); got != want {
+			t.Errorf("SkipsStep(%q) = %v, want %v", step, got, want)
+		}
+	}
+
+	empty := domain.OnboardingStepData{}
+	for _, step := range domain.OnboardingStepOrder {
+		if empty.SkipsStep(step) {
+			t.Errorf("an empty tenant must skip nothing, skipped %q", step)
+		}
+	}
+	if len(empty.VisibleSteps()) != len(domain.OnboardingStepOrder) {
+		t.Error("an empty tenant must see every step")
+	}
+}

--- a/backend/internal/application/activation/onboarding.go
+++ b/backend/internal/application/activation/onboarding.go
@@ -46,8 +46,16 @@ type ProfileUpdater interface {
 
 // WizardState is the payload of GET /onboarding/state.
 type WizardState struct {
-	CurrentStep string         `json:"current_step"`
-	Steps       []string       `json:"steps"`
+	CurrentStep string `json:"current_step"`
+	// Steps is what the ProgressStepper renders: the steps THIS USER will
+	// actually see, with auto-skipped ones removed (#438 criterion 3). It is not
+	// the canonical catalogue — a user who skips two steps must read
+	// "step 2 of 3", not "step 2 of 5" with two rows that never arrive.
+	Steps []string `json:"steps"`
+	// SkippedSteps is what was removed and is returned for transparency, not for
+	// rendering. A client that drew these would flash a step criterion 3 forbids.
+	SkippedSteps []string `json:"skipped_steps"`
+	// StepIndex is the cursor's position among the VISIBLE steps.
 	StepIndex   int            `json:"step_index"`
 	Completed   bool           `json:"completed"`
 	CompletedAt *time.Time     `json:"completed_at,omitempty"`
@@ -68,7 +76,33 @@ type OnboardingUseCase struct {
 	orgs     OrgUpdater
 	orgCur   OrgCurrencyUpdater
 	profiles ProfileUpdater
-	now      func() time.Time
+	// probe decides which steps are auto-skipped. Optional and nil-safe: with no
+	// probe every step is shown, which is the old behaviour and the safe default
+	// — showing a step the user did not need costs them a click; hiding one they
+	// did need loses their answer.
+	probe domain.OnboardingStepProbe
+	now   func() time.Time
+}
+
+// WithStepProbe attaches the auto-skip reader (#438 criteria 2 and 3).
+func (uc *OnboardingUseCase) WithStepProbe(p domain.OnboardingStepProbe) *OnboardingUseCase {
+	uc.probe = p
+	return uc
+}
+
+// stepData resolves the auto-skip decisions once. A probe failure degrades to
+// "skip nothing": a wizard that shows a redundant step is a minor annoyance, and
+// one that hides a step whose data does NOT exist strands the user on a tunnel
+// they cannot complete.
+func (uc *OnboardingUseCase) stepData(ctx context.Context, tenantID, userID uuid.UUID) domain.OnboardingStepData {
+	if uc.probe == nil {
+		return domain.OnboardingStepData{}
+	}
+	data, err := uc.probe.OnboardingStepData(ctx, tenantID, userID)
+	if err != nil {
+		return domain.OnboardingStepData{}
+	}
+	return data
 }
 
 // WithOrgCurrencyUpdater attaches the optional tenant-currency writer.
@@ -114,7 +148,10 @@ func (uc *OnboardingUseCase) GetState(ctx context.Context, tenantID, userID uuid
 			CurrentStep: domain.OnboardingStepOrganization,
 		}
 	}
-	return toWizardState(progress), nil
+
+	// Criterion 2: ONE call resolves the whole tunnel, auto-skip decisions
+	// included. No step may issue its own status call on mount.
+	return toWizardState(progress, uc.stepData(ctx, tenantID, userID)), nil
 }
 
 // SaveStepInput is one step's submission.
@@ -194,27 +231,68 @@ func (uc *OnboardingUseCase) SaveStep(ctx context.Context, tenantID, userID uuid
 	}
 
 	// Move the cursor. An explicit Next wins (including backwards); otherwise
-	// advance one step, clamped at the last.
-	progress.CurrentStep = uc.nextStep(input.Step, input.Next)
+	// advance one step, clamped at the last. Auto-skipped steps are stepped over
+	// in both directions — landing on a hidden step would strand the user on a
+	// screen the client is forbidden to render.
+	data := uc.stepData(ctx, tenantID, userID)
+	progress.CurrentStep = uc.nextStep(input.Step, input.Next, data)
 
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress), nil
+	return toWizardState(progress, data), nil
 }
 
-// nextStep resolves the cursor move.
-func (uc *OnboardingUseCase) nextStep(current domain.OnboardingStepKey, next string) domain.OnboardingStepKey {
+// nextStep resolves the cursor move over the VISIBLE steps only.
+//
+// An explicit Next that names a skipped step is honoured as a direction, not as
+// a destination: the cursor lands on the nearest visible step in that direction.
+// Silently ignoring it would leave the user on the step they just submitted.
+func (uc *OnboardingUseCase) nextStep(current domain.OnboardingStepKey, next string, data domain.OnboardingStepData) domain.OnboardingStepKey {
+	visible := data.VisibleSteps()
+	if len(visible) == 0 {
+		// Unreachable while `goal` is unskippable, but a cursor with nowhere to
+		// go must not be a panic.
+		return current
+	}
+
 	if next != "" {
 		if parsed, err := domain.ParseOnboardingStep(next); err == nil {
-			return parsed
+			backwards := parsed.Index() < current.Index()
+			return nearestVisible(parsed, visible, backwards)
 		}
 	}
+
 	idx := current.Index() + 1
 	if idx >= len(domain.OnboardingStepOrder) {
 		idx = len(domain.OnboardingStepOrder) - 1
 	}
-	return domain.OnboardingStepOrder[idx]
+	return nearestVisible(domain.OnboardingStepOrder[idx], visible, false)
+}
+
+// nearestVisible snaps a target onto the visible sequence, searching forward
+// (or backward) and falling back to the other direction at the ends.
+func nearestVisible(target domain.OnboardingStepKey, visible []domain.OnboardingStepKey, backwards bool) domain.OnboardingStepKey {
+	for _, s := range visible {
+		if s == target {
+			return target
+		}
+	}
+
+	if backwards {
+		for i := len(visible) - 1; i >= 0; i-- {
+			if visible[i].Index() < target.Index() {
+				return visible[i]
+			}
+		}
+		return visible[0]
+	}
+	for _, s := range visible {
+		if s.Index() > target.Index() {
+			return s
+		}
+	}
+	return visible[len(visible)-1]
 }
 
 // Complete closes the wizard and lifts the route guard. Idempotent: completing an
@@ -237,14 +315,17 @@ func (uc *OnboardingUseCase) Complete(ctx context.Context, tenantID, userID uuid
 		progress.Completed = true
 		progress.CompletedAt = &now
 	}
-	progress.CurrentStep = domain.OnboardingStepTeam
+	// Park the cursor on the last step this user actually saw, not on the
+	// catalogue's last step — which may be one they never walked.
+	visible := uc.stepData(ctx, tenantID, userID).VisibleSteps()
+	progress.CurrentStep = visible[len(visible)-1]
 	progress.TenantID = tenantID
 	progress.UserID = userID
 
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress), nil
+	return toWizardState(progress, uc.stepData(ctx, tenantID, userID)), nil
 }
 
 // Suggestions is the payload of GET /onboarding/suggestions: the sector/goal
@@ -294,10 +375,17 @@ func (uc *OnboardingUseCase) GetSuggestions(ctx context.Context, tenantID, userI
 // helpers
 // ---------------------------------------------------------------------------
 
-func toWizardState(p *domain.OnboardingProgress) *WizardState {
-	steps := make([]string, 0, len(domain.OnboardingStepOrder))
-	for _, s := range domain.OnboardingStepOrder {
+func toWizardState(p *domain.OnboardingProgress, data domain.OnboardingStepData) *WizardState {
+	visible := data.VisibleSteps()
+	steps := make([]string, 0, len(visible))
+	for _, s := range visible {
 		steps = append(steps, string(s))
+	}
+	skipped := make([]string, 0, len(domain.OnboardingStepOrder)-len(visible))
+	for _, s := range domain.OnboardingStepOrder {
+		if data.SkipsStep(s) {
+			skipped = append(skipped, string(s))
+		}
 	}
 
 	answers := p.Answers
@@ -305,26 +393,56 @@ func toWizardState(p *domain.OnboardingProgress) *WizardState {
 		answers = domain.JSONMap{}
 	}
 
-	idx := p.CurrentStep.Index()
+	// The cursor's position among the VISIBLE steps — what "step N of M" reads.
+	//
+	// A cursor pointing at a hidden step is SNAPPED onto the visible sequence
+	// rather than merely re-indexed. Two ways it gets there and both are normal:
+	// a brand-new progress row is initialised on `organization`, which may be the
+	// first step skipped; and a stored row can predate the data that now skips
+	// its step. Reporting the hidden key would tell the client to render a screen
+	// criterion 3 forbids, and reporting index 0 while naming a hidden step would
+	// have the stepper and the screen disagree.
+	cursor := p.CurrentStep
+	idx := -1
+	for i, s := range visible {
+		if s == cursor {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 && len(visible) > 0 {
+		cursor = nearestVisible(cursor, visible, false)
+		for i, s := range visible {
+			if s == cursor {
+				idx = i
+				break
+			}
+		}
+	}
+	if idx < 0 {
+		idx = 0
+	}
+
 	state := &WizardState{
-		CurrentStep: string(p.CurrentStep),
-		Steps:       steps,
-		StepIndex:   idx,
-		Completed:   p.Completed,
-		CompletedAt: p.CompletedAt,
-		Industry:    p.Industry,
-		Country:     p.Country,
-		Goal:        p.Goal,
-		Answers:     answers,
-		Landing:     onboarding.LandingForGoal(p.Goal),
+		CurrentStep:  string(cursor),
+		Steps:        steps,
+		SkippedSteps: skipped,
+		StepIndex:    idx,
+		Completed:    p.Completed,
+		CompletedAt:  p.CompletedAt,
+		Industry:     p.Industry,
+		Country:      p.Country,
+		Goal:         p.Goal,
+		Answers:      answers,
+		Landing:      onboarding.LandingForGoal(p.Goal),
 	}
 	if p.Completed {
 		state.Percent = 100
 	} else {
 		state.Percent = idx * 100 / len(steps)
 	}
-	if state.CurrentStep == "" {
-		state.CurrentStep = string(domain.OnboardingStepOrganization)
+	if state.CurrentStep == "" && len(visible) > 0 {
+		state.CurrentStep = string(visible[0])
 	}
 	return state
 }

--- a/backend/internal/application/activation/posture.go
+++ b/backend/internal/application/activation/posture.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package activation
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/monitoring"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// The Posture Reveal (#438) — the surface that DEFINES the Aha moment.
+//
+// Everything here is computed from the tenant's OWN rows. #438 criterion 7 is
+// absolute: no sample, no demo, no placeholder value may reach the payload. That
+// is not a UI preference — the reveal is the launch-gate metric, and a screen
+// that renders a plausible number from fixture data would make the metric report
+// success while activation is nil.
+//
+// Criterion 8 is the counterpart and is why Execute returns an error rather than
+// a half-empty summary: if the payload would be empty, NOTHING is recorded. No
+// `posture.revealed` event, no histogram observation. A reveal that cannot show
+// anything has not revealed anything, and recording it would quietly turn a
+// rendering failure into a product success.
+// ---------------------------------------------------------------------------
+
+// The read models and the ports live in internal/domain (see domain/posture.go
+// for why: repository cannot import this package). Aliased here so the use case
+// and its tests read naturally and so a caller never has to know which package a
+// shape came from.
+type (
+	PostureRiskCounts    = domain.PostureRiskCounts
+	PostureControlCounts = domain.PostureControlCounts
+	PostureRisk          = domain.PostureRisk
+	PostureReader        = domain.PostureReader
+)
+
+// PostureRiskView is one risk with its residual, as the reveal renders it.
+type PostureRiskView struct {
+	PostureRisk
+	Residual scoring.Residual `json:"residual"`
+}
+
+// TopRiskLimit is how many risks the reveal composes — defined in the domain so
+// the repository shares the same number without importing this package.
+const TopRiskLimit = domain.TopRiskLimit
+
+// PostureSummary is the payload of GET /posture.
+type PostureSummary struct {
+	Risks    PostureRiskCounts    `json:"risks"`
+	Controls PostureControlCounts `json:"controls"`
+	// CoveragePercent is nil, NOT zero, when no applicable control exists. Zero
+	// would read as "you have covered nothing", which is a different and false
+	// statement from "there is nothing to cover yet".
+	CoveragePercent *float64          `json:"coverage_percent"`
+	TopRisks        []PostureRiskView `json:"top_risks"`
+	// ResidualFormulaVersion is echoed so a stored or forwarded figure can never
+	// be reinterpreted under a later formula (ADR 0003).
+	ResidualFormulaVersion string    `json:"residual_formula_version"`
+	GeneratedAt            time.Time `json:"generated_at"`
+	// RevealedAt is when this tenant FIRST reached the reveal. Stable across
+	// re-renders — criterion 11, first-occurrence-wins.
+	RevealedAt *time.Time `json:"revealed_at,omitempty"`
+	// FirstReveal is true only on the render that recorded the event, so the
+	// client can celebrate once without deciding anything itself.
+	FirstReveal bool `json:"first_reveal"`
+}
+
+// IsRevealable encodes criterion 6's three requirements and criterion 8's
+// refusal. All three must hold or there is nothing to reveal:
+//
+//	a non-zero risk count · a non-null coverage percentage · at least one residual
+func (s *PostureSummary) IsRevealable() bool {
+	return s != nil &&
+		s.Risks.Total > 0 &&
+		s.CoveragePercent != nil &&
+		len(s.TopRisks) > 0
+}
+
+// PostureUseCase computes the reveal and records the Aha exactly once.
+type PostureUseCase struct {
+	reader   PostureReader
+	repo     domain.ActivationRepository
+	recorder *Recorder
+	now      func() time.Time
+}
+
+// NewPostureUseCase builds the use case. Both dependencies are required: unlike
+// the rest of this package, the reveal must NOT degrade silently — a reveal that
+// renders zeros because its reader was nil is exactly the failure criterion 8
+// exists to prevent.
+func NewPostureUseCase(reader PostureReader, repo domain.ActivationRepository, recorder *Recorder) *PostureUseCase {
+	return &PostureUseCase{
+		reader:   reader,
+		repo:     repo,
+		recorder: recorder,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Execute computes the reveal for one (tenant, user) and, when it is revealable
+// and this is the first time, records `posture.revealed` and observes the v2
+// time-to-Aha histogram.
+//
+// Errors are typed and each one means something different to the client:
+//
+//   - ErrForbidden  — no tenant or no user on the session.
+//   - ErrNotFound   — the tenant has nothing to reveal yet (criterion 8). NOTHING
+//     is recorded and NOTHING is observed on this path.
+func (uc *PostureUseCase) Execute(ctx context.Context, tenantID, userID uuid.UUID) (*PostureSummary, error) {
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant and a user are required to read a posture")
+	}
+	if uc.reader == nil {
+		return nil, domain.NewInternalError("posture reader is not wired")
+	}
+
+	counts, err := uc.reader.RiskCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	controls, err := uc.reader.ControlCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	top, err := uc.reader.TopRisks(ctx, tenantID, TopRiskLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]uuid.UUID, 0, len(top))
+	for _, r := range top {
+		ids = append(ids, r.ID)
+	}
+	credits := map[uuid.UUID][]scoring.ControlCredit{}
+	if len(ids) > 0 {
+		credits, err = uc.reader.ControlCreditsByRisk(ctx, tenantID, ids)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	views := make([]PostureRiskView, 0, len(top))
+	for _, r := range top {
+		views = append(views, PostureRiskView{
+			PostureRisk: r,
+			Residual:    scoring.ComputeResidual(r.Inherent, credits[r.ID]),
+		})
+	}
+
+	summary := &PostureSummary{
+		Risks:                  counts,
+		Controls:               controls,
+		CoveragePercent:        coveragePercent(controls),
+		TopRisks:               views,
+		ResidualFormulaVersion: scoring.ResidualFormulaVersion,
+		GeneratedAt:            uc.now(),
+	}
+
+	if !summary.IsRevealable() {
+		// Criterion 8: fail loudly, record nothing, observe nothing. The client
+		// renders an explicit error state and the metric stays honest.
+		return nil, domain.NewNotFoundError("posture", tenantID)
+	}
+
+	uc.recordReveal(ctx, tenantID, userID, summary)
+	return summary, nil
+}
+
+// recordReveal writes `posture.revealed` at most once per tenant and observes the
+// v2 histogram. Best-effort like the rest of this package: a metric must never be
+// able to fail the screen it measures.
+func (uc *PostureUseCase) recordReveal(ctx context.Context, tenantID, userID uuid.UUID, summary *PostureSummary) {
+	if uc.repo == nil {
+		return
+	}
+
+	firsts, err := uc.repo.FirstOccurrences(ctx, tenantID)
+	if err != nil {
+		return
+	}
+
+	// Criterion 11: first-occurrence-wins. An already-revealed tenant gets its
+	// original timestamp back and no second row is written.
+	if at, seen := firsts[domain.ActivationPostureRevealed]; seen {
+		revealedAt := at
+		summary.RevealedAt = &revealedAt
+		return
+	}
+
+	recorded := uc.recorder.RecordOnce(ctx, tenantID, string(domain.ActivationPostureRevealed),
+		map[string]interface{}{
+			"risk_count":       summary.Risks.Total,
+			"coverage_percent": summary.CoveragePercent,
+			"top_risks":        len(summary.TopRisks),
+			"formula_version":  summary.ResidualFormulaVersion,
+		})
+	if !recorded {
+		// Another request won the race. Not an error, and not a second event.
+		return
+	}
+
+	// Read the timestamp BACK from the stored event rather than taking a second
+	// clock reading. The recorder stamps `occurred_at` with its own clock, so a
+	// second reading here would report a `revealed_at` that differs — by
+	// microseconds in production, by enough to fail criterion 11's "completed_at
+	// is unchanged" the moment the screen is rendered twice.
+	stored, err := uc.repo.FirstOccurrences(ctx, tenantID)
+	if err != nil {
+		return
+	}
+	at, ok := stored[domain.ActivationPostureRevealed]
+	if !ok {
+		// Recorded but unreadable: the store swallowed it. Do not observe a
+		// duration against a t0 we cannot prove.
+		return
+	}
+	revealedAt := at
+	summary.RevealedAt = &revealedAt
+	summary.FirstReveal = true
+
+	// Count the tenant whether or not a signup anchor exists to measure against —
+	// the defect D-010 told this work not to inherit.
+	monitoring.CountAhaReached()
+
+	// v2 is the Posture Reveal definition and only that. Without a signup anchor
+	// there is no honest duration, so nothing is observed rather than inventing a
+	// t0 that would flatter the histogram.
+	if signup, ok := firsts[domain.ActivationSignup]; ok {
+		monitoring.ObserveTimeToAha(monitoring.AhaDefinitionV2, revealedAt.Sub(signup))
+	}
+}
+
+// coveragePercent is implemented controls over APPLICABLE controls, rounded to
+// one decimal. Nil when nothing is applicable: zero would say "you have covered
+// nothing", which is false when there is nothing to cover.
+//
+// `in_progress` earns no coverage here even though ADR 0003 gives it residual
+// credit. The two answer different questions: coverage is "how much of the
+// framework is done", and a control being worked on is not done.
+func coveragePercent(c PostureControlCounts) *float64 {
+	applicable := c.Applicable()
+	if applicable <= 0 {
+		return nil
+	}
+	pct := float64(c.Implemented) / float64(applicable) * 100
+	pct = float64(int64(pct*10+0.5)) / 10
+	return &pct
+}

--- a/backend/internal/application/activation/posture_test.go
+++ b/backend/internal/application/activation/posture_test.go
@@ -1,0 +1,407 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/monitoring"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// Tenant-aware reader double.
+//
+// Keyed BY TENANT on purpose: a double that ignored the tenant argument could
+// not fail the isolation test, and a test that cannot fail proves nothing
+// (#438 criterion 10).
+// ---------------------------------------------------------------------------
+
+type fakePostureReader struct {
+	counts   map[uuid.UUID]PostureRiskCounts
+	controls map[uuid.UUID]PostureControlCounts
+	top      map[uuid.UUID][]PostureRisk
+	credits  map[uuid.UUID]map[uuid.UUID][]scoring.ControlCredit
+	recog    map[uuid.UUID]RecognitionCounts
+
+	fail bool
+	// seenTenants records every tenant the use case actually asked about.
+	seenTenants []uuid.UUID
+}
+
+func newFakePostureReader() *fakePostureReader {
+	return &fakePostureReader{
+		counts:   map[uuid.UUID]PostureRiskCounts{},
+		controls: map[uuid.UUID]PostureControlCounts{},
+		top:      map[uuid.UUID][]PostureRisk{},
+		credits:  map[uuid.UUID]map[uuid.UUID][]scoring.ControlCredit{},
+		recog:    map[uuid.UUID]RecognitionCounts{},
+	}
+}
+
+func (f *fakePostureReader) RiskCounts(_ context.Context, tenantID uuid.UUID) (PostureRiskCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return PostureRiskCounts{}, errors.New("risk store down")
+	}
+	return f.counts[tenantID], nil
+}
+
+func (f *fakePostureReader) ControlCounts(_ context.Context, tenantID uuid.UUID) (PostureControlCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return PostureControlCounts{}, errors.New("compliance store down")
+	}
+	return f.controls[tenantID], nil
+}
+
+func (f *fakePostureReader) TopRisks(_ context.Context, tenantID uuid.UUID, limit int) ([]PostureRisk, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return nil, errors.New("risk store down")
+	}
+	rs := f.top[tenantID]
+	if len(rs) > limit {
+		rs = rs[:limit]
+	}
+	return rs, nil
+}
+
+func (f *fakePostureReader) ControlCreditsByRisk(_ context.Context, tenantID uuid.UUID, ids []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return nil, errors.New("mapping store down")
+	}
+	out := map[uuid.UUID][]scoring.ControlCredit{}
+	for _, id := range ids {
+		if c, ok := f.credits[tenantID][id]; ok {
+			out[id] = c
+		}
+	}
+	return out, nil
+}
+
+func (f *fakePostureReader) RecognitionCounts(_ context.Context, tenantID uuid.UUID) (RecognitionCounts, error) {
+	f.seenTenants = append(f.seenTenants, tenantID)
+	if f.fail {
+		return RecognitionCounts{}, errors.New("store down")
+	}
+	return f.recog[tenantID], nil
+}
+
+// seedRevealable gives a tenant everything the reveal needs: risks, applicable
+// controls and one mapped control.
+func seedRevealable(r *fakePostureReader, tenant uuid.UUID) uuid.UUID {
+	riskID := uuid.New()
+	r.counts[tenant] = PostureRiskCounts{Total: 12, ByLevel: map[string]int{"critical": 2, "high": 4, "medium": 5, "low": 1}}
+	r.controls[tenant] = PostureControlCounts{Frameworks: 1, Total: 20, Implemented: 8, NotApplicable: 4, InProgress: 3}
+	r.top[tenant] = []PostureRisk{{ID: riskID, Title: "Compromission d'un compte à privilèges", Inherent: 16, Level: "critical"}}
+	r.credits[tenant] = map[uuid.UUID][]scoring.ControlCredit{
+		riskID: {{Status: scoring.ControlImplemented, HasEvidence: true}, {Status: scoring.ControlInProgress}},
+	}
+	return riskID
+}
+
+func newPosture(reader PostureReader, repo *fakeRepo) *PostureUseCase {
+	return NewPostureUseCase(reader, repo, NewRecorder(repo))
+}
+
+// ---------------------------------------------------------------------------
+// RULE #4 — the trio
+// ---------------------------------------------------------------------------
+
+func TestPostureSummary_Success(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+
+	got, err := newPosture(reader, repo).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got.Risks.Total != 12 {
+		t.Errorf("risk count = %d, want 12", got.Risks.Total)
+	}
+	// 8 implemented over 16 applicable (20 − 4 not applicable) = 50%.
+	if got.CoveragePercent == nil || *got.CoveragePercent != 50 {
+		t.Errorf("coverage = %v, want 50", got.CoveragePercent)
+	}
+	if len(got.TopRisks) != 1 {
+		t.Fatalf("top risks = %d, want 1", len(got.TopRisks))
+	}
+	// ADR 0003, checkable by hand: (1.0 + 0.30)/2 = 0.65 · 0.80 × 0.65 = 0.52
+	// 16 × (1 − 0.52) = 7.68
+	if v := got.TopRisks[0].Residual.Value; v != 7.68 {
+		t.Errorf("residual = %v, want 7.68", v)
+	}
+	if got.ResidualFormulaVersion != scoring.ResidualFormulaVersion {
+		t.Errorf("formula version = %q", got.ResidualFormulaVersion)
+	}
+	if !got.FirstReveal || got.RevealedAt == nil {
+		t.Errorf("the first reveal must be flagged and dated, got first=%v at=%v", got.FirstReveal, got.RevealedAt)
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); !has {
+		t.Error("posture.revealed must be recorded on a successful reveal")
+	}
+}
+
+// Criterion 8: a payload that would be empty renders an error state, records
+// NOTHING and observes NOTHING.
+func TestPostureSummary_NotFound(t *testing.T) {
+	cases := map[string]func(*fakePostureReader, uuid.UUID){
+		"no risks at all": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.controls[tenant] = PostureControlCounts{Total: 10, Implemented: 5}
+		},
+		"risks but no applicable control": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.counts[tenant] = PostureRiskCounts{Total: 4}
+			r.controls[tenant] = PostureControlCounts{Total: 3, NotApplicable: 3}
+			r.top[tenant] = []PostureRisk{{ID: uuid.New(), Title: "x", Inherent: 9}}
+		},
+		"counted risks but none readable": func(r *fakePostureReader, tenant uuid.UUID) {
+			r.counts[tenant] = PostureRiskCounts{Total: 4}
+			r.controls[tenant] = PostureControlCounts{Total: 10, Implemented: 5}
+		},
+	}
+
+	for name, seed := range cases {
+		reader := newFakePostureReader()
+		repo := newFakeRepo()
+		tenant, user := uuid.New(), uuid.New()
+		seed(reader, tenant)
+
+		countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+		v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+
+		got, err := newPosture(reader, repo).Execute(context.Background(), tenant, user)
+		if err == nil {
+			t.Errorf("%s: an unrevealable posture must error, got %+v", name, got)
+			continue
+		}
+		if !errors.Is(err, domain.ErrNotFound) {
+			t.Errorf("%s: error = %v, want ErrNotFound", name, err)
+		}
+		if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); has {
+			t.Errorf("%s: posture.revealed was recorded for an empty reveal", name)
+		}
+		if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 0 {
+			t.Errorf("%s: aha_reached_total moved by %v on an empty reveal", name, got)
+		}
+		if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 0 {
+			t.Errorf("%s: v2 histogram observed %d times on an empty reveal", name, got)
+		}
+	}
+}
+
+func TestPostureSummary_Unauthorized(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	uc := newPosture(reader, repo)
+
+	for name, call := range map[string][2]uuid.UUID{
+		"no tenant": {uuid.Nil, user},
+		"no user":   {tenant, uuid.Nil},
+		"neither":   {uuid.Nil, uuid.Nil},
+	} {
+		_, err := uc.Execute(context.Background(), call[0], call[1])
+		if err == nil || !errors.Is(err, domain.ErrForbidden) {
+			t.Errorf("%s: error = %v, want ErrForbidden", name, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Criteria 10 and 11
+// ---------------------------------------------------------------------------
+
+// Criterion 10: every read is scoped to the caller's tenant. Tenant B holds a
+// full posture; tenant A holds nothing and must see nothing of B's.
+func TestPostureSummary_NeverReadsAnotherTenant(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenantA, tenantB, user := uuid.New(), uuid.New(), uuid.New()
+	seedRevealable(reader, tenantB)
+
+	_, err := newPosture(reader, repo).Execute(context.Background(), tenantA, user)
+	if err == nil {
+		t.Fatal("tenant A holds nothing; it must not be able to reveal tenant B's posture")
+	}
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+
+	for _, seen := range reader.seenTenants {
+		if seen != tenantA {
+			t.Errorf("the use case read tenant %v while serving tenant %v", seen, tenantA)
+		}
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenantB, domain.ActivationPostureRevealed); has {
+		t.Error("tenant A's request recorded a reveal against tenant B")
+	}
+}
+
+// Criterion 11: rendering twice creates no duplicate row and does not move
+// completed_at.
+func TestPostureSummary_RevealIsIdempotent(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	uc := newPosture(reader, repo)
+
+	first, err := uc.Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("first reveal: %v", err)
+	}
+	second, err := uc.Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("second reveal: %v", err)
+	}
+
+	rows := 0
+	for _, e := range repo.events {
+		if e.TenantID == tenant && e.EventKey == domain.ActivationPostureRevealed {
+			rows++
+		}
+	}
+	if rows != 1 {
+		t.Errorf("posture.revealed recorded %d times, want exactly 1", rows)
+	}
+	if second.FirstReveal {
+		t.Error("the second render must not be flagged as the first reveal")
+	}
+	if first.RevealedAt == nil || second.RevealedAt == nil || !first.RevealedAt.Equal(*second.RevealedAt) {
+		t.Errorf("revealed_at moved: %v then %v", first.RevealedAt, second.RevealedAt)
+	}
+}
+
+// D-010: the reveal is the v2 definition. It must never touch v1, whose series
+// is frozen at the executive-dashboard definition.
+func TestPostureSummary_ObservesV2AndNeverV1(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+	repo.events = append(repo.events, domain.ActivationEvent{
+		TenantID:   tenant,
+		EventKey:   domain.ActivationSignup,
+		OccurredAt: time.Now().UTC().Add(-5 * time.Minute),
+	})
+
+	v1Before := ahaObservations(t, monitoring.AhaDefinitionV1)
+	v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+	countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 1 {
+		t.Errorf("v2 gained %d observations, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV1) - v1Before; got != 0 {
+		t.Errorf("the reveal leaked %d observations into the frozen v1 series", got)
+	}
+	if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 1 {
+		t.Errorf("aha_reached_total moved by %v, want 1", got)
+	}
+}
+
+// The tenant with no signup anchor is still counted — the D-010 defect again,
+// this time on the reveal's own path.
+func TestPostureSummary_CountsATenantWithNoSignupAnchor(t *testing.T) {
+	reader := newFakePostureReader()
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+	seedRevealable(reader, tenant)
+
+	countBefore := testutil.ToFloat64(monitoring.AhaReachedTotal)
+	v2Before := ahaObservations(t, monitoring.AhaDefinitionV2)
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := testutil.ToFloat64(monitoring.AhaReachedTotal) - countBefore; got != 1 {
+		t.Errorf("aha_reached_total moved by %v, want 1", got)
+	}
+	if got := ahaObservations(t, monitoring.AhaDefinitionV2) - v2Before; got != 0 {
+		t.Errorf("a duration was observed with no signup anchor: +%d", got)
+	}
+}
+
+// A dead store must surface, not degrade into a plausible-looking zero posture:
+// that is the failure that would make the launch-gate metric lie.
+func TestPostureSummary_PropagatesReaderFailure(t *testing.T) {
+	reader := newFakePostureReader()
+	reader.fail = true
+	repo := newFakeRepo()
+	tenant, user := uuid.New(), uuid.New()
+
+	if _, err := newPosture(reader, repo).Execute(context.Background(), tenant, user); err == nil {
+		t.Fatal("a failing reader must surface as an error, not as an empty posture")
+	}
+	if has, _ := repo.HasEvent(context.Background(), tenant, domain.ActivationPostureRevealed); has {
+		t.Error("a failed read recorded a reveal")
+	}
+}
+
+// Zero coverage and "nothing to cover" are different statements. Nil is the only
+// honest answer to the second.
+func TestCoveragePercent_NilWhenNothingIsApplicable(t *testing.T) {
+	if got := coveragePercent(PostureControlCounts{}); got != nil {
+		t.Errorf("no controls at all: coverage = %v, want nil", *got)
+	}
+	if got := coveragePercent(PostureControlCounts{Total: 5, NotApplicable: 5}); got != nil {
+		t.Errorf("everything scoped out: coverage = %v, want nil", *got)
+	}
+	if got := coveragePercent(PostureControlCounts{Total: 4, Implemented: 0}); got == nil || *got != 0 {
+		t.Errorf("applicable but none implemented: coverage = %v, want 0", got)
+	}
+	// in_progress earns no coverage: a control being worked on is not done.
+	got := coveragePercent(PostureControlCounts{Total: 4, Implemented: 1, InProgress: 3})
+	if got == nil || *got != 25 {
+		t.Errorf("coverage = %v, want 25", got)
+	}
+}
+
+func TestPostureSummary_IsRevealableRequiresAllThree(t *testing.T) {
+	pct := 40.0
+	full := &PostureSummary{
+		Risks:           PostureRiskCounts{Total: 3},
+		CoveragePercent: &pct,
+		TopRisks:        []PostureRiskView{{}},
+	}
+	if !full.IsRevealable() {
+		t.Fatal("a complete summary must be revealable")
+	}
+
+	noRisks := *full
+	noRisks.Risks = PostureRiskCounts{}
+	noCoverage := *full
+	noCoverage.CoveragePercent = nil
+	noTop := *full
+	noTop.TopRisks = nil
+
+	for name, s := range map[string]*PostureSummary{
+		"no risk count": &noRisks,
+		"no coverage":   &noCoverage,
+		"no residual":   &noTop,
+		"nil summary":   nil,
+	} {
+		if s.IsRevealable() {
+			t.Errorf("%s must not be revealable", name)
+		}
+	}
+}

--- a/backend/internal/application/activation/recognition.go
+++ b/backend/internal/application/activation/recognition.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package activation
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Recognition (#438 criterion 9) — the screen for the tenant that was already
+// configured before any of this shipped.
+//
+// #234's backfill made their checklist truthful and then stopped. Their
+// activation question is not "how do I create a risk"; it is "what does OpenRisk
+// already know about us that we did not". Walking a CISO whose bank has two
+// hundred risks through a five-step tunnel that asks them to write their first
+// one is worse than showing them nothing.
+//
+// So this surface answers with THEIR OWN NUMBERS and nothing else. Same rule as
+// the reveal: no sample, no demo, no placeholder.
+// ---------------------------------------------------------------------------
+
+// Read model and port live in internal/domain (domain/posture.go explains why).
+type (
+	RecognitionCounts = domain.RecognitionCounts
+	RecognitionReader = domain.RecognitionReader
+)
+
+// Recognition is the payload of GET /onboarding/recognition.
+type Recognition struct {
+	Counts RecognitionCounts `json:"counts"`
+	// Recognised is true when the tenant holds pre-existing data, which is what
+	// decides between this screen and the five-step tunnel. The SERVER decides:
+	// a client that could choose would be a client that can skip the tunnel.
+	Recognised bool `json:"recognised"`
+	// SkipTunnel mirrors Recognised for the guard, named for what the client does
+	// with it rather than for what it means.
+	SkipTunnel bool `json:"skip_tunnel"`
+}
+
+// RecognitionUseCase answers "does this tenant already have a posture?".
+type RecognitionUseCase struct {
+	reader RecognitionReader
+}
+
+// NewRecognitionUseCase builds the use case.
+func NewRecognitionUseCase(reader RecognitionReader) *RecognitionUseCase {
+	return &RecognitionUseCase{reader: reader}
+}
+
+// Execute returns the tenant's own counts.
+//
+// Typed errors: ErrForbidden with no tenant or no user on the session. Unlike
+// the reveal there is no ErrNotFound — a tenant holding nothing is a legitimate
+// answer here ("you are new, take the tunnel"), not a failure.
+func (uc *RecognitionUseCase) Execute(ctx context.Context, tenantID, userID uuid.UUID) (*Recognition, error) {
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant and a user are required to read a recognition")
+	}
+	if uc.reader == nil {
+		return nil, domain.NewInternalError("recognition reader is not wired")
+	}
+
+	counts, err := uc.reader.RecognitionCounts(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	recognised := counts.Any()
+	return &Recognition{
+		Counts:     counts,
+		Recognised: recognised,
+		SkipTunnel: recognised,
+	}, nil
+}

--- a/backend/internal/application/activation/recognition_test.go
+++ b/backend/internal/application/activation/recognition_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// Criterion 9: the tenant configured before any of this shipped sees ITS OWN
+// counts and is not walked through a tunnel that asks for its first risk.
+func TestRecognition_Success(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	reader.recog[tenant] = RecognitionCounts{Risks: 214, Frameworks: 2, Controls: 187, Assets: 43, Members: 9}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Counts.Risks != 214 || got.Counts.Controls != 187 {
+		t.Errorf("counts = %+v, want the tenant's own rows", got.Counts)
+	}
+	if !got.Recognised || !got.SkipTunnel {
+		t.Errorf("a configured tenant must be recognised and skip the tunnel, got %+v", got)
+	}
+}
+
+// A tenant that holds nothing is NOT an error — it is the brand-new case, and
+// the honest answer is "take the tunnel".
+func TestRecognition_BrandNewTenantIsNotAnError(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("a brand-new tenant must not error: %v", err)
+	}
+	if got.Recognised || got.SkipTunnel {
+		t.Errorf("a brand-new tenant must not skip the tunnel, got %+v", got)
+	}
+}
+
+// The founding member alone is not "a team". Counting them as pre-existing data
+// would send every brand-new tenant to the recognition screen instead of the
+// tunnel — the exact inversion of criterion 9.
+func TestRecognition_FoundingMemberAloneIsNotRecognition(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	reader.recog[tenant] = RecognitionCounts{Members: 1}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Recognised {
+		t.Error("one member and nothing else is a brand-new tenant, not a recognised one")
+	}
+
+	reader.recog[tenant] = RecognitionCounts{Members: 2}
+	got, _ = NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if !got.Recognised {
+		t.Error("a second member is real pre-existing data")
+	}
+}
+
+func TestRecognition_NotFound(t *testing.T) {
+	// There is no NotFound on this path by design, and that is worth pinning:
+	// an empty tenant is a legitimate answer, so a future edit that starts
+	// returning ErrNotFound here would silently break the brand-new journey.
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenant, user)
+	if err != nil {
+		t.Fatalf("an empty tenant must not be a 404: %v", err)
+	}
+	if got == nil {
+		t.Fatal("an empty tenant must still get a payload")
+	}
+
+	// An unwired reader IS an error — a zeroed recognition would send a
+	// configured bank into the tunnel.
+	if _, err := NewRecognitionUseCase(nil).Execute(context.Background(), tenant, user); err == nil {
+		t.Error("an unwired reader must error rather than report an empty tenant")
+	}
+}
+
+func TestRecognition_Unauthorized(t *testing.T) {
+	reader := newFakePostureReader()
+	tenant, user := uuid.New(), uuid.New()
+	uc := NewRecognitionUseCase(reader)
+
+	for name, call := range map[string][2]uuid.UUID{
+		"no tenant": {uuid.Nil, user},
+		"no user":   {tenant, uuid.Nil},
+		"neither":   {uuid.Nil, uuid.Nil},
+	} {
+		if _, err := uc.Execute(context.Background(), call[0], call[1]); err == nil || !errors.Is(err, domain.ErrForbidden) {
+			t.Errorf("%s: error = %v, want ErrForbidden", name, err)
+		}
+	}
+}
+
+// Criterion 10 again, on this surface.
+func TestRecognition_NeverReadsAnotherTenant(t *testing.T) {
+	reader := newFakePostureReader()
+	tenantA, tenantB, user := uuid.New(), uuid.New(), uuid.New()
+	reader.recog[tenantB] = RecognitionCounts{Risks: 214, Frameworks: 2, Controls: 187}
+
+	got, err := NewRecognitionUseCase(reader).Execute(context.Background(), tenantA, user)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.Counts.Risks != 0 || got.Recognised {
+		t.Errorf("tenant A saw tenant B's data: %+v", got.Counts)
+	}
+	for _, seen := range reader.seenTenants {
+		if seen != tenantA {
+			t.Errorf("the use case read tenant %v while serving tenant %v", seen, tenantA)
+		}
+	}
+}
+
+func TestRecognitionCounts_Any(t *testing.T) {
+	cases := map[string]struct {
+		counts RecognitionCounts
+		want   bool
+	}{
+		"empty":       {RecognitionCounts{}, false},
+		"one member":  {RecognitionCounts{Members: 1}, false},
+		"two members": {RecognitionCounts{Members: 2}, true},
+		"one risk":    {RecognitionCounts{Risks: 1}, true},
+		"a framework": {RecognitionCounts{Frameworks: 1}, true},
+		"controls":    {RecognitionCounts{Controls: 1}, true},
+		"assets":      {RecognitionCounts{Assets: 1}, true},
+	}
+	for name, tc := range cases {
+		if got := tc.counts.Any(); got != tc.want {
+			t.Errorf("%s: Any() = %v, want %v", name, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/domain/posture.go
+++ b/backend/internal/domain/posture.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package domain
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// ---------------------------------------------------------------------------
+// Posture read models (#438).
+//
+// These live in the domain rather than in the application package for one
+// structural reason: `internal/infrastructure/repository` cannot import
+// `internal/application/activation` — that package imports
+// `infrastructure/audittrail`, which imports `infrastructure/repository`, and
+// the cycle is real. Ports are declared in the application layer and satisfied
+// structurally by the repository (the pattern `OrgUpdater` already uses), which
+// only works if the TYPES they exchange sit in a package both may import.
+//
+// So: the shapes are here, the use cases and the ports stay in the application
+// layer, and no layer points the wrong way.
+// ---------------------------------------------------------------------------
+
+// TopRiskLimit is how many risks the reveal composes. Small on purpose: the
+// screen makes one statement the user can forward to their CISO, not a register
+// dump. Lives here so the use case and the repository share one number.
+const TopRiskLimit = 5
+
+// PostureRiskCounts is the tenant's risk register, in numbers.
+type PostureRiskCounts struct {
+	Total int `json:"total"`
+	// ByLevel is keyed by the Score Engine's own bands (low/medium/high/critical).
+	// The reveal never invents a banding of its own.
+	ByLevel map[string]int `json:"by_level"`
+}
+
+// PostureControlCounts is the tenant's compliance position, in numbers.
+type PostureControlCounts struct {
+	Frameworks int `json:"frameworks"`
+	Total      int `json:"total"`
+	// Implemented, InProgress and NotApplicable are counted separately because
+	// coverage and residual credit treat them differently: coverage excludes
+	// scoped-out controls from BOTH sides of the ratio, and gives `in_progress`
+	// nothing, while ADR 0003 gives `in_progress` partial residual credit.
+	Implemented   int `json:"implemented"`
+	NotApplicable int `json:"not_applicable"`
+	InProgress    int `json:"in_progress"`
+}
+
+// Applicable is Total minus the deliberately scoped-out controls.
+func (c PostureControlCounts) Applicable() int {
+	n := c.Total - c.NotApplicable
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// PostureRisk is one risk as the reveal reads it, before the residual is applied.
+type PostureRisk struct {
+	ID    uuid.UUID `json:"id"`
+	Title string    `json:"title"`
+	// Inherent is Risk.Score — the FROZEN P×I×AC value. The reveal reads it and
+	// never recomputes it.
+	Inherent float64 `json:"inherent"`
+	Level    string  `json:"level"`
+}
+
+// RecognitionCounts is what a tenant already holds, straight from its own rows.
+type RecognitionCounts struct {
+	Risks      int `json:"risks"`
+	Frameworks int `json:"frameworks"`
+	Controls   int `json:"controls"`
+	Assets     int `json:"assets"`
+	Members    int `json:"members"`
+}
+
+// Any is false for a tenant that holds nothing — the brand-new case, which
+// belongs in the tunnel and not on the recognition screen.
+//
+// One member is NOT recognition: every brand-new tenant has exactly one. Testing
+// `Members > 0` here would send every newcomer to the recognition screen and
+// nobody to the tunnel, which is the precise inversion of criterion 9.
+func (c RecognitionCounts) Any() bool {
+	return c.Risks > 0 || c.Frameworks > 0 || c.Controls > 0 || c.Assets > 0 || c.Members > 1
+}
+
+// PostureReader is the tenant-scoped read side of the Posture Reveal.
+//
+// EVERY method MUST filter on tenantID — #438 criterion 10, ABSOLUTE RULE #2.
+// The tenant is an argument on every call rather than a field on the
+// implementation, so a forgotten filter is a visible omission in a query rather
+// than an invisible one in a long-lived struct.
+type PostureReader interface {
+	RiskCounts(ctx context.Context, tenantID uuid.UUID) (PostureRiskCounts, error)
+	// TopRisks returns the tenant's highest-scoring risks, most exposed first.
+	TopRisks(ctx context.Context, tenantID uuid.UUID, limit int) ([]PostureRisk, error)
+	ControlCounts(ctx context.Context, tenantID uuid.UUID) (PostureControlCounts, error)
+	// ControlCreditsByRisk returns, per risk id, the credits ADR 0003 consumes.
+	// HasEvidence must be filled from the evidence library, or every implemented
+	// control silently earns 0.70 instead of 1.00 and the reveal under-reports
+	// the tenant's own posture.
+	ControlCreditsByRisk(ctx context.Context, tenantID uuid.UUID, riskIDs []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error)
+}
+
+// ---------------------------------------------------------------------------
+// Auto-skip (#438 criteria 2 and 3)
+// ---------------------------------------------------------------------------
+
+// OnboardingStepData says which of the tunnel's questions this (tenant, user)
+// has ALREADY answered with real data.
+//
+// The server decides, and it decides once: criterion 2 allows exactly one
+// GET /onboarding/state for the whole tunnel, so no step may probe on mount.
+// Criterion 3 then requires a step whose data exists to never render, never
+// flash, and to be absent from the stepper count shown to that user.
+type OnboardingStepData struct {
+	// HasOrganizationProfile is true when the organisation already carries the
+	// facts the organization step collects (an industry and a size), so asking
+	// again would be asking a member to re-describe a company that is already
+	// described.
+	HasOrganizationProfile bool `json:"has_organization_profile"`
+	// HasUserProfile is true when this user already has a name and a job title.
+	HasUserProfile bool `json:"has_user_profile"`
+	// HasFramework is true when the tenant already imported a framework.
+	HasFramework bool `json:"has_framework"`
+	// HasTeam is true when the tenant has more than its founding member.
+	HasTeam bool `json:"has_team"`
+}
+
+// OnboardingStepProbe reads the auto-skip decisions. Tenant AND user scoped:
+// the profile question is about a person, the framework question is about a
+// company, and conflating them would skip a new member's profile step because
+// their colleague filled one in.
+type OnboardingStepProbe interface {
+	OnboardingStepData(ctx context.Context, tenantID, userID uuid.UUID) (OnboardingStepData, error)
+}
+
+// SkipsStep answers whether one wizard step should be hidden from this user.
+//
+// `goal` is NEVER skippable and that is deliberate: it is a preference, not a
+// record. No stored row can prove what a user wants to do next, and skipping it
+// from an inferred answer would silently choose their landing page for them.
+func (d OnboardingStepData) SkipsStep(step OnboardingStepKey) bool {
+	switch step {
+	case OnboardingStepOrganization:
+		return d.HasOrganizationProfile
+	case OnboardingStepProfile:
+		return d.HasUserProfile
+	case OnboardingStepFramework:
+		return d.HasFramework
+	case OnboardingStepTeam:
+		return d.HasTeam
+	default:
+		return false
+	}
+}
+
+// VisibleSteps is the ordered sequence this user will actually walk. Never
+// empty: `goal` is unskippable, so there is always at least one step and the
+// tunnel can never complete without the user having done anything.
+func (d OnboardingStepData) VisibleSteps() []OnboardingStepKey {
+	out := make([]OnboardingStepKey, 0, len(OnboardingStepOrder))
+	for _, s := range OnboardingStepOrder {
+		if !d.SkipsStep(s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// RecognitionReader is the tenant-scoped read side of the recognition screen.
+type RecognitionReader interface {
+	RecognitionCounts(ctx context.Context, tenantID uuid.UUID) (RecognitionCounts, error)
+}

--- a/backend/internal/handler/activation_handler.go
+++ b/backend/internal/handler/activation_handler.go
@@ -25,6 +25,11 @@ type ActivationHandler struct {
 	state      *appactivation.GetStateUseCase
 	celebrated *appactivation.MarkCelebratedUseCase
 	onboarding *appactivation.OnboardingUseCase
+	// posture and recognition are OPTIONAL (nil-safe): a deployment that has not
+	// wired the posture reader still serves the checklist and the wizard. They
+	// answer 503 rather than an empty posture — see GetPosture.
+	posture     *appactivation.PostureUseCase
+	recognition *appactivation.RecognitionUseCase
 }
 
 // NewActivationHandler wires the handler.
@@ -34,6 +39,67 @@ func NewActivationHandler(
 	onboarding *appactivation.OnboardingUseCase,
 ) *ActivationHandler {
 	return &ActivationHandler{state: state, celebrated: celebrated, onboarding: onboarding}
+}
+
+// WithPosture attaches the Posture Reveal use case (#438).
+func (h *ActivationHandler) WithPosture(uc *appactivation.PostureUseCase) *ActivationHandler {
+	h.posture = uc
+	return h
+}
+
+// WithRecognition attaches the recognition use case (#438 criterion 9).
+func (h *ActivationHandler) WithRecognition(uc *appactivation.RecognitionUseCase) *ActivationHandler {
+	h.recognition = uc
+	return h
+}
+
+// GetPosture GET /posture
+//
+// The Posture Reveal: the screen that DEFINES the Aha moment, computed entirely
+// from this tenant's own rows. Recording `posture.revealed` and observing the v2
+// time-to-Aha histogram happen inside the use case, exactly once per tenant.
+//
+// The 404 on this route is load-bearing and is NOT a missing-resource error in
+// the usual sense: #438 criterion 8 requires that a reveal which would render
+// empty produces an explicit error state and records NOTHING. Answering 200 with
+// zeros would turn a rendering failure into a green launch-gate metric.
+func (h *ActivationHandler) GetPosture(c *fiber.Ctx) error {
+	tenantID, userID, ok := h.identity(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+	if h.posture == nil {
+		return c.Status(fiber.StatusServiceUnavailable).
+			JSON(fiber.Map{"error": "Posture is not available on this deployment"})
+	}
+
+	summary, err := h.posture.Execute(c.UserContext(), tenantID, userID)
+	if err != nil {
+		return writeAppError(c, err)
+	}
+	return c.JSON(summary)
+}
+
+// GetRecognition GET /onboarding/recognition
+//
+// What OpenRisk already knows about a tenant that was configured before the
+// tunnel existed (#438 criterion 9). The SERVER decides whether the tunnel is
+// skipped: a client that could choose would be a client that can skip it.
+func (h *ActivationHandler) GetRecognition(c *fiber.Ctx) error {
+	tenantID, userID, ok := h.identity(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Unauthorized"})
+	}
+	if h.recognition == nil {
+		return c.Status(fiber.StatusServiceUnavailable).
+			JSON(fiber.Map{"error": "Recognition is not available on this deployment"})
+	}
+
+	recognition, err := h.recognition.Execute(c.UserContext(), tenantID, userID)
+	if err != nil {
+		return writeAppError(c, err)
+	}
+	return c.JSON(recognition)
 }
 
 // identity resolves (tenant, user) from the request context.

--- a/backend/internal/infrastructure/repository/gorm_posture_repository.go
+++ b/backend/internal/infrastructure/repository/gorm_posture_repository.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Affero General Public License v3.0 (see LICENSE).
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/opendefender/openrisk/internal/domain"
+	"github.com/opendefender/openrisk/pkg/scoring"
+)
+
+// GormPostureRepository is the read side of the Posture Reveal and the
+// recognition screen (#438).
+//
+// ONE RULE GOVERNS EVERY QUERY IN THIS FILE: `tenant_id = ?`, on the table's own
+// tenant column, with no join that could reach a row belonging to somebody else.
+// This is #438 criterion 10 and ABSOLUTE RULE #2, and it matters more here than
+// almost anywhere else in the codebase — the reveal is the screen a brand-new
+// customer forwards to their CISO, so a leak here is a leak into an email.
+//
+// Models are domain structs rather than table names so GORM applies the
+// soft-delete scope: a tenant whose only risk was deleted has not created a
+// risk, and raw SQL would silently have counted the tombstone.
+type GormPostureRepository struct {
+	db *gorm.DB
+}
+
+// NewGormPostureRepository builds the repository.
+func NewGormPostureRepository(db *gorm.DB) *GormPostureRepository {
+	return &GormPostureRepository{db: db}
+}
+
+// Compile-time proof that this satisfies both ports. Without these, a signature
+// drift would only surface at wiring time in main.go.
+var (
+	_ domain.PostureReader       = (*GormPostureRepository)(nil)
+	_ domain.RecognitionReader   = (*GormPostureRepository)(nil)
+	_ domain.OnboardingStepProbe = (*GormPostureRepository)(nil)
+)
+
+// RiskCounts returns the tenant's register in numbers, banded by the Score
+// Engine's own criticality column — the reveal never invents a banding.
+func (r *GormPostureRepository) RiskCounts(ctx context.Context, tenantID uuid.UUID) (domain.PostureRiskCounts, error) {
+	out := domain.PostureRiskCounts{ByLevel: map[string]int{}}
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to count risks")
+	}
+
+	var rows []struct {
+		Criticality string
+		N           int64
+	}
+	if err := r.db.WithContext(ctx).
+		Model(&domain.Risk{}).
+		Select("criticality, COUNT(*) AS n").
+		Where("tenant_id = ?", tenantID).
+		Group("criticality").
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to count risks: %w", err)
+	}
+
+	for _, row := range rows {
+		out.ByLevel[row.Criticality] = int(row.N)
+		out.Total += int(row.N)
+	}
+	return out, nil
+}
+
+// TopRisks returns the tenant's most exposed risks, highest Score Engine score
+// first. `Risk.Score` is read, never recomputed: it is frozen.
+func (r *GormPostureRepository) TopRisks(ctx context.Context, tenantID uuid.UUID, limit int) ([]domain.PostureRisk, error) {
+	if tenantID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant is required to read risks")
+	}
+	if limit <= 0 {
+		limit = domain.TopRiskLimit
+	}
+
+	var risks []domain.Risk
+	if err := r.db.WithContext(ctx).
+		Where("tenant_id = ?", tenantID).
+		Order("score DESC, created_at ASC").
+		Limit(limit).
+		Find(&risks).Error; err != nil {
+		return nil, fmt.Errorf("failed to read top risks: %w", err)
+	}
+
+	out := make([]domain.PostureRisk, 0, len(risks))
+	for _, risk := range risks {
+		title := risk.Title
+		if title == "" {
+			title = risk.Name
+		}
+		out = append(out, domain.PostureRisk{
+			ID:       risk.ID,
+			Title:    title,
+			Inherent: risk.Score,
+			Level:    string(risk.Criticality),
+		})
+	}
+	return out, nil
+}
+
+// ControlCounts returns the tenant's compliance position. Statuses are counted
+// separately rather than reduced here, because coverage and residual credit
+// treat `in_progress` and `not_applicable` differently (ADR 0003).
+func (r *GormPostureRepository) ControlCounts(ctx context.Context, tenantID uuid.UUID) (domain.PostureControlCounts, error) {
+	var out domain.PostureControlCounts
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to count controls")
+	}
+
+	var rows []struct {
+		Status string
+		N      int64
+	}
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceControl{}).
+		Select("status, COUNT(*) AS n").
+		Where("tenant_id = ?", tenantID).
+		Group("status").
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to count controls: %w", err)
+	}
+
+	for _, row := range rows {
+		n := int(row.N)
+		out.Total += n
+		switch domain.ControlStatus(row.Status) {
+		case domain.ControlStatusImplemented:
+			out.Implemented += n
+		case domain.ControlStatusInProgress:
+			out.InProgress += n
+		case domain.ControlStatusNotApplicable:
+			out.NotApplicable += n
+		}
+	}
+
+	var frameworks int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceFramework{}).
+		Where("tenant_id = ?", tenantID).
+		Count(&frameworks).Error; err != nil {
+		return out, fmt.Errorf("failed to count frameworks: %w", err)
+	}
+	out.Frameworks = int(frameworks)
+
+	return out, nil
+}
+
+// ControlCreditsByRisk returns, per risk, the credits ADR 0003 consumes.
+//
+// Two tenancy guards, not one. The WHERE pins `risk_control_mappings.tenant_id`,
+// AND the join to `compliance_controls` carries `c.tenant_id = m.tenant_id`, so
+// a mapping row that pointed at another tenant's control (a corrupted row, a bad
+// import) still cannot pull that control's status into this tenant's score.
+//
+// HasEvidence is filled from the evidence library on the same terms the
+// compliance repository uses — accepted review, not expired. Getting this wrong
+// is silent: every implemented control would earn 0.70 instead of 1.00 and the
+// reveal would under-report the tenant's own posture.
+func (r *GormPostureRepository) ControlCreditsByRisk(ctx context.Context, tenantID uuid.UUID, riskIDs []uuid.UUID) (map[uuid.UUID][]scoring.ControlCredit, error) {
+	out := map[uuid.UUID][]scoring.ControlCredit{}
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to read control mappings")
+	}
+	if len(riskIDs) == 0 {
+		return out, nil
+	}
+
+	var rows []struct {
+		RiskID        uuid.UUID
+		Status        string
+		EvidenceCount int64
+	}
+	if err := r.db.WithContext(ctx).
+		Table("risk_control_mappings m").
+		Select(`m.risk_id AS risk_id,
+		        c.status AS status,
+		        (SELECT COUNT(*)
+		           FROM evidence_control_links l
+		           JOIN evidences e
+		             ON e.id = l.evidence_id
+		            AND e.tenant_id = l.tenant_id
+		            AND e.deleted_at IS NULL
+		          WHERE l.tenant_id = m.tenant_id
+		            AND l.control_id = c.id
+		            AND e.review = ?
+		            AND (e.valid_until IS NULL OR e.valid_until > ?)
+		        ) AS evidence_count`,
+			domain.EvidenceReviewAccepted, time.Now()).
+		Joins("JOIN compliance_controls c ON c.id = m.control_id AND c.tenant_id = m.tenant_id AND c.deleted_at IS NULL").
+		Where("m.tenant_id = ? AND m.risk_id IN ? AND m.deleted_at IS NULL", tenantID, riskIDs).
+		Scan(&rows).Error; err != nil {
+		return out, fmt.Errorf("failed to read control mappings: %w", err)
+	}
+
+	for _, row := range rows {
+		out[row.RiskID] = append(out[row.RiskID], scoring.ControlCredit{
+			Status:      scoring.ParseControlCoverageStatus(row.Status),
+			HasEvidence: row.EvidenceCount > 0,
+		})
+	}
+	return out, nil
+}
+
+// RecognitionCounts answers "what does OpenRisk already know about us" for the
+// tenant configured before any of this shipped (criterion 9).
+//
+// Members are counted on `organization_id`, which is that table's own tenant
+// column — the same choice the activation backfill makes for the `team` step,
+// and deliberately not `tenant_id`, which `organization_members` does not have.
+func (r *GormPostureRepository) RecognitionCounts(ctx context.Context, tenantID uuid.UUID) (domain.RecognitionCounts, error) {
+	var out domain.RecognitionCounts
+	if tenantID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant is required to read a recognition")
+	}
+
+	counts := []struct {
+		model  any
+		column string
+		into   *int
+	}{
+		{&domain.Risk{}, "tenant_id", &out.Risks},
+		{&domain.ComplianceFramework{}, "tenant_id", &out.Frameworks},
+		{&domain.ComplianceControl{}, "tenant_id", &out.Controls},
+		{&domain.Asset{}, "tenant_id", &out.Assets},
+		{&domain.OrganizationMember{}, "organization_id", &out.Members},
+	}
+
+	for _, c := range counts {
+		var n int64
+		if err := r.db.WithContext(ctx).
+			Model(c.model).
+			Where(c.column+" = ?", tenantID).
+			Count(&n).Error; err != nil {
+			return out, fmt.Errorf("failed to count %T: %w", c.model, err)
+		}
+		*c.into = int(n)
+	}
+	return out, nil
+}
+
+// OnboardingStepData resolves the tunnel's auto-skip decisions in one pass
+// (#438 criteria 2 and 3). Called ONCE per GET /onboarding/state; no step may
+// probe on mount.
+//
+// Tenant-scoped like everything else in this file, and user-scoped where the
+// question is about a person: the profile step belongs to the individual, so a
+// colleague having filled theirs in must not skip this user's.
+func (r *GormPostureRepository) OnboardingStepData(ctx context.Context, tenantID, userID uuid.UUID) (domain.OnboardingStepData, error) {
+	var out domain.OnboardingStepData
+	if tenantID == uuid.Nil || userID == uuid.Nil {
+		return out, domain.NewForbiddenError("a tenant and a user are required to resolve onboarding steps")
+	}
+
+	// The organisation step asks for an industry and a size. Both must already be
+	// present to skip it: an organisation with a name and nothing else has not
+	// answered the question the step actually asks.
+	var org domain.Organization
+	if err := r.db.WithContext(ctx).
+		Select("industry", "size").
+		Where("id = ?", tenantID).
+		First(&org).Error; err != nil && err != gorm.ErrRecordNotFound {
+		return out, fmt.Errorf("failed to read the organization profile: %w", err)
+	}
+	out.HasOrganizationProfile = strings.TrimSpace(org.Industry) != "" && strings.TrimSpace(string(org.Size)) != ""
+
+	// The profile step asks for a name and a function. `job_title` is stored in
+	// User.Department — see onboarding_profile_writes.go, which is the writer this
+	// probe has to agree with. Reading a different column here would skip a step
+	// the wizard never filled, or ask again for one it did.
+	var user domain.User
+	if err := r.db.WithContext(ctx).
+		Select("full_name", "department").
+		Where("id = ?", userID).
+		First(&user).Error; err != nil && err != gorm.ErrRecordNotFound {
+		return out, fmt.Errorf("failed to read the user profile: %w", err)
+	}
+	out.HasUserProfile = strings.TrimSpace(user.FullName) != "" && strings.TrimSpace(user.Department) != ""
+
+	var frameworks int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.ComplianceFramework{}).
+		Where("tenant_id = ?", tenantID).
+		Count(&frameworks).Error; err != nil {
+		return out, fmt.Errorf("failed to count frameworks: %w", err)
+	}
+	out.HasFramework = frameworks > 0
+
+	// More than the founding member. Exactly one member is every brand-new
+	// tenant, so `> 0` here would skip the team step for everybody.
+	var members int64
+	if err := r.db.WithContext(ctx).
+		Model(&domain.OrganizationMember{}).
+		Where("organization_id = ?", tenantID).
+		Count(&members).Error; err != nil {
+		return out, fmt.Errorf("failed to count members: %w", err)
+	}
+	out.HasTeam = members > 1
+
+	return out, nil
+}


### PR DESCRIPTION
Part of #438 — **PR 3 of 4**. Backend only. **Stacked on #625** (PR 2/4), which is stacked on
#622 (PR 1/4). Review in that order.

Does **not** close #438. PR 4 is the frontend.

## What it adds

**`GET /posture`** — the Posture Reveal, computed entirely from the tenant's own rows.
Records `posture.revealed` exactly once and observes
`ObserveTimeToAha(AhaDefinitionV2, …)`.

**Criterion 8 is implemented as a refusal, not as a check.** A payload that would be empty
returns `ErrNotFound` and records **nothing** — no event, no observation, no counter. Answering
`200` with zeros is the failure the criterion exists to prevent: it would turn a rendering
failure into a green launch-gate metric. `IsRevealable()` encodes criterion 6's three
requirements literally — a non-zero risk count, a non-null coverage percentage, at least one
residual.

**`GET /onboarding/recognition`** — criterion 9. What OpenRisk already knows about the tenant
#234 backfilled. Two deliberate asymmetries with the reveal:

- **A brand-new tenant is not an error here.** It is a legitimate answer ("take the tunnel"),
  so there is no `ErrNotFound` on this path and a test pins that, because a future edit adding
  one would silently break the brand-new journey.
- **One member is not a team.** Every brand-new tenant has exactly one, so `Members > 0` would
  route every newcomer to recognition and nobody to the tunnel — the precise inversion of
  criterion 9.

**Auto-skip** — criteria 2 and 3. `GET /onboarding/state` now resolves the whole tunnel in
**one** call, auto-skip decisions included, and `WizardState.Steps` carries only the steps this
user will actually see. `SkippedSteps` is returned for transparency, not for rendering.

Three things that took a second pass:

- **The cursor steps over hidden steps in both directions.** An explicit `Next` naming a hidden
  step is honoured as a *direction*, not a destination — silently ignoring it would leave the
  user on the step they just submitted.
- **A cursor pointing at a hidden step is snapped onto the visible sequence.** Two normal ways
  to get there: a brand-new progress row is initialised on `organization`, which may be the
  first step skipped; and a stored row can predate the data that now skips its step.
- **`goal` is never skippable.** It is a preference, not a record. Nothing stored can prove
  what a user wants to do next, and skipping it from an inferred answer would silently choose
  their landing page.

## Architecture note — why the read models moved to `internal/domain`

`internal/infrastructure/repository` **cannot** import `internal/application/activation`: that
package imports `infrastructure/audittrail`, which imports `infrastructure/repository`. The
cycle is real and the compiler says so.

The codebase's answer is narrow ports declared in the application layer and satisfied
structurally (the `OrgUpdater` pattern), which only works if the exchanged **types** live
somewhere both may import. So the shapes are in `internal/domain/posture.go`, the use cases and
the aliases stay in the application layer, and no layer points the wrong way. Compile-time
assertions in the repository keep the three ports honest — without them a signature drift would
surface only at wiring time in `main.go`.

## Tenant isolation — criterion 10

Every query in `gorm_posture_repository.go` filters on the table's own tenant column. The
control-mapping query carries **two** guards, not one:

```sql
JOIN compliance_controls c
  ON c.id = m.control_id
 AND c.tenant_id = m.tenant_id      -- second guard
 AND c.deleted_at IS NULL
WHERE m.tenant_id = ? AND m.risk_id IN ?
```

so a mapping row pointing at another tenant's control — a corrupt row, a bad import — still
cannot pull that control's status into this tenant's score. Models are domain structs rather
than table names so GORM applies the soft-delete scope: a tenant whose only risk was deleted
has not created a risk, and raw SQL would have counted the tombstone.

`TestPostureSummary_NeverReadsAnotherTenant` and `TestRecognition_NeverReadsAnotherTenant` use
a reader double keyed **by tenant** and assert every tenant the use case actually asked about.
A double that ignored the tenant argument could not fail, and a test that cannot fail proves
nothing.

## Two defects the tests caught before they shipped

1. **`revealed_at` was read from a second clock.** The recorder stamps `occurred_at` with its
   own clock; taking another `now()` for the response meant the first render reported a
   timestamp the second render could not reproduce. That is criterion 11's "`completed_at` is
   unchanged", failing on every second render. Fixed by reading the value **back** from the
   stored event.
2. **A fresh cursor parked on a hidden step.** `GetState` initialises a new progress row on
   `organization` before the probe runs, so a user whose organisation step was skipped got a
   cursor pointing at a screen the client is forbidden to draw.

## Verification

```
$ go build ./...
(no output — success)

$ go vet ./internal/application/activation/ ./internal/infrastructure/repository/ ./internal/handler/ ./internal/domain/
(no output — success)

$ go test ./internal/application/activation/ -v   # 45 tests, 0 failures
--- PASS: TestPostureSummary_Success (0.00s)
--- PASS: TestPostureSummary_NotFound (0.00s)
--- PASS: TestPostureSummary_Unauthorized (0.00s)
--- PASS: TestPostureSummary_NeverReadsAnotherTenant (0.00s)
--- PASS: TestPostureSummary_RevealIsIdempotent (0.00s)
--- PASS: TestPostureSummary_ObservesV2AndNeverV1 (0.00s)
--- PASS: TestPostureSummary_CountsATenantWithNoSignupAnchor (0.00s)
--- PASS: TestPostureSummary_PropagatesReaderFailure (0.00s)
--- PASS: TestPostureSummary_IsRevealableRequiresAllThree (0.00s)
--- PASS: TestCoveragePercent_NilWhenNothingIsApplicable (0.00s)
--- PASS: TestRecognition_Success (0.00s)
--- PASS: TestRecognition_BrandNewTenantIsNotAnError (0.00s)
--- PASS: TestRecognition_FoundingMemberAloneIsNotRecognition (0.00s)
--- PASS: TestRecognition_NotFound (0.00s)
--- PASS: TestRecognition_Unauthorized (0.00s)
--- PASS: TestRecognition_NeverReadsAnotherTenant (0.00s)
--- PASS: TestRecognitionCounts_Any (0.00s)
--- PASS: TestWizard_AutoSkippedStepsAreAbsentFromTheStepper (0.00s)
--- PASS: TestWizard_StateResolvesAutoSkipInASingleProbe (0.00s)
--- PASS: TestWizard_GoalIsNeverSkippable (0.00s)
--- PASS: TestWizard_CursorStepsOverHiddenSteps (0.00s)
--- PASS: TestWizard_StepIndexIsRelativeToVisibleSteps (0.00s)
--- PASS: TestWizard_ProbeFailureShowsEveryStep (0.00s)
--- PASS: TestWizard_NoProbeShowsEveryStep (0.00s)
--- PASS: TestWizard_CompleteParksOnTheLastVisibleStep (0.00s)
--- PASS: TestOnboardingStepData_SkipsStep (0.00s)
... (the 19 pre-existing tests in the package also pass)
ok      github.com/opendefender/openrisk/internal/application/activation 0.026s
```

RULE #4's trio is present on both new use cases: `TestPostureSummary_Success` /
`_NotFound` / `_Unauthorized` and `TestRecognition_Success` / `_NotFound` / `_Unauthorized`.

## Criteria

Backend halves now met and covered by a test: **2, 3, 5, 7, 8, 9, 10, 11**. Each still needs
its frontend half in PR 4 — a backend that returns the right step map does not prove the client
never flashes a skipped step.

Not touched by this PR: **1, 4, 6, 12, 13, 14, 15** — all frontend, E2E, a11y or docs.

## Security review

- Every query tenant-filtered; the mapping join double-guarded. No raw SQL string
  interpolation — every value is a bound parameter.
- No new write path. `GET /posture` writes one activation event and nothing else; the starter
  risk write path is PR 4's and does not exist yet.
- `/posture` and `/onboarding/recognition` are both behind `protected` and resolve
  `(tenant, user)` from the session only — no id is taken from the request, matching the
  session-sufficient rule (#529) the other activation routes follow.
- The `503` on an unwired use case is deliberate: a nil-safe degradation to an empty posture is
  exactly the silent failure criterion 8 forbids.

## Honest remainders

- **`Risk.ResidualRisk` is still not written**, per ADR 0003 being `proposed`. The reveal
  computes the residual and returns it; nothing is persisted. That stays true until the owner
  signs off `MaxEffectiveness = 0.80` and the credit weights.
- **`docs/openapi.yaml` is not updated.** The activation and onboarding surface is absent from
  the spec today — `/activation/state`, `/onboarding/*` are none of them documented — so adding
  two orphan paths would be inconsistent. Documenting the whole surface is worth its own issue;
  flagging it here because #608 was a P0 caused by exactly this drift.
- **No repository-level integration test.** `gorm_posture_repository.go` is proven by
  compile-time port assertions and by the use-case tests against a double; the SQL itself,
  including the double tenant guard on the join, is not exercised against a database in this
  PR. Criterion 10's E2E half lands in PR 4.
- **`ControlCredit.HasEvidence`** is filled from the evidence library on the same terms
  `gorm_compliance_repository.go` uses (accepted review, not expired). If those terms ever
  diverge, the reveal and the compliance screen will disagree about the same control.
- **Criterion 15 (the checklist can be closed) contradicts criterion 1 (no dismiss) on a fast
  read.** They are different surfaces: criterion 1 is the tunnel, criterion 15 is the
  post-tunnel checklist panel. PR 4 must not collapse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014q9DW1Xun6EkgDy7pRxvv6
