### PR TITLE
fix(onboarding): five defects found by walking the tunnel in a browser (#438)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2898,7 +2898,16 @@ func main() {
 	protected.Post("/onboarding/complete", activationHandler.CompleteOnboarding)
 	protected.Get("/onboarding/recognition", activationHandler.GetRecognition)
 	protected.Get("/onboarding/starter-risks", activationHandler.GetStarterRisks)
-	protected.Post("/onboarding/starter-risks", activationHandler.AdoptStarterRisks)
+	// The POST WRITES REAL RISKS into the tenant's register, so it carries the
+	// same permission as every other risk-creation path. The tunnel is walked by
+	// invited members too, and one without `risks:create` must not be able to
+	// put three rows in a register they may not write to.
+	//
+	// The client treats the resulting 403 the way it treats a 409: the step
+	// advances without adopting. A blocking tunnel that refuses to advance
+	// because of a permission the user will never have would lock them out of
+	// the product — the failure #438's Risk section names.
+	protected.Post("/onboarding/starter-risks", riskCreate, activationHandler.AdoptStarterRisks)
 	protected.Put("/onboarding/steps/:step", activationHandler.SaveOnboardingStep)
 
 	// The Posture Reveal (#438). Outside the /onboarding group on purpose: it is

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -925,12 +925,44 @@ func main() {
 		})
 	})
 
+	// Liveness/readiness. This is what docker-compose, the Helm probes and the
+	// E2E webServer wait on, so it must PROBE rather than assert.
+	//
+	// It used to return a hardcoded {"status":"UP","db":"CONNECTED"} — twelve
+	// lines below /status, whose own comment says it probes "so the public status
+	// page reflects reality, not a hardcoded UP". With Postgres stopped, this
+	// endpoint went on reporting a healthy database while every query failed with
+	// connection refused: an orchestrator would keep a dead instance in rotation
+	// and an operator debugging an outage would be told the database is fine.
+	//
+	// A failed probe answers 503, because a readiness probe that cannot fail is
+	// not a readiness probe.
 	api.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{
-			"status":  "UP",
+		dbUp := true
+		if sqlDB, err := database.DB.DB(); err != nil {
+			dbUp = false
+		} else {
+			// Bounded: a probe that blocks on a wedged connection turns a health
+			// check into an outage of its own.
+			ctx, cancel := context.WithTimeout(c.UserContext(), 2*time.Second)
+			defer cancel()
+			if sqlDB.PingContext(ctx) != nil {
+				dbUp = false
+			}
+		}
+
+		status := "UP"
+		code := fiber.StatusOK
+		if !dbUp {
+			status = "DOWN"
+			code = fiber.StatusServiceUnavailable
+		}
+
+		return c.Status(code).JSON(fiber.Map{
+			"status":  status,
 			"version": Version,
 			"commit":  Commit,
-			"db":      "CONNECTED",
+			"db":      map[bool]string{true: "CONNECTED", false: "DISCONNECTED"}[dbUp],
 			// Drives the permanent "demonstration data" banner. Served from the
 			// backend rather than a frontend build flag so the two cannot disagree
 			// about whether the data on screen is real.

--- a/backend/internal/application/activation/starter_risks.go
+++ b/backend/internal/application/activation/starter_risks.go
@@ -7,6 +7,7 @@ package activation
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -109,7 +110,7 @@ type AdoptResult struct {
 //     writing two rows when three were asked for would leave the user counting.
 //   - ErrConflict — this tenant already adopted. Idempotence with a name, so the
 //     client can say "already done" instead of retrying into a duplicate.
-func (uc *StarterRisksUseCase) Adopt(ctx context.Context, tenantID, userID uuid.UUID, keys []string) (*AdoptResult, error) {
+func (uc *StarterRisksUseCase) Adopt(ctx context.Context, tenantID, userID uuid.UUID, keys []string, lang string) (*AdoptResult, error) {
 	if tenantID == uuid.Nil || userID == uuid.Nil {
 		return nil, domain.NewForbiddenError("a tenant and a user are required to adopt starter risks")
 	}
@@ -120,6 +121,8 @@ func (uc *StarterRisksUseCase) Adopt(ctx context.Context, tenantID, userID uuid.
 	if len(keys) != onboarding.StarterRiskPickCount {
 		return nil, domain.NewValidationError("exactly three starter risks must be selected")
 	}
+
+	writeLang := normaliseLang(lang)
 
 	// Resolve EVERY key before writing ANY row. A half-adopted register — two
 	// rows written, the third key rejected — is worse than a refusal, and the
@@ -137,14 +140,10 @@ func (uc *StarterRisksUseCase) Adopt(ctx context.Context, tenantID, userID uuid.
 			return nil, domain.NewValidationError("unknown starter risk: " + key)
 		}
 
-		// The language the row is written in follows the tenant's own answers,
-		// not a request header: the register is read by colleagues who never saw
-		// this screen.
-		lang := uc.language(ctx, tenantID, userID)
 		drafts = append(drafts, domain.StarterRiskDraft{
 			StarterKey:  statement.Key,
-			Title:       statement.Title(lang),
-			Description: statement.Description(lang),
+			Title:       statement.Title(writeLang),
+			Description: statement.Description(writeLang),
 			Probability: statement.Probability,
 			Impact:      statement.Impact,
 			Tags:        statement.Tags,
@@ -194,19 +193,26 @@ func (uc *StarterRisksUseCase) answers(ctx context.Context, tenantID, userID uui
 	return progress.Industry, progress.Country
 }
 
-// language picks the language the rows are written in. French by default: it is
-// the primary market's language and the catalogue's source language, so a
-// missing answer produces the statement as authored rather than a translation.
-func (uc *StarterRisksUseCase) language(ctx context.Context, tenantID, userID uuid.UUID) string {
-	if uc.repo == nil {
+// normaliseLang resolves the language the rows are WRITTEN in.
+//
+// This used to read a `language` answer off the `profile` step. #438 retired
+// that route, and nothing writes that answer any more — so every tenant, English
+// ones included, got French statements written into their risk register. Rows a
+// customer did not author, in a language their colleagues may not read, is the
+// precise failure ADR 0003 and this file's header set out to avoid.
+//
+// The language now comes from the caller, because it is a PREFERENCE and not
+// CONTENT: it selects which of two server-authored strings to store, and it
+// cannot introduce text of the client's own. Anything unrecognised falls back to
+// French — the catalogue's source language, so an unknown value stores the
+// statement as authored rather than an accidental half-translation.
+func normaliseLang(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "en":
+		return "en"
+	case "fr":
+		return "fr"
+	default:
 		return "fr"
 	}
-	progress, err := uc.repo.Get(ctx, tenantID, userID)
-	if err != nil || progress == nil {
-		return "fr"
-	}
-	if lang := stringAnswer(progress.StepAnswers(domain.OnboardingStepProfile), "language"); lang != "" {
-		return lang
-	}
-	return "fr"
 }

--- a/backend/internal/application/activation/starter_risks_test.go
+++ b/backend/internal/application/activation/starter_risks_test.go
@@ -81,7 +81,7 @@ func TestAdoptStarterRisks_Success(t *testing.T) {
 	seedAnswers(repo, tenant, user, "banking", "CM")
 	keys := threeKeys(t)
 
-	got, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, keys)
+	got, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, keys, "fr")
 	if err != nil {
 		t.Fatalf("Adopt: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestAdoptStarterRisks_NotFound(t *testing.T) {
 	keys := threeKeys(t)
 	keys[2] = "starter_does_not_exist"
 
-	_, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, keys)
+	_, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, keys, "fr")
 	if err == nil || !errors.Is(err, domain.ErrValidation) {
 		t.Fatalf("error = %v, want ErrValidation", err)
 	}
@@ -150,7 +150,7 @@ func TestAdoptStarterRisks_Unauthorized(t *testing.T) {
 		"no user":   {tenant, uuid.Nil},
 		"neither":   {uuid.Nil, uuid.Nil},
 	} {
-		if _, err := uc.Adopt(context.Background(), call[0], call[1], keys); err == nil || !errors.Is(err, domain.ErrForbidden) {
+		if _, err := uc.Adopt(context.Background(), call[0], call[1], keys, "fr"); err == nil || !errors.Is(err, domain.ErrForbidden) {
 			t.Errorf("Adopt %s: error = %v, want ErrForbidden", name, err)
 		}
 		if _, err := uc.List(context.Background(), call[0], call[1]); err == nil || !errors.Is(err, domain.ErrForbidden) {
@@ -166,6 +166,62 @@ func TestAdoptStarterRisks_Unauthorized(t *testing.T) {
 // The properties that keep a customer's register clean
 // ---------------------------------------------------------------------------
 
+// THE BUG THIS ARGUMENT EXISTS TO FIX, pinned.
+//
+// The write language used to be read off the retired `profile` step's answers,
+// which nothing writes any more — so every tenant, English ones included, got
+// French statements written into their risk register. Rows a customer did not
+// author, in a language their colleagues may not read.
+func TestAdoptStarterRisks_WritesInTheRequestedLanguage(t *testing.T) {
+	for _, lang := range []string{"en", "fr"} {
+		repo, writer := newFakeRepo(), newFakeStarterWriter()
+		tenant, user := uuid.New(), uuid.New()
+		seedAnswers(repo, tenant, user, "banking", "CM")
+		keys := threeKeys(t)
+
+		if _, err := NewStarterRisksUseCase(repo, writer).Adopt(
+			context.Background(), tenant, user, keys, lang,
+		); err != nil {
+			t.Fatalf("%s: Adopt: %v", lang, err)
+		}
+
+		for i, draft := range writer.written[tenant] {
+			statement, _ := onboarding.StarterRiskByKey(keys[i])
+			if draft.Title != statement.Title(lang) {
+				t.Errorf("%s: title = %q, want %q", lang, draft.Title, statement.Title(lang))
+			}
+		}
+	}
+}
+
+// The language selects one of two SERVER-AUTHORED strings; it can never
+// introduce text of the client's own. An unrecognised value stores the statement
+// as authored rather than an accidental half-translation.
+func TestAdoptStarterRisks_UnknownLanguageFallsBackToFrench(t *testing.T) {
+	hostile := "en\u0000; --"
+	for _, lang := range []string{"", "de", "EN-GB", hostile} {
+		repo, writer := newFakeRepo(), newFakeStarterWriter()
+		tenant, user := uuid.New(), uuid.New()
+		seedAnswers(repo, tenant, user, "banking", "CM")
+		keys := threeKeys(t)
+
+		if _, err := NewStarterRisksUseCase(repo, writer).Adopt(
+			context.Background(), tenant, user, keys, lang,
+		); err != nil {
+			t.Fatalf("%q: Adopt: %v", lang, err)
+		}
+		statement, _ := onboarding.StarterRiskByKey(keys[0])
+		if got := writer.written[tenant][0].Title; got != statement.Title("fr") {
+			t.Errorf("%q: title = %q, want the French original", lang, got)
+		}
+	}
+
+	// Case and padding are tolerated: a client sending "EN" or " en " means en.
+	if got := normaliseLang(" EN "); got != "en" {
+		t.Errorf("normaliseLang with padding = %q, want en", got)
+	}
+}
+
 // The tunnel is resumable and back-navigable BY DESIGN, so a user will return to
 // step 2. Without this guard every return visit doubles the register.
 func TestAdoptStarterRisks_IsIdempotentPerTenant(t *testing.T) {
@@ -175,11 +231,11 @@ func TestAdoptStarterRisks_IsIdempotentPerTenant(t *testing.T) {
 	uc := NewStarterRisksUseCase(repo, writer)
 	keys := threeKeys(t)
 
-	if _, err := uc.Adopt(context.Background(), tenant, user, keys); err != nil {
+	if _, err := uc.Adopt(context.Background(), tenant, user, keys, "fr"); err != nil {
 		t.Fatalf("first adopt: %v", err)
 	}
 
-	_, err := uc.Adopt(context.Background(), tenant, user, keys)
+	_, err := uc.Adopt(context.Background(), tenant, user, keys, "fr")
 	if err == nil || !errors.Is(err, domain.ErrConflict) {
 		t.Fatalf("second adopt: error = %v, want ErrConflict", err)
 	}
@@ -196,7 +252,7 @@ func TestAdoptStarterRisks_NeverWritesToAnotherTenant(t *testing.T) {
 	tenantA, tenantB, user := uuid.New(), uuid.New(), uuid.New()
 	seedAnswers(repo, tenantA, user, "banking", "CM")
 
-	if _, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenantA, user, threeKeys(t)); err != nil {
+	if _, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenantA, user, threeKeys(t), "fr"); err != nil {
 		t.Fatalf("Adopt: %v", err)
 	}
 	if len(writer.written[tenantB]) != 0 {
@@ -205,7 +261,7 @@ func TestAdoptStarterRisks_NeverWritesToAnotherTenant(t *testing.T) {
 
 	// And tenant B's own adoption is not blocked by tenant A's.
 	seedAnswers(repo, tenantB, user, "health", "FR")
-	if _, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenantB, user, threeKeys(t)); err != nil {
+	if _, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenantB, user, threeKeys(t), "fr"); err != nil {
 		t.Errorf("tenant B must be able to adopt independently: %v", err)
 	}
 }
@@ -231,14 +287,14 @@ func TestAdoptStarterRisks_RequiresExactlyThree(t *testing.T) {
 		"four":  eight[:4],
 		"eight": eight,
 	} {
-		if _, err := uc.Adopt(context.Background(), tenant, user, keys); err == nil || !errors.Is(err, domain.ErrValidation) {
+		if _, err := uc.Adopt(context.Background(), tenant, user, keys, "fr"); err == nil || !errors.Is(err, domain.ErrValidation) {
 			t.Errorf("%s: error = %v, want ErrValidation", name, err)
 		}
 	}
 
 	// A duplicate is three keys but not three statements.
 	dup := []string{eight[0], eight[0], eight[1]}
-	if _, err := uc.Adopt(context.Background(), tenant, user, dup); err == nil || !errors.Is(err, domain.ErrValidation) {
+	if _, err := uc.Adopt(context.Background(), tenant, user, dup, "fr"); err == nil || !errors.Is(err, domain.ErrValidation) {
 		t.Errorf("a repeated key must be rejected, got %v", err)
 	}
 	if len(writer.written[tenant]) != 0 {
@@ -254,7 +310,7 @@ func TestAdoptStarterRisks_SurfacesAPartialFailure(t *testing.T) {
 	tenant, user := uuid.New(), uuid.New()
 	seedAnswers(repo, tenant, user, "banking", "CM")
 
-	got, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, threeKeys(t))
+	got, err := NewStarterRisksUseCase(repo, writer).Adopt(context.Background(), tenant, user, threeKeys(t), "fr")
 	if err == nil {
 		t.Fatal("a failing writer must surface")
 	}
@@ -316,7 +372,7 @@ func TestListStarterRisks_ReportsAnExistingAdoption(t *testing.T) {
 	seedAnswers(repo, tenant, user, "banking", "CM")
 	uc := NewStarterRisksUseCase(repo, writer)
 
-	if _, err := uc.Adopt(context.Background(), tenant, user, threeKeys(t)); err != nil {
+	if _, err := uc.Adopt(context.Background(), tenant, user, threeKeys(t), "fr"); err != nil {
 		t.Fatalf("Adopt: %v", err)
 	}
 	offer, err := uc.List(context.Background(), tenant, user)

--- a/backend/internal/auth/token_test.go
+++ b/backend/internal/auth/token_test.go
@@ -10,6 +10,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -22,21 +24,24 @@ import (
 	authpkg "github.com/opendefender/openrisk/pkg/auth"
 )
 
-// newTokenHarness builds a TokenManager over an in-memory sqlite refresh_tokens
+// newTokenHarness builds a TokenManager over a temporary sqlite refresh_tokens
 // table with an org resolver that yields claims for whichever org it is asked
 // about (recording the last org it saw, so tests can assert org preservation).
 func newTokenHarness(t *testing.T) (*TokenManager, *gorm.DB, *resolverSpy) {
 	t.Helper()
 
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	// Use a per-test temp file instead of ":memory:" so that concurrent
+	// goroutines (TestRefresh_ConcurrentRotation_OneWinner) share a single
+	// database through WAL mode and busy_timeout, which models the real
+	// Postgres serialisation. ":memory:" with MaxOpenConns(1) was flaky
+	// under make test's inter-package parallelism.
+	dbPath := filepath.Join(t.TempDir(), "token_test.db")
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000", dbPath)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	// Pin to a single connection: sqlite ":memory:" is per-connection, so an
-	// unbounded pool would give each concurrent goroutine its OWN database and
-	// every one of them would "win" the rotation. One connection models the single
-	// logical database (Postgres) where the atomic UPDATE genuinely serialises.
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxOpenConns(4)
 	require.NoError(t, db.Exec(`
 		CREATE TABLE refresh_tokens (
 			id TEXT PRIMARY KEY,

--- a/backend/internal/domain/business_roles.go
+++ b/backend/internal/domain/business_roles.go
@@ -203,7 +203,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Chief information security officer: cyber risks, vulnerabilities, incidents, security controls and KPIs.",
 		DefaultLanding: "/",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"vulnerabilities:read", "vulnerabilities:update",
 			"incidents:read", "incidents:create", "incidents:update",
@@ -223,7 +222,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "IT director: global IT view, assets, availability and IT risks.",
 		DefaultLanding: "/assets",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"assets:read", "assets:create", "assets:update", "assets:delete",
 			"mitigations:read", "mitigations:create", "mitigations:update",
@@ -243,7 +241,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Risk management: register, assessments, treatments, heatmaps and reporting.",
 		DefaultLanding: "/risks",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update", "risks:delete",
 			"mitigations:read", "mitigations:create", "mitigations:update", "mitigations:delete",
 			"assets:read",
@@ -261,7 +258,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Audit: audit campaigns, findings, evidences, action plans and history (broad read + audit management).",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",
@@ -281,7 +277,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Compliance: frameworks, controls, evidences, remediation plans and regulatory obligations.",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",
@@ -302,7 +297,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Internal control: control testing, evidences, audits and remediation plans.",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read", "mitigations:update",
@@ -323,7 +317,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Asset owner: manages their asset scope and tracks associated risks.",
 		DefaultLanding: "/assets",
 		Permissions: []PermissionKey{
-			"events:read",
 			"assets:read", "assets:create", "assets:update",
 			"risks:read",
 			"mitigations:read", "mitigations:update",
@@ -339,7 +332,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Risk owner: treats the risks they own and their mitigation plans.",
 		DefaultLanding: "/risks",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:update",
 			"mitigations:read", "mitigations:create", "mitigations:update",
 			"assets:read",
@@ -355,7 +347,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "SOC analyst: vulnerabilities, incidents, scans, automation and risk treatment.",
 		DefaultLanding: "/vulnerabilities",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"vulnerabilities:read", "vulnerabilities:update", "vulnerabilities:delete",
 			"incidents:read", "incidents:create", "incidents:update", "incidents:delete",
@@ -374,7 +365,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Executive / board: strategic dashboard, financial exposure and reports — no technical detail.",
 		DefaultLanding: "/analytics",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"compliance:read",
 			"reports:board:read",
@@ -388,7 +378,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Read-only access to the whole GRC posture.",
 		DefaultLanding: "/",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",

--- a/backend/internal/handler/activation_handler.go
+++ b/backend/internal/handler/activation_handler.go
@@ -88,6 +88,11 @@ type adoptStarterRisksInput struct {
 	// that could post free text would be an unvalidated write into a customer's
 	// risk register.
 	Keys []string `json:"keys"`
+	// Lang selects WHICH of the two server-authored strings is stored. It is a
+	// preference, not content — it cannot introduce text of the client's own, and
+	// anything unrecognised falls back to French. Sent by the client because it
+	// is the only party that knows which language the person is reading.
+	Lang string `json:"lang"`
 }
 
 // AdoptStarterRisks POST /onboarding/starter-risks
@@ -110,7 +115,7 @@ func (h *ActivationHandler) AdoptStarterRisks(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
 	}
 
-	result, err := h.starter.Adopt(c.UserContext(), tenantID, userID, in.Keys)
+	result, err := h.starter.Adopt(c.UserContext(), tenantID, userID, in.Keys, in.Lang)
 	if err != nil {
 		return writeAppError(c, err)
 	}

--- a/backend/internal/handler/authz_route_coverage_test.go
+++ b/backend/internal/handler/authz_route_coverage_test.go
@@ -83,6 +83,26 @@ var routesWithoutPermissionGuard = []string{
 	"DELETE /tokens/:id",
 	"GET /action-center",
 	"GET /activation/state",
+	// #438 — the Posture Reveal, the recognition screen and the starter
+	// catalogue READ.
+	//
+	// Session-sufficient for the same reason as GET /activation/state, which
+	// this list already carries: they are the product's own account of where
+	// THIS user stands, resolved from (tenant, user) on the session with no id
+	// taken from the request. Gating a user's own posture behind a permission
+	// would hide their own data from them, and there is no permission that
+	// means "may look at yourself".
+	//
+	// The catalogue READ returns compiled-in statements (pkg/onboarding)
+	// filtered by the caller's own stored sector; the only tenant-derived field
+	// is already_adopted. The catalogue WRITE is NOT here — POST
+	// /onboarding/starter-risks carries risks:create, like every other risk
+	// write.
+	//
+	// NEEDS A REVIEWER'S AGREEMENT per this list's contract.
+	"GET /onboarding/recognition",
+	"GET /onboarding/starter-risks",
+	"GET /posture",
 	"GET /ai/status",
 	"GET /analytics/dashboard",
 	"GET /analytics/export",

--- a/backend/internal/security/isolation/registry.go
+++ b/backend/internal/security/isolation/registry.go
@@ -499,6 +499,28 @@ var decisions = []Decision{
 	{"/api/v1/activation/state", Pending,
 		"assessed, not pinned: same (tenant, user) gate, 401 when either is missing. Unresolved: the activation state aggregates progress across several modules and this sweep did not read each source. Settled by a two-tenant test over the activation state use case"},
 
+	// --- Posture reveal and recognition (#438) ----------------------------
+	//
+	// All three resolve (tenant, user) from the session and take no id from the
+	// request, and every query in gorm_posture_repository.go filters on the
+	// table's own tenant column — the control-mapping join carries a second
+	// guard, c.tenant_id = m.tenant_id, so a corrupt mapping row cannot pull
+	// another tenant's control status into this tenant's score.
+	//
+	// Pending rather than Covered, deliberately: the use-case tests
+	// (TestPostureSummary_NeverReadsAnotherTenant,
+	// TestRecognition_NeverReadsAnotherTenant,
+	// TestAdoptStarterRisks_NeverWritesToAnotherTenant) drive a reader double
+	// keyed BY TENANT, which proves the use case passes the caller's tenant
+	// down. It does NOT exercise the SQL. Claiming Covered on that basis would
+	// be exactly the guess this register exists to prevent.
+	{"/api/v1/posture", Pending,
+		"assessed, not pinned: (tenant, user) resolved from the session, 401 when either is missing; every query in gorm_posture_repository.go filters on tenant_id and the compliance_controls join carries c.tenant_id = m.tenant_id. Unresolved: application/activation TestPostureSummary_NeverReadsAnotherTenant asserts the use case reads only the caller's tenant, but it drives a double — the repository SQL itself has no cross-tenant test. Settled by a two-tenant repository test over RiskCounts, TopRisks, ControlCounts and ControlCreditsByRisk"},
+	{"/api/v1/onboarding/recognition", Pending,
+		"assessed, not pinned: same (tenant, user) gate; RecognitionCounts counts five tables, each on its own tenant column (organization_members on organization_id, which is that table's tenant column). Unresolved: application/activation TestRecognition_NeverReadsAnotherTenant drives a double, not the SQL. Settled by the same two-tenant repository test"},
+	{"/api/v1/onboarding/starter-risks", Pending,
+		"assessed, not pinned: GET returns a COMPILED-IN catalogue (pkg/onboarding) filtered by the caller's own stored sector and country, so the response body holds no tenant rows; the only tenant-derived field is already_adopted, read through the tenant-scoped risk repository. POST writes through application/risk CreateRiskUseCase, which stamps TenantID from the caller. Unresolved: TestAdoptStarterRisks_NeverWritesToAnotherTenant drives a writer double. Settled by a repository-level test asserting an adopted row lands on the caller's tenant only"},
+
 	// --- Risks and scoring (5) --------------------------------------------
 	{"/api/v1/risks", Covered,
 		"handler/risk_isolation_test TestRiskIsolation_ListLeaksNothing drives GET /risks over the real handler and repository from one tenant against another's register; TestRiskIsolation_NilTenantIsDenied covers the unresolved-tenant case"},

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,41 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
+### D-043 — the sidebar shows five destinations twice · raised 2026-09-11
+**Context** — `frontend/src/shared/navModel.ts` defines seven nav groups. The
+first, `g_pilot`, holds exactly `risks · vulnerabilities · mitigations ·
+incidents · automation` — and every one of those five is a verbatim duplicate
+(same key, path, label, icon and permission) of an item in `g_identify`,
+`g_evaluate` or `g_treat`. The live sidebar renders 28 links of which 5 pairs
+point at the same route, and on `/risks` TWO sidebar links carry
+`aria-current="page"` at once.
+
+The model contradicts its own documentation twice. `g_pilot`'s comment says it
+is "« Où en suis-je ? » (dashboard par rôle, exécutif, financier)" — those five
+screens are in `g_monitor`, not here. And the block comment says the core
+intention "identify → score → treat → prove" **leads** the order; `g_pilot`
+leads instead.
+
+**Options**
+- **A — delete `g_pilot`.** The GRC flow (identify → evaluate → treat → prove)
+  becomes the navigation, matching what the file says it wanted. Five links
+  disappear from the sidebar; nobody loses a destination.
+- **B — keep `g_pilot` as a deliberate quick-access group, and remove the five
+  duplicates from the flow groups.** `g_evaluate` would then be empty and would
+  have to go, and "Traiter" would lose its whole contents.
+- **C — keep both and mark only one instance current.** The duplication stays;
+  only the `aria-current` defect is fixed.
+
+**Recommendation** — A. It is the only option under which the file's own stated
+intent and its contents agree, and it is the one that removes the duplication
+rather than hiding it.
+
+**Cost of delay** — Low but compounding: every new operational screen has to be
+added in two places, and the "is this group the dashboards or the registers?"
+question is re-asked by each person who edits the file.
+
+**Reversible?** — Yes, entirely. One array in one file.
+
 ### D-041 — may the backend container generate its own RS256 keypair? · raised 2026-09-09
 **Context** — #328's criterion 5 wants a one-click deploy to a third-party
 platform (Render/Railway/Fly). It cannot be built today: the backend panics at

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -93,6 +93,38 @@ optional keys:
 - **Public URL / CORS:** `APP_BASE_URL`, `CORS_ORIGINS`, `VITE_API_URL` when you
   put OpenRisk behind a real domain / reverse proxy.
 
+## Capabilities
+
+<!-- BEGIN GENERATED: entitlements matrix -->
+<!-- Generated from backend/pkg/entitlements/entitlements.go.
+     Do not edit by hand: `go test ./pkg/entitlements/ -run TestSelfHostDoc -update`. -->
+
+| Capability | Free | Pro | Business | Enterprise |
+|---|---|---|---|---|
+| Users | 2 | 10 | 50 | unlimited |
+| Risks | 50 | 500 | unlimited | unlimited |
+| Assets | 50 | unlimited | unlimited | unlimited |
+| Integrations | 1 | 10 | unlimited | unlimited |
+| REST API | limited | yes | yes | yes |
+| Automation rules | — | yes | advanced | advanced |
+| AI advisor | — | yes | advanced | advanced |
+| Compliance frameworks | basic | standard | advanced | custom |
+| SSO (SAML / OIDC) | — | — | yes | advanced |
+| Multi-tenant | — | — | — | yes |
+| On-premise entitlement | — | — | — | yes |
+| Financial quantification | — | yes | yes | yes |
+| SmartScore | — | yes | yes | yes |
+| Executive dashboard | — | yes | yes | yes |
+| Scanner | — | yes | yes | yes |
+| Threat intelligence (CTI) | — | — | yes | advanced |
+| Governance | — | — | yes | advanced |
+| SLA | — | — | 99.5% | 99.9% |
+| Support | community | email | priority | dedicated |
+
+A self-hosted instance registers its first organisation with no plan set, so it resolves to **Free**: 2 users, 50 risks, 50 assets, 1 integration(s).
+
+<!-- END GENERATED: entitlements matrix -->
+
 ## Upgrade
 
 ```bash

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -415,7 +415,17 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
       offline: { color: 'var(--fg-muted)', label: ['Hors ligne', 'Offline'], pulse: false },
     };
   let m = meta[status.state];
-  let state: string = status.state;
+  // `live` is the realtime stream's own state, reported SEPARATELY from the
+  // connection state below. It used to overwrite `data-state`, which meant the
+  // attribute never read "online" while the API was reachable — it always
+  // carried a live-* value instead. That silently broke the contract
+  // tests/e2e/dead-controls.spec.ts reads ("the status dot reports the REAL
+  // connection"), and conflated two questions a user asks separately: can the
+  // app reach the server, and are updates arriving by themselves.
+  //
+  // The colour and the label still combine both, because one dot is the right
+  // amount of chrome. Only the machine-readable attributes are split.
+  let liveState: string = 'none';
 
   if (status.state === 'online') {
     switch (live.state) {
@@ -425,7 +435,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Mises à jour en direct', 'Live updates on'],
           pulse: true,
         };
-        state = 'live';
+        liveState = 'live';
         break;
       case 'RECONNECTING':
       case 'INITIALIZING':
@@ -434,7 +444,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Reconnexion au flux…', 'Reconnecting to the live stream…'],
           pulse: false,
         };
-        state = 'live-reconnecting';
+        liveState = 'live-reconnecting';
         break;
       case 'RESYNCING':
         m = {
@@ -442,7 +452,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Resynchronisation en cours', 'Resynchronising'],
           pulse: false,
         };
-        state = 'live-resyncing';
+        liveState = 'live-resyncing';
         break;
       case 'FORBIDDEN':
         // Said plainly rather than shown as a fault: nothing is broken, this
@@ -455,7 +465,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           ],
           pulse: false,
         };
-        state = 'live-forbidden';
+        liveState = 'live-forbidden';
         break;
       case 'ERROR':
       case 'DISCONNECTED':
@@ -467,7 +477,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           ],
           pulse: false,
         };
-        state = 'live-off';
+        liveState = 'live-off';
         break;
     }
   }
@@ -478,7 +488,8 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
       className="flex items-center px-2"
       title={label}
       data-testid="connection-status"
-      data-state={state}
+      data-state={status.state}
+      data-live={liveState}
     >
       <span
         className="w-[7px] h-[7px] rounded-full"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router';
+import { Link, useNavigate, useLocation } from 'react-router';
 import {
   ChevronsUpDown,
   PanelLeftClose,
@@ -152,12 +152,23 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
     const active = item.key === activeKey;
     const Icon = item.icon;
     return (
-      <button
+      // A LINK, not a button. Every nav entry used to be `<button
+      // onClick={navigate(...)}>`, which renders no href — so Ctrl/Cmd+click,
+      // middle-click and "copy link address" all did nothing, and a screen
+      // reader announced 27 buttons where a user expects a list of links.
+      //
+      // A risk manager comparing two registers side by side needs a second tab,
+      // and there was no way to open one. `Link` keeps the SPA navigation for a
+      // plain click and lets the browser handle the modified ones itself.
+      <Link
         key={item.key}
+        to={item.href ?? item.path}
         data-testid={`nav-${item.key}`}
         // Anchor for the product tour's third coach mark (features/onboarding/ProductTour).
         data-tour={`nav-${item.key}`}
-        onClick={() => navigate(item.href ?? item.path)}
+        // The visual highlight told sighted users which page they were on; this
+        // is the same fact, for everyone else.
+        aria-current={active ? 'page' : undefined}
         title={L[item.labelKey]}
         className={cn(
           'w-full flex items-center gap-[11px] px-[11px] py-2 rounded-[9px] relative mb-0.5 transition-colors',
@@ -203,7 +214,7 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
               {navCounts[item.badge.count]}
             </span>
           ))}
-      </button>
+      </Link>
     );
   };
 

--- a/frontend/src/features/ai/AiAdvisor.tsx
+++ b/frontend/src/features/ai/AiAdvisor.tsx
@@ -96,6 +96,14 @@ export function AiAdvisor() {
 
   return (
     <div className="flex flex-col" style={{ height: 'calc(100vh - 58px)' }}>
+      {/* The page had no heading at all — no h1, no h2, nothing. Every other
+          screen in the app opens with one, and without it a screen-reader user
+          landing here has no way to tell which page they are on, nor to jump to
+          it from the headings list. It is visually hidden because the screen's
+          own chrome (the provenance badge, the conversation) already tells a
+          sighted user where they are. */}
+      <h1 className="sr-only">{tr('IA Advisor', 'AI Advisor')}</h1>
+
       {/* Provenance badge */}
       <div
         className="shrink-0 flex items-center justify-center gap-2 py-2.5"
@@ -213,13 +221,25 @@ export function AiAdvisor() {
               className="flex-1 h-12 px-[18px] rounded-[14px] text-[14px] text-ink outline-none disabled:opacity-60"
               style={{ border: '1px solid var(--border-strong)', background: 'var(--bg-elevated)' }}
             />
+            {/* An icon-only control needs a name, or it is announced as
+                "button" and nothing more — the one control that sends the
+                message. The label follows the state so a screen reader is told
+                the send is in flight rather than silently ignored. */}
             <button
               onClick={() => send()}
               disabled={ask.isPending}
+              aria-label={
+                ask.isPending ? tr('Envoi en cours…', 'Sending…') : tr('Envoyer', 'Send')
+              }
+              title={ask.isPending ? tr('Envoi en cours…', 'Sending…') : tr('Envoyer', 'Send')}
               className="w-12 h-12 rounded-[14px] flex items-center justify-center text-fg-primary shrink-0 disabled:opacity-60"
               style={{ background: 'var(--accent-solid)', color: 'var(--fg-on-solid)' }}
             >
-              {ask.isPending ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
+              {ask.isPending ? (
+                <Loader2 size={20} className="animate-spin" aria-hidden="true" />
+              ) : (
+                <Send size={20} aria-hidden="true" />
+              )}
             </button>
           </div>
           <div className="text-center text-[11px] text-ink-muted mt-2.5">

--- a/frontend/src/features/assets/CreateAssetModal.tsx
+++ b/frontend/src/features/assets/CreateAssetModal.tsx
@@ -127,20 +127,31 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
           >
-            <div className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+            {/* Announced as a dialog and named by its own heading. Without these
+                a screen reader walks straight past the form into the inventory
+                behind it, which is still in the tree. */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-asset-title"
+              className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+            >
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div className="flex items-center gap-3">
                   <div className="rounded-2xl bg-primary/10 p-2 text-primary">
                     <Server size={20} />
                   </div>
-                  <h2 className="text-xl font-semibold text-ink">{t('assets.createAsset')}</h2>
+                  <h2 id="create-asset-title" className="text-xl font-semibold text-ink">
+                    {t('assets.createAsset')}
+                  </h2>
                 </div>
                 <button
                   type="button"
                   onClick={handleClose}
+                  aria-label={t('common.close')}
                   className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                 >
-                  <X size={20} />
+                  <X size={20} aria-hidden="true" />
                 </button>
               </div>
 
@@ -161,10 +172,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
 
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="create-asset-type"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.type')}
                       </label>
                       <select
+                        id="create-asset-type"
                         {...register('type')}
                         disabled={isSubmitting}
                         className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -177,10 +192,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
                       </select>
                     </div>
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="create-asset-criticality"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.criticality')}
                       </label>
                       <select
+                        id="create-asset-criticality"
                         {...register('criticality')}
                         disabled={isSubmitting}
                         className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -199,10 +218,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
                   </Field>
 
                   <div className="space-y-1.5">
-                    <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                    <label
+                      htmlFor="create-asset-category"
+                      className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                    >
                       {t('assets.form.category', 'Catégorie typée')}
                     </label>
                     <select
+                      id="create-asset-category"
                       value={category}
                       disabled={isSubmitting}
                       onChange={(e) => {

--- a/frontend/src/features/assets/EditAssetModal.tsx
+++ b/frontend/src/features/assets/EditAssetModal.tsx
@@ -144,13 +144,22 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
               transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
               className="fixed inset-0 z-50 flex items-center justify-center p-4"
             >
-              <div className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+              {/* Announced as a dialog and named by its own heading — the
+                  inventory table behind it stays in the tree otherwise. */}
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="edit-asset-title"
+                className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+              >
                 <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                   <div className="flex items-center gap-3">
                     <div className="rounded-2xl bg-primary/10 p-2 text-primary">
                       <Server size={20} />
                     </div>
-                    <h2 className="text-xl font-semibold text-ink">{t('assets.editAsset')}</h2>
+                    <h2 id="edit-asset-title" className="text-xl font-semibold text-ink">
+                      {t('assets.editAsset')}
+                    </h2>
                   </div>
                   <div className="flex items-center gap-1">
                     {onShowHistory && asset?.id && (
@@ -167,9 +176,10 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                     <button
                       type="button"
                       onClick={handleClose}
+                      aria-label={t('common.close')}
                       className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                     >
-                      <X size={20} />
+                      <X size={20} aria-hidden="true" />
                     </button>
                   </div>
                 </div>
@@ -186,10 +196,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
 
                     <div className="grid grid-cols-2 gap-4">
                       <div className="space-y-1.5">
-                        <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                        <label
+                          htmlFor="edit-asset-type"
+                          className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                        >
                           {t('assets.form.type')}
                         </label>
                         <select
+                          id="edit-asset-type"
                           {...register('type')}
                           disabled={isSubmitting}
                           className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -202,10 +216,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                         </select>
                       </div>
                       <div className="space-y-1.5">
-                        <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                        <label
+                          htmlFor="edit-asset-criticality"
+                          className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                        >
                           {t('assets.form.criticality')}
                         </label>
                         <select
+                          id="edit-asset-criticality"
                           {...register('criticality')}
                           disabled={isSubmitting}
                           className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -224,10 +242,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                     </Field>
 
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="edit-asset-category"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.category', 'Catégorie typée')}
                       </label>
                       <select
+                        id="edit-asset-category"
                         value={category}
                         disabled={isSubmitting}
                         onChange={(e) => {

--- a/frontend/src/features/attackSurface/TopologyView.tsx
+++ b/frontend/src/features/attackSurface/TopologyView.tsx
@@ -111,6 +111,25 @@ export default function TopologyView() {
   const nodes = useMemo(() => data?.nodes ?? [], [data]);
   const edges = useMemo(() => data?.edges ?? [], [data]);
 
+  // How many assets survive the zone and criticality filters.
+  //
+  // The header used to report data.nodes.length unconditionally, so unticking
+  // CRITICAL removed nodes from the canvas while the count kept claiming the
+  // whole estate. A count that ignores the filter beside a graph that obeys it
+  // is a screen telling the user two different things at once.
+  //
+  // Mirrors the predicate the layout effect uses; if one changes the other must.
+  const visibleCount = useMemo(
+    () =>
+      nodes.filter(
+        (n) =>
+          (!zoneFilter || n.zone === zoneFilter) &&
+          critFilter.has((n.criticality ?? 'LOW') as string),
+      ).length,
+    [nodes, zoneFilter, critFilter],
+  );
+  const filtered = visibleCount !== nodes.length;
+
   // The highlighted chain: origin + everything impacted + everything reachable.
   const highlighted = useMemo(() => {
     if (!chain) return null;
@@ -403,7 +422,13 @@ export default function TopologyView() {
     <PageFrame wide>
       <PageHeader
         title="Topologie de la surface d'attaque"
-        count={data ? `${data.nodes?.length ?? 0} actifs · ${data.edges?.length ?? 0} liens` : null}
+        count={
+          data
+            ? filtered
+              ? `${visibleCount} / ${nodes.length} actifs`
+              : `${nodes.length} actifs · ${edges.length} liens`
+            : null
+        }
         actions={
           <>
             <Btn label="SVG" icon={Download} onClick={() => void doExport('svg')} />
@@ -482,6 +507,7 @@ export default function TopologyView() {
         {(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const).map((c) => (
           <Chip
             key={c}
+            testId={`universe-filter-${c.toLowerCase()}`}
             label={CRIT_LABEL[c]}
             color={critColor[c.toLowerCase() as Criticality]}
             active={critFilter.has(c)}

--- a/frontend/src/features/automation/AutomationPage.tsx
+++ b/frontend/src/features/automation/AutomationPage.tsx
@@ -506,6 +506,9 @@ function TemplateGallery({ onClose }: { onClose: () => void }) {
       style={{ background: 'rgba(0,0,0,.35)' }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-templates-title"
         className="w-full max-w-[720px] max-h-[85vh] flex flex-col rounded-[14px] or-scalein"
         style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
       >
@@ -514,8 +517,11 @@ function TemplateGallery({ onClose }: { onClose: () => void }) {
           style={{ borderBottom: '1px solid var(--border)' }}
         >
           <div>
-            <h2 className="text-[15px] font-bold text-ink inline-flex items-center gap-2">
-              <Sparkles size={16} style={{ color: 'var(--accent-500)' }} />
+            <h2
+              id="automation-templates-title"
+              className="text-[15px] font-bold text-ink inline-flex items-center gap-2"
+            >
+              <Sparkles size={16} style={{ color: 'var(--accent-500)' }} aria-hidden="true" />
               {tr('Modèles prêts à l’emploi', 'Ready-made templates')}
             </h2>
             <p className="text-[12px] mt-0.5" style={{ color: 'var(--fg-secondary)' }}>

--- a/frontend/src/features/automation/DryRunPanel.tsx
+++ b/frontend/src/features/automation/DryRunPanel.tsx
@@ -235,6 +235,9 @@ export function DryRunPanel({ rule, onClose }: { rule: AutomationRule; onClose: 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,.35)' }}>
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dry-run-title"
         className="w-full max-w-[760px] h-full overflow-y-auto or-slidein"
         style={{ background: 'var(--bg-elevated)', borderLeft: '1px solid var(--border-strong)' }}
       >
@@ -245,7 +248,11 @@ export function DryRunPanel({ rule, onClose }: { rule: AutomationRule; onClose: 
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <FlaskConical size={16} style={{ color: 'var(--accent-500)' }} />
-              <h2 className="text-[15px] font-bold truncate" style={{ color: 'var(--fg-primary)' }}>
+              <h2
+                id="dry-run-title"
+                className="text-[15px] font-bold truncate"
+                style={{ color: 'var(--fg-primary)' }}
+              >
                 {tr('Tester', 'Test')} — {rule.name}
               </h2>
             </div>

--- a/frontend/src/features/automation/RuleEditorModal.tsx
+++ b/frontend/src/features/automation/RuleEditorModal.tsx
@@ -186,6 +186,9 @@ export function RuleEditorModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-editor-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[640px] rounded-[16px] flex flex-col or-scalein"
         style={{
@@ -199,14 +202,19 @@ export function RuleEditorModal({
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="flex items-center gap-2 text-[15px] font-bold text-ink">
-            <Workflow size={17} />{' '}
+          {/* A dialog's name should come from a heading, not a styled div. */}
+          <h2
+            id="rule-editor-title"
+            className="flex items-center gap-2 text-[15px] font-bold text-ink"
+          >
+            <Workflow size={17} aria-hidden="true" />{' '}
             {rule
               ? tr('Modifier la règle', 'Edit rule')
               : tr('Nouvelle automatisation', 'New automation')}
-          </div>
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >

--- a/frontend/src/features/evidence/CreateEvidenceModal.tsx
+++ b/frontend/src/features/evidence/CreateEvidenceModal.tsx
@@ -72,13 +72,24 @@ export function CreateEvidenceModal({
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
       {/* max-h + internal scroll: the submit button must never be pushed off
           screen on a short viewport, which is a bug this project has already had. */}
-      <div className="relative w-full max-w-[560px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein">
+      {/* Announced as a dialog and named by its heading; the evidence library
+          behind it stays in the accessibility tree otherwise. */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-evidence-title"
+        className="relative w-full max-w-[560px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein"
+      >
         <header className="px-5 py-4 border-b border-line flex items-center justify-between shrink-0">
-          <h2 className="text-ink font-semibold text-[15px]">
+          <h2 id="create-evidence-title" className="text-ink font-semibold text-[15px]">
             {tr('Enregistrer une preuve', 'Record evidence')}
           </h2>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
-            <X size={16} />
+          <button
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
+          >
+            <X size={16} aria-hidden="true" />
           </button>
         </header>
 

--- a/frontend/src/features/evidence/EvidenceDrawer.tsx
+++ b/frontend/src/features/evidence/EvidenceDrawer.tsx
@@ -45,10 +45,15 @@ export function EvidenceDrawer({
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <aside className="relative w-full max-w-[560px] h-full bg-surface border-l border-line overflow-y-auto or-slidein">
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="evidence-drawer-title"
+        className="relative w-full max-w-[560px] h-full bg-surface border-l border-line overflow-y-auto or-slidein"
+      >
         <header className="sticky top-0 bg-surface border-b border-line px-5 py-4 flex items-start gap-3">
           <div className="min-w-0 flex-1">
-            <h2 className="text-ink font-semibold text-[15px] truncate">
+            <h2 id="evidence-drawer-title" className="text-ink font-semibold text-[15px] truncate">
               {isLoading ? tr('Chargement…', 'Loading…') : evidence?.title}
             </h2>
             {evidence && meta ? (
@@ -71,7 +76,11 @@ export function EvidenceDrawer({
               </div>
             ) : null}
           </div>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
+          <button
+            aria-label={tr('Fermer', 'Close')}
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+          >
             <X size={16} />
           </button>
         </header>

--- a/frontend/src/features/financial/FinancialDashboard.tsx
+++ b/frontend/src/features/financial/FinancialDashboard.tsx
@@ -455,6 +455,9 @@ function MethodologyModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="methodology-title"
         className="or-scalein w-full max-w-lg max-h-[88vh] flex flex-col rounded-[14px] overflow-hidden"
         style={{ background: 'var(--bg)', border: '1px solid var(--border)' }}
         onClick={(e) => e.stopPropagation()}
@@ -464,12 +467,16 @@ function MethodologyModal({
           style={{ borderColor: 'var(--border)' }}
         >
           <div className="flex items-center gap-2">
-            <BookOpen size={16} style={{ color: 'var(--accent-500)' }} />
-            <span className="text-[14px] font-semibold text-ink">
+            <BookOpen size={16} style={{ color: 'var(--accent-500)' }} aria-hidden="true" />
+            <h2 id="methodology-title" className="text-[14px] font-semibold text-ink">
               {tr('Méthodologie', 'Methodology')}
-            </span>
+            </h2>
           </div>
-          <button onClick={onClose} className="text-ink-muted hover:text-ink">
+          <button
+            onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
+            className="text-ink-muted hover:text-ink"
+          >
             <X size={18} />
           </button>
         </div>

--- a/frontend/src/features/governance/GovernancePage.tsx
+++ b/frontend/src/features/governance/GovernancePage.tsx
@@ -432,6 +432,9 @@ function AuditDetailDrawer({ e, onClose }: { e: AuditEvent; onClose: () => void 
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="governance-event-title"
         onClick={(ev) => ev.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -453,9 +456,12 @@ function AuditDetailDrawer({ e, onClose }: { e: AuditEvent; onClose: () => void 
             >
               {e.action}
             </span>
-            <div className="disp text-[16px] font-bold text-ink leading-snug mt-2">
+            <h2
+              id="governance-event-title"
+              className="disp text-[16px] font-bold text-ink leading-snug mt-2"
+            >
               {e.summary || `${e.action} ${e.entity_type}`}
-            </div>
+            </h2>
             <div className="text-[12px] mt-1" style={{ color: 'var(--fg-secondary)' }}>
               {e.entity_type} ·{' '}
               {e.actor_email || (e.actor_id ? e.actor_id.slice(0, 8) : tr('système', 'system'))} ·{' '}
@@ -1496,6 +1502,9 @@ function ModalShell({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="governance-modal-title"
         className="or-scalein w-full max-w-lg flex flex-col rounded-[14px]"
         style={{
           maxHeight: '90vh',
@@ -1508,8 +1517,10 @@ function ModalShell({
           className="flex items-center justify-between px-5 py-3.5"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <span className="text-[15px] font-semibold">{title}</span>
-          <button onClick={onClose}>
+          <h2 id="governance-modal-title" className="text-[15px] font-semibold">
+            {title}
+          </h2>
+          <button onClick={onClose} aria-label={tr('Fermer', 'Close')}>
             <X size={18} />
           </button>
         </div>

--- a/frontend/src/features/incidents/DeclareIncidentModal.tsx
+++ b/frontend/src/features/incidents/DeclareIncidentModal.tsx
@@ -110,7 +110,12 @@ export function DeclareIncidentModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ background: 'rgba(0,0,0,.4)' }}
     >
+      {/* Announced as a dialog and named by its heading; the incident list
+          behind it stays in the accessibility tree otherwise. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="declare-incident-title"
         className="w-full max-w-[640px] max-h-[90vh] flex flex-col rounded-[14px] or-scalein"
         style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
       >
@@ -119,6 +124,7 @@ export function DeclareIncidentModal({
           style={{ borderBottom: '1px solid var(--border)' }}
         >
           <h2
+            id="declare-incident-title"
             className="text-[15px] font-bold inline-flex items-center gap-2"
             style={{ color: 'var(--fg-primary)' }}
           >

--- a/frontend/src/features/incidents/DeclareIncidentModal.tsx
+++ b/frontend/src/features/incidents/DeclareIncidentModal.tsx
@@ -317,6 +317,10 @@ export function DeclareIncidentModal({
                     <select
                       className={field}
                       style={fieldStyle}
+                      aria-label={tr(
+                        `Personne — partie prenante ${i + 1}`,
+                        `Person — stakeholder ${i + 1}`,
+                      )}
                       value={sh.user_id ?? ''}
                       onChange={(e) =>
                         setStakeholders((list) =>
@@ -336,6 +340,10 @@ export function DeclareIncidentModal({
                     <select
                       className={field}
                       style={fieldStyle}
+                      aria-label={tr(
+                        `Rôle — partie prenante ${i + 1}`,
+                        `Role — stakeholder ${i + 1}`,
+                      )}
                       value={sh.role ?? ''}
                       onChange={(e) =>
                         setStakeholders((list) =>

--- a/frontend/src/features/incidents/IncidentDrawer.tsx
+++ b/frontend/src/features/incidents/IncidentDrawer.tsx
@@ -117,7 +117,12 @@ export function IncidentDrawer({
         }}
         onClick={onClose}
       >
+        {/* Announced as a dialog and named by the incident it shows; the list
+            behind it stays in the accessibility tree otherwise. */}
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="incident-drawer-title"
           onClick={(e) => e.stopPropagation()}
           className="h-full flex flex-col"
           style={{
@@ -159,9 +164,12 @@ export function IncidentDrawer({
                     {tr(statusMeta(status).fr, statusMeta(status).en)}
                   </span>
                 </div>
-                <div className="disp text-[16px] font-bold text-ink leading-snug">
+                <h2
+                  id="incident-drawer-title"
+                  className="disp text-[16px] font-bold text-ink leading-snug"
+                >
                   {incident.title}
-                </div>
+                </h2>
                 <div className="text-[11.5px] text-ink-muted mt-1">
                   {tr('Signalé par', 'Reported by')} {incident.reported_by || '—'} ·{' '}
                   {relTime(incident.created_at, lang)}
@@ -171,7 +179,7 @@ export function IncidentDrawer({
                 onClick={onClose}
                 className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft hover:text-ink transition-colors"
                 style={{ background: 'var(--bg-hover)' }}
-                aria-label="Close"
+                aria-label={tr('Fermer', 'Close')}
               >
                 <X size={18} />
               </button>

--- a/frontend/src/features/incidents/IncidentsScreen.tsx
+++ b/frontend/src/features/incidents/IncidentsScreen.tsx
@@ -50,8 +50,25 @@ export function IncidentsScreen() {
   const navigate = useNavigate();
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
 
-  const hasRole = useAuthStore((s) => s.hasRole);
-  const canWrite = hasRole('admin') || hasRole('analyst');
+  // Gate on the permission the SERVER actually enforces, not on a role name.
+  //
+  // This was hasRole('admin') || hasRole('analyst'). The backend abandoned that
+  // exact gate — cmd/server/main.go says so in as many words: "analyst" is not a
+  // runtime org role (they are root/admin/user), so the check was effectively
+  // admin-only and could never be granted to a business role. It moved to the
+  // incidents:* permission family; the client never followed.
+  //
+  // The consequence was not cosmetic. A tenant's founding user carries
+  // permissions ["*"] and an EMPTY role string, so hasRole('admin') was false and
+  // the owner of the workspace could not declare an incident on their own
+  // incident screen — while POST /incidents would have accepted it.
+  const hasPermission = useAuthStore((s) => s.hasPermission);
+  // Three permissions, because the server enforces three. One boolean for all of
+  // them would hide Delete from someone who may resolve, or offer Delete to
+  // someone the API will refuse.
+  const canCreate = hasPermission('incidents:create');
+  const canUpdate = hasPermission('incidents:update');
+  const canDelete = hasPermission('incidents:delete');
 
   const [showCreate, setShowCreate] = useState(false);
   const [selected, setSelected] = useState<Incident | null>(null);
@@ -246,7 +263,7 @@ export function IncidentsScreen() {
             />
             <select
               value={inc.status}
-              disabled={!canWrite}
+              disabled={!canUpdate}
               aria-label={tr('Statut de l’incident', 'Incident status')}
               onChange={(e) => setStatus(inc, e.target.value as IncidentStatus)}
               className="appearance-none text-[12px] font-semibold rounded-full pl-6 pr-6 py-1.5 outline-none disabled:opacity-70"
@@ -254,7 +271,7 @@ export function IncidentsScreen() {
                 color: statusMeta(inc.status).color,
                 background: `color-mix(in srgb,${statusMeta(inc.status).color} 12%,transparent)`,
                 border: `1px solid color-mix(in srgb,${statusMeta(inc.status).color} 30%,transparent)`,
-                cursor: canWrite ? 'pointer' : 'not-allowed',
+                cursor: canUpdate ? 'pointer' : 'not-allowed',
               }}
             >
               {STATUSES.map((st) => (
@@ -285,7 +302,7 @@ export function IncidentsScreen() {
         ),
       },
     ],
-    [lang, canWrite],
+    [lang, canUpdate],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* -------------------------------------------------------------- actions */
@@ -309,11 +326,11 @@ export function IncidentsScreen() {
         icon: Trash2,
         danger: true,
         separatorBefore: true,
-        hidden: () => !canWrite,
+        hidden: () => !canDelete,
         onSelect: (inc) => remove(inc),
       },
     ],
-    [lang, canWrite, navigate],
+    [lang, canDelete, navigate],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   const bulkActions: BulkAction<Incident>[] = useMemo(
@@ -322,7 +339,7 @@ export function IncidentsScreen() {
         key: 'resolve',
         label: tr('Marquer résolus', 'Mark resolved'),
         icon: CheckCircle2,
-        hidden: !canWrite,
+        hidden: !canUpdate,
         selectionOnly: true,
         run: async ({ rows }) => {
           await Promise.all(
@@ -340,14 +357,14 @@ export function IncidentsScreen() {
         label: tr('Supprimer', 'Delete'),
         icon: Trash2,
         danger: true,
-        hidden: !canWrite,
+        hidden: !canDelete,
         selectionOnly: true,
         run: async ({ rows }) => {
           rows.forEach((inc) => remove(inc));
         },
       },
     ],
-    [lang, canWrite, updateIncident],
+    [lang, canUpdate, canDelete, updateIncident],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
@@ -363,7 +380,7 @@ export function IncidentsScreen() {
               onClick={exportCsv}
             />
             <Btn label={tr('War Room', 'War Room')} icon={Activity} onClick={openWarRoom} />
-            {canWrite && (
+            {canCreate && (
               <Btn
                 label={tr('Déclarer un incident', 'Declare an incident')}
                 icon={Siren}
@@ -426,7 +443,7 @@ export function IncidentsScreen() {
           'Titre, description ou déclarant…',
           'Title, description or reporter…',
         )}
-        selectable={canWrite}
+        selectable={canUpdate || canDelete}
         rowActions={rowActions}
         bulkActions={bulkActions}
         onRowClick={(inc) => setSelected(inc)}
@@ -441,7 +458,7 @@ export function IncidentsScreen() {
               'Nothing to report. An incident can be declared here, or opened automatically by a rule, a scan or a threat feed — each one then carries a banner saying which.',
             )}
             primaryAction={
-              canWrite ? (
+              canCreate ? (
                 <Btn
                   label={tr('Déclarer un incident', 'Declare an incident')}
                   icon={Siren}
@@ -458,7 +475,11 @@ export function IncidentsScreen() {
 
       {showCreate && <DeclareIncidentModal onClose={() => setShowCreate(false)} />}
       {selected && (
-        <IncidentDrawer incident={selected} canWrite={canWrite} onClose={() => setSelected(null)} />
+        <IncidentDrawer
+          incident={selected}
+          canWrite={canUpdate}
+          onClose={() => setSelected(null)}
+        />
       )}
     </PageFrame>
   );

--- a/frontend/src/features/incidents/PostMortemPanel.tsx
+++ b/frontend/src/features/incidents/PostMortemPanel.tsx
@@ -153,7 +153,11 @@ export function PostMortemPanel({
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,.35)' }}>
+      {/* Announced as a dialog and named by its heading. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="post-mortem-title"
         className="w-full max-w-[760px] h-full overflow-y-auto or-slidein"
         style={{ background: 'var(--bg-elevated)', borderLeft: '1px solid var(--border-strong)' }}
       >
@@ -163,6 +167,7 @@ export function PostMortemPanel({
         >
           <div>
             <h2
+              id="post-mortem-title"
               className="text-[15px] font-bold inline-flex items-center gap-2"
               style={{ color: 'var(--fg-primary)' }}
             >

--- a/frontend/src/features/incidents/WarRoom.tsx
+++ b/frontend/src/features/incidents/WarRoom.tsx
@@ -457,7 +457,13 @@ export function WarRoom() {
           }}
           onClick={() => setConfirmClose(false)}
         >
+          {/* alertdialog, not dialog: a question with exactly two answers is
+              announced whole on open rather than waiting to be explored. */}
           <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="warroom-close-title"
+            aria-describedby="warroom-close-body"
             onClick={(e) => e.stopPropagation()}
             className="glass-strong rounded-[18px] shadow-card-lg p-[26px]"
             style={{ width: 'min(90vw,420px)', animation: 'or-scalein .18s ease' }}
@@ -471,10 +477,13 @@ export function WarRoom() {
             >
               <AlertTriangle size={24} />
             </div>
-            <div className="disp text-[18px] font-bold text-ink mb-2">
+            <h2 id="warroom-close-title" className="disp text-[18px] font-bold text-ink mb-2">
               {tr('Clore cet incident ?', 'Close this incident?')}
-            </div>
-            <div className="text-[13.5px] text-ink-soft leading-relaxed mb-[22px]">
+            </h2>
+            <div
+              id="warroom-close-body"
+              className="text-[13.5px] text-ink-soft leading-relaxed mb-[22px]"
+            >
               {tr(
                 'Le statut passera à « Clos » et l’incident sortira des incidents actifs.',
                 'The status will be set to "Closed" and it will leave the active incidents.',

--- a/frontend/src/features/infrastructure/AgentDeployModal.tsx
+++ b/frontend/src/features/infrastructure/AgentDeployModal.tsx
@@ -72,6 +72,9 @@ export function AgentDeployModal({ config, onClose }: { config: ScanConfig; onCl
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="agent-deploy-title"
         className="relative w-full max-w-[520px] max-h-[90vh] flex flex-col rounded-2xl glass-strong overflow-hidden"
         style={{ border: '1px solid var(--border-strong)', animation: 'or-scalein .22s ease' }}
       >
@@ -79,13 +82,13 @@ export function AgentDeployModal({ config, onClose }: { config: ScanConfig; onCl
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="text-[15px] font-semibold text-ink">
+          <h2 id="agent-deploy-title" className="text-[15px] font-semibold text-ink">
             {tr('Déployer un Agent', 'Deploy an Agent')}
-          </div>
+          </h2>
           <button
             onClick={onClose}
             className="w-8 h-8 rounded-lg flex items-center justify-center text-ink-soft hover:bg-hover"
-            aria-label="Close"
+            aria-label={tr('Fermer', 'Close')}
           >
             <X size={18} />
           </button>

--- a/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
+++ b/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
@@ -100,6 +100,9 @@ export function ScanConfigDrawer({
         onClick={onClose}
       />
       <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="scan-config-title"
         className="relative h-full w-full max-w-[460px] flex flex-col glass-strong"
         style={{ borderLeft: '1px solid var(--border-strong)', animation: 'or-slidein .28s ease' }}
       >
@@ -119,9 +122,9 @@ export function ScanConfigDrawer({
               <meta.icon size={18} strokeWidth={1.8} />
             </div>
             <div>
-              <div className="text-[15px] font-semibold text-ink">
+              <h2 id="scan-config-title" className="text-[15px] font-semibold text-ink">
                 {tr('Nouvelle configuration', 'New scan config')}
-              </div>
+              </h2>
               <div className="text-[12px] text-ink-soft">{meta.short}</div>
             </div>
           </div>

--- a/frontend/src/features/mitigations/CreateMitigationModal.tsx
+++ b/frontend/src/features/mitigations/CreateMitigationModal.tsx
@@ -125,25 +125,35 @@ export const CreateMitigationModal = ({
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-90 flex items-center justify-center p-4"
           >
-            <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+            {/* Announced as a dialog and named by its heading; the board behind
+                it stays in the accessibility tree otherwise. */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-mitigation-title"
+              className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+            >
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div>
-                  <h2 className="text-2xl font-semibold text-ink">Créer un plan d'atténuation</h2>
-                  <p className="text-sm text-ink-muted">Créez un plan pour atténuer un risque</p>
+                  <h2 id="create-mitigation-title" className="text-2xl font-semibold text-ink">
+                    {t('mitigations.createTitle')}
+                  </h2>
+                  <p className="text-sm text-ink-muted">{t('mitigations.createSubtitle')}</p>
                 </div>
                 <button
                   type="button"
                   onClick={handleClose}
+                  aria-label={t('common.close')}
                   className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                 >
-                  <X size={20} />
+                  <X size={20} aria-hidden="true" />
                 </button>
               </div>
 
               <form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
                 <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6 scrollbar-thin">
                   <Field
-                    label="Titre"
+                    label={t('mitigations.fieldTitle')}
                     message={errors.title?.message}
                     status={errors.title?.message ? 'invalid' : 'default'}
                   >
@@ -151,10 +161,14 @@ export const CreateMitigationModal = ({
                   </Field>
 
                   <div className="space-y-1.5">
-                    <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                      Description
+                    <label
+                      htmlFor="create-mitigation-description"
+                      className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                    >
+                      {t('mitigations.fieldDescription')}
                     </label>
                     <textarea
+                      id="create-mitigation-description"
                       {...register('description')}
                       rows={4}
                       className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/40"
@@ -167,23 +181,36 @@ export const CreateMitigationModal = ({
 
                   <div className="grid gap-4 sm:grid-cols-2">
                     <div>
-                      <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                        Deadline
+                      <label
+                        htmlFor="create-mitigation-due-date"
+                        className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
+                        {t('mitigations.fieldDeadline')}
                       </label>
-                      <Input type="date" {...register('due_date')} disabled={isSubmitting} />
+                      <Input
+                        id="create-mitigation-due-date"
+                        type="date"
+                        {...register('due_date')}
+                        disabled={isSubmitting}
+                      />
                     </div>
                     <div>
-                      <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                        Priorité
+                      <label
+                        htmlFor="create-mitigation-priority"
+                        className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
+                        {t('mitigations.fieldPriority')}
                       </label>
                       <select
+                        id="create-mitigation-priority"
                         {...register('priority')}
                         className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink"
                       >
-                        <option value="critical">Critique</option>
-                        <option value="high">Élevé</option>
-                        <option value="medium">Moyen</option>
-                        <option value="low">Bas</option>
+                        {(['critical', 'high', 'medium', 'low'] as const).map((level) => (
+                          <option key={level} value={level}>
+                            {t(`mitigations.priority.${level}`)}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   </div>
@@ -191,7 +218,7 @@ export const CreateMitigationModal = ({
 
                 <div className="flex shrink-0 justify-end gap-3 border-t border-border bg-elevated px-6 py-4">
                   <Button type="button" variant="ghost" onClick={handleClose}>
-                    Annuler
+                    {t('common.cancel')}
                   </Button>
                   <Button
                     type="submit"
@@ -199,8 +226,8 @@ export const CreateMitigationModal = ({
                     loading={isSubmitting}
                     className="gap-2"
                   >
-                    <Zap size={16} />
-                    Créer
+                    <Zap size={16} aria-hidden="true" />
+                    {t('common.create')}
                   </Button>
                 </div>
               </form>

--- a/frontend/src/features/onboarding/OnboardingGuard.tsx
+++ b/frontend/src/features/onboarding/OnboardingGuard.tsx
@@ -54,12 +54,23 @@ export function OnboardingGuard({ children }: { children: ReactNode }) {
 /**
  * Wraps the wizard itself: someone who has already finished has no business
  * being sent back through it (a bookmark, a back button, a stale tab).
+ *
+ * A completed user goes to the POSTURE REVEAL, not to `landing`.
+ *
+ * This used to send them to `data.landing` — the screen derived from their
+ * chosen goal — which quietly defeated the whole of #438: the last step calls
+ * `POST /onboarding/complete`, this wrapper saw `completed: true` on the very
+ * next render and redirected before the reveal could mount. Five screens
+ * collected facts and the user was dropped on a register, which is the exact
+ * activation cliff the issue exists to remove.
+ *
+ * `landing` is where they go FROM the reveal, and the reveal offers it.
  */
 export function OnboardingCompletedRedirect({ children }: { children: ReactNode }) {
   const { data, isLoading } = useOnboardingState();
 
   if (isLoading && !data) return <GuardPlaceholder />;
-  if (data?.completed) return <Navigate to={data.landing || '/'} replace />;
+  if (data?.completed) return <Navigate to="/posture" replace />;
   return <>{children}</>;
 }
 

--- a/frontend/src/features/onboarding/PosturePage.tsx
+++ b/frontend/src/features/onboarding/PosturePage.tsx
@@ -21,7 +21,7 @@ import { AlertTriangle, ArrowRight, Check, Copy, Users } from 'lucide-react';
 
 import { useI18n } from '../../hooks/useI18n';
 import type { PostureRiskView, PostureSummary } from '../../services/activationService';
-import { usePosture, useCountUp, usePrefersReducedMotion } from './useActivation';
+import { useOnboardingState, usePosture, useCountUp, usePrefersReducedMotion } from './useActivation';
 
 export function PosturePage() {
   const { t } = useI18n();
@@ -90,12 +90,41 @@ function PostureReveal({ summary }: { summary: PostureSummary }) {
         </ul>
       </section>
 
+      <LandingCta />
+
       <InviteBlock />
 
       <p className="text-[11.5px] text-ink-muted mt-6 m-0">
         {t('onboarding.posture.formulaVersion', { version: summary.residual_formula_version })}
       </p>
     </div>
+  );
+}
+
+/**
+ * The way out of the reveal.
+ *
+ * The tunnel now ends here rather than on the goal's landing screen, so this is
+ * where `landing` is offered — a reveal with no forward control is a dead end,
+ * and the user has just been told something worth acting on.
+ */
+function LandingCta() {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const { data: onboarding } = useOnboardingState();
+  const landing = onboarding?.landing || '/';
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(landing)}
+      data-testid="posture-continue"
+      className="mt-8 px-5 py-2.5 rounded-lg text-[13.5px] font-semibold inline-flex items-center gap-2"
+      style={{ background: 'var(--accent-solid)', color: 'var(--fg-on-solid)' }}
+    >
+      {t('onboarding.posture.continue')}
+      <ArrowRight size={15} aria-hidden="true" />
+    </button>
   );
 }
 

--- a/frontend/src/features/onboarding/RecognitionPage.tsx
+++ b/frontend/src/features/onboarding/RecognitionPage.tsx
@@ -17,12 +17,30 @@ import { AlertTriangle } from 'lucide-react';
 
 import { useI18n } from '../../hooks/useI18n';
 import type { RecognitionCounts } from '../../services/activationService';
-import { useCountUp, usePrefersReducedMotion, useRecognition } from './useActivation';
+import {
+  useCompleteOnboarding,
+  useCountUp,
+  usePrefersReducedMotion,
+  useRecognition,
+} from './useActivation';
 
 export function RecognitionPage() {
   const { t } = useI18n();
   const navigate = useNavigate();
   const { data, isLoading, isError } = useRecognition();
+
+  // Acknowledging the recognition IS this user's completion of onboarding.
+  //
+  // Without it they are trapped. `OnboardingGuard` sends anyone whose wizard is
+  // unfinished here from EVERY app route, and criterion 9 keeps the tunnel — the
+  // only other thing that completes it — off their screen. So the button led
+  // back to a page that led back to the button, for the whole population #234
+  // backfilled: every existing customer.
+  const complete = useCompleteOnboarding();
+
+  const enter = () => {
+    complete.mutate(undefined, { onSuccess: () => navigate('/posture') });
+  };
 
   if (isLoading) return <RecognitionSkeleton label={t('onboarding.recognition.loading')} />;
 
@@ -56,12 +74,20 @@ export function RecognitionPage() {
 
       <button
         type="button"
-        onClick={() => navigate('/posture')}
-        className="mt-8 px-5 py-2.5 rounded-lg text-[13.5px] font-semibold"
+        onClick={enter}
+        disabled={complete.isPending}
+        data-testid="recognition-continue"
+        className="mt-8 px-5 py-2.5 rounded-lg text-[13.5px] font-semibold disabled:opacity-60"
         style={{ background: 'var(--accent-solid)', color: 'var(--fg-on-solid)' }}
       >
-        {t('onboarding.recognition.action')}
+        {complete.isPending ? t('onboarding.tunnel.saving') : t('onboarding.recognition.action')}
       </button>
+
+      {complete.isError && (
+        <p className="text-[12.5px] mt-3 m-0" role="alert" style={{ color: 'var(--high)' }}>
+          {t('onboarding.recognition.completeFailed')}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/onboarding/useActivation.ts
+++ b/frontend/src/features/onboarding/useActivation.ts
@@ -27,6 +27,7 @@ import {
   type AdoptStarterRisksResult,
 } from '../../services/activationService';
 import { confetti } from '../../shared/celebrate';
+import { useUIStore } from '../../store/uiStore';
 
 /** Shared key — invalidate it after any mutation that can complete a step. */
 export const ACTIVATION_QUERY_KEY = ['activation', 'state'];
@@ -236,8 +237,11 @@ export function useStarterRisks(enabled = true) {
  */
 export function useAdoptStarterRisks() {
   const qc = useQueryClient();
+  // The rows are written in the language the user is READING. Resolved here
+  // rather than at the call site so every caller gets it right by default.
+  const lang = useUIStore((s) => s.lang);
   return useMutation<AdoptStarterRisksResult, unknown, string[]>({
-    mutationFn: (keys: string[]) => activationService.adoptStarterRisks(keys),
+    mutationFn: (keys: string[]) => activationService.adoptStarterRisks(keys, lang),
     retry: false,
     onSuccess: () => {
       // New risks exist now: the checklist's first_risk row, the offer's

--- a/frontend/src/features/onboarding/wizard/stepPrimitives.tsx
+++ b/frontend/src/features/onboarding/wizard/stepPrimitives.tsx
@@ -9,6 +9,7 @@
 
 import { ArrowLeft, ArrowRight, Loader2 } from 'lucide-react';
 
+import { useI18n } from '../../../hooks/useI18n';
 
 
 export function Field({
@@ -65,6 +66,8 @@ export function StepShell({
   errorHint?: string;
   retryLabel?: string;
 }) {
+  const { t } = useI18n();
+
   return (
     <form
       onSubmit={(e) => {
@@ -129,8 +132,8 @@ export function StepShell({
             className="h-11 px-4 rounded-[10px] text-[13.5px] font-semibold text-ink inline-flex items-center gap-1.5"
             style={{ background: 'var(--bg-hover)', border: '1px solid var(--border-strong)' }}
           >
-            <ArrowLeft size={15} />
-            Retour
+            <ArrowLeft size={15} aria-hidden="true" />
+            {t('onboarding.tunnel.back')}
           </button>
         )}
         <button

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -16,11 +16,7 @@ import { toast } from 'sonner';
 import { useUIStore } from '../../../store/uiStore';
 import { useAuthStore } from '../../../hooks/useAuthStore';
 import { i18n, type OnboardingStepKey } from '../../../services/activationService';
-import {
-  useAdoptStarterRisks,
-  useOnboardingSuggestions,
-  useStarterRisks,
-} from '../useActivation';
+import { useAdoptStarterRisks, useOnboardingSuggestions, useStarterRisks } from '../useActivation';
 import { useCatalogs, useImportCatalogAsFramework } from '../../compliance/useCompliance';
 import type { StarterRiskOffer } from '../../../services/activationService';
 import { Field, StepShell } from './stepPrimitives';
@@ -92,9 +88,7 @@ export function OrganizationStep() {
     setCountry(str(stored, 'country'));
     setCurrency(str(stored, 'currency'));
     setTimezone(str(stored, 'timezone', Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'));
-    setFullName(
-      str(stored, 'full_name', str(legacyProfile, 'full_name', user?.full_name ?? '')),
-    );
+    setFullName(str(stored, 'full_name', str(legacyProfile, 'full_name', user?.full_name ?? '')));
     setJobTitle(str(stored, 'job_title', str(legacyProfile, 'job_title', user?.department ?? '')));
   }, [stored, legacyProfile, orgName, user]);
 
@@ -127,7 +121,10 @@ export function OrganizationStep() {
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
@@ -333,7 +330,10 @@ export function GoalStep() {
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       <div className="flex flex-col gap-2.5">
@@ -458,7 +458,10 @@ function StarterRiskPicker({
     <div className="mt-7">
       <div className="flex items-baseline justify-between mb-2.5">
         <h2 className="text-[14px] font-bold text-ink m-0">
-          {tr(`Sélectionnez ${pick} risques qui vous concernent`, `Pick ${pick} risks that apply to you`)}
+          {tr(
+            `Sélectionnez ${pick} risques qui vous concernent`,
+            `Pick ${pick} risks that apply to you`,
+          )}
         </h2>
         {/* aria-live so the count is announced as the user selects, which is how
             a screen-reader user knows when the primary button will unlock. */}
@@ -566,7 +569,18 @@ export function FrameworkStep() {
   const { data: suggestions, isLoading } = useOnboardingSuggestions();
   const { data: catalogs } = useCatalogs();
   const importCatalog = useImportCatalogAsFramework();
+  const stored = useStoredAnswers('framework');
   const [imported, setImported] = useState<string[]>([]);
+
+  // Restore what was already imported. Without this, stepping Back and Forward
+  // cleared every tick: the catalogues were still imported server-side, but the
+  // step claimed they were not and offered to import them a second time.
+  useEffect(() => {
+    const previous = stored.imported;
+    if (Array.isArray(previous)) {
+      setImported(previous.filter((k): k is string => typeof k === 'string'));
+    }
+  }, [stored]);
 
   // The suggested keys, resolved against the real catalog registry so we never
   // offer something that cannot actually be imported.
@@ -577,6 +591,24 @@ export function FrameworkStep() {
       .filter((c): c is NonNullable<typeof c> => !!c && c.available !== false)
       .slice(0, 5);
   }, [suggestions, catalogs]);
+
+  /**
+   * Importing a catalogue is the ONLY thing in the whole tunnel that creates a
+   * control, and the reveal this tunnel ends on cannot be computed without one:
+   * `coveragePercent` returns nil with zero applicable controls, `IsRevealable`
+   * is then false, and GET /posture answers 404. A user who walked five screens
+   * landed on "Impossible de calculer votre posture" — the exact activation
+   * cliff #438 exists to remove, rebuilt at the last step.
+   *
+   * The server already defines this step as satisfied by HasFramework — that is
+   * what OnboardingStepData.SkipsStep tests to auto-skip it. The client simply
+   * did not hold the same line. It does now.
+   *
+   * Except when the catalogue offers nothing: blocking there would trap the user
+   * in a step with no control to press, which is worse than the 404. Then the
+   * step stays passable and the reveal's own error state does its job.
+   */
+  const mustImport = offered.length > 0 && imported.length === 0;
 
   const runImport = (key: string) => {
     const catalog = offered.find((c) => c.key === key);
@@ -606,11 +638,15 @@ export function FrameworkStep() {
       onBack={() => go({ imported }, -1)}
       onNext={() => go({ imported }, 1)}
       nextLabel={tr('Continuer', 'Continue')}
+      nextDisabled={mustImport}
       busy={busy}
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       {isLoading && (
@@ -674,6 +710,17 @@ export function FrameworkStep() {
           {tr(
             'Aucune suggestion pour ces réponses — vous pourrez choisir un référentiel depuis Conformité.',
             'No suggestion for these answers — you can pick a framework from Compliance.',
+          )}
+        </div>
+      )}
+
+      {/* A disabled button with no explanation is its own defect. This says what
+          to press and what it buys, rather than leaving the user to guess. */}
+      {mustImport && (
+        <div className="text-[12.5px] text-ink-soft mt-4" data-testid="framework-required">
+          {tr(
+            'Importez-en un pour continuer : vos contrôles sont ce qui rend votre posture calculable.',
+            'Import one to continue: your controls are what makes your posture computable.',
           )}
         </div>
       )}

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -310,7 +310,7 @@ export function GoalStep() {
         // A 409 means this tenant already adopted — expected on a resumed
         // tunnel, and not a reason to block the user on a screen they finished.
         onError: (err: unknown) => {
-          if (isConflict(err)) go({ goal, starter_risks: picked }, 1);
+          if (isExpectedAdoptionRefusal(err)) go({ goal, starter_risks: picked }, 1);
         },
       });
       return;
@@ -375,7 +375,7 @@ export function GoalStep() {
         pick={pick}
         alreadyAdopted={alreadyAdopted}
         onToggle={toggle}
-        failed={adopt.isError && !isConflict(adopt.error)}
+        failed={adopt.isError && !isExpectedAdoptionRefusal(adopt.error)}
         lang={lang}
         tr={tr}
       />
@@ -536,10 +536,23 @@ function StarterRiskPicker({
   );
 }
 
-/** A 409 from the adoption endpoint means "already done", not "failed". */
-function isConflict(err: unknown): boolean {
+/**
+ * Answers the adoption endpoint gives that are NOT failures to retry.
+ *
+ *   409 — this tenant already adopted. The tunnel is resumable by design, so a
+ *         user WILL come back to this step; a second adoption is refused rather
+ *         than doubling their register.
+ *   403 — the caller may not create risks. POST /onboarding/starter-risks
+ *         carries `risks:create` like every other risk write, and an invited
+ *         member without it must still be able to finish the tunnel: it blocks
+ *         the whole app, so refusing to advance over a permission they will
+ *         never have would lock them out of the product.
+ *
+ * Both let the step advance. Neither writes anything.
+ */
+function isExpectedAdoptionRefusal(err: unknown): boolean {
   const status = (err as { response?: { status?: number } } | null)?.response?.status;
-  return status === 409;
+  return status === 409 || status === 403;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -22,11 +22,9 @@ import { StepShell } from './stepPrimitives';
 import { num, useStepNav, useStoredAnswers } from './stepNav';
 import {
   useCompleteOnboarding,
-  usePosture,
   usePrefersReducedMotion,
   useSaveOnboardingStep,
 } from '../useActivation';
-import type { PostureRiskView } from '../../../services/activationService';
 
 // ---------------------------------------------------------------------------
 // The matrix
@@ -300,18 +298,32 @@ export function CoverStep() {
   const save = useSaveOnboardingStep();
   const complete = useCompleteOnboarding();
 
-  // The posture is read here so the residual shown is the REAL one, computed by
-  // the server from this tenant's own control mappings (ADR 0003). A number
-  // invented client-side would be the placeholder criterion 7 forbids, on the
-  // screen the whole tunnel builds towards.
-  const { data: posture, isLoading } = usePosture();
+  // DELIBERATELY DOES NOT FETCH /posture.
+  //
+  // It used to, so the card could show a server-computed residual. But GET
+  // /posture is what records `posture.revealed` — the Aha moment itself (D-010)
+  // — so fetching it here fired the Aha one step early: the metric behind the
+  // eight-minute promise was measured before the user had seen anything, and
+  // `first_reveal` was already false by the time the reveal mounted, so the
+  // reveal never celebrated.
+  //
+  // The screen therefore shows the score the user just set in step 4, which it
+  // owns, and says plainly that the residual is computed on the next screen.
+  // Nothing here is invented: the number comes from their own answers.
+  const scored = useStoredAnswers('score');
   const [accepted, setAccepted] = useState(false);
 
   useEffect(() => {
     setAccepted(stored.accepted === true);
   }, [stored]);
 
-  const risk: PostureRiskView | undefined = useMemo(() => posture?.top_risks?.[0], [posture]);
+  // Score Engine arithmetic on the user's own step-4 answers: P × I. Asset
+  // criticality is the engine's third factor and is not known at this point,
+  // which the step-4 copy already says.
+  const inherent = useMemo(
+    () => Math.round(num(scored, 'probability', 0) * num(scored, 'impact', 0) * 100) / 100,
+    [scored],
+  );
 
   /**
    * Save, then lift the guard, then land on the reveal.
@@ -351,26 +363,7 @@ export function CoverStep() {
       )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
-      {isLoading && <div className="h-28 rounded-xl or-skeleton" />}
-
-      {/* The degraded case the DoD names: the posture is not computable yet
-          (no framework imported, or the import failed). The step still works —
-          it stores the acceptance — and says plainly that the number is not
-          available rather than showing a zero that would read as "no risk". */}
-      {!isLoading && !risk && (
-        <div
-          className="rounded-xl p-4 text-[13px] text-ink-soft"
-          style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
-          data-testid="cover-unavailable"
-        >
-          {tr(
-            'Le résiduel sera calculé dès qu’un référentiel sera importé — nous vous le montrerons à l’écran suivant.',
-            'The residual is computed as soon as a framework is imported — we will show it on the next screen.',
-          )}
-        </div>
-      )}
-
-      {!isLoading && risk && <ResidualCard risk={risk} accepted={accepted} tr={tr} />}
+      <InherentCard inherent={inherent} tr={tr} />
 
       <label
         className="mt-5 flex items-start gap-3 cursor-pointer"
@@ -394,62 +387,33 @@ export function CoverStep() {
   );
 }
 
-function ResidualCard({
-  risk,
-  accepted,
-  tr,
-}: {
-  risk: PostureRiskView;
-  accepted: boolean;
-  tr: (fr: string, en: string) => string;
-}) {
-  const reduced = usePrefersReducedMotion();
-
-  // Both numbers come from the server. `accepted` only decides WHICH of the two
-  // the screen leads with — it never computes one. The user is being shown what
-  // their controls have already earned, not a projection.
-  const shown = accepted ? risk.residual.value : risk.residual.inherent;
-  const band = bandOf(shown);
-
+/**
+ * What the user has, and what comes next.
+ *
+ * No residual number here: computing one would need the tenant's control
+ * mappings, and the only endpoint that returns them is the reveal — which
+ * records the Aha. Showing a client-computed figure instead would be the
+ * placeholder criterion 7 forbids, on the screen that leads into the reveal.
+ */
+function InherentCard({ inherent, tr }: { inherent: number; tr: (fr: string, en: string) => string }) {
   return (
     <div
       className="rounded-xl p-5"
       style={{ background: 'var(--bg-surface)', border: '1px solid var(--border-subtle)' }}
       data-testid="cover-residual"
     >
-      <div className="text-[13.5px] font-semibold text-ink mb-3 truncate">{risk.title}</div>
-
       <div className="flex items-end gap-5">
-        <Figure label={tr('Inhérent', 'Inherent')} value={risk.residual.inherent} muted />
-        <ShieldCheck
-          size={18}
-          aria-hidden="true"
-          style={{ color: accepted ? 'var(--low)' : 'var(--fg-muted)', marginBottom: 6 }}
-        />
-        <Figure
-          label={tr('Résiduel', 'Residual')}
-          value={shown}
-          color={bandColor(band)}
-          testId="cover-residual-value"
-          reduced={reduced}
-        />
+        <Figure label={tr('Inhérent', 'Inherent')} value={inherent} />
+        <ShieldCheck size={18} aria-hidden="true" style={{ color: 'var(--fg-muted)', marginBottom: 6 }} />
+        <div>
+          <div className="text-[10.5px] uppercase tracking-wide text-ink-muted">
+            {tr('Résiduel', 'Residual')}
+          </div>
+          <div className="text-[13px] text-ink-soft mt-1" data-testid="cover-residual-pending">
+            {tr('calculé à l’écran suivant', 'computed on the next screen')}
+          </div>
+        </div>
       </div>
-
-      {risk.residual.coverage.measured ? (
-        <div className="text-[12px] text-ink-soft mt-3" role="status" aria-live="polite">
-          {tr(
-            `${risk.residual.coverage.applicable} contrôle(s) rattaché(s) — réduction de ${risk.residual.reduction}`,
-            `${risk.residual.coverage.applicable} control(s) mapped — down by ${risk.residual.reduction}`,
-          )}
-        </div>
-      ) : (
-        <div className="text-[12px] text-ink-muted mt-3">
-          {tr(
-            'Aucun contrôle rattaché pour l’instant — le résiduel égale l’inhérent.',
-            'No control mapped yet — the residual equals the inherent score.',
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -14,13 +14,18 @@
 // (criterion 13) — not a shorter animation, no animation.
 
 import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
 import { ShieldCheck } from 'lucide-react';
 
 import { useUIStore } from '../../../store/uiStore';
-import { useAuthStore } from '../../../hooks/useAuthStore';
 import { StepShell } from './stepPrimitives';
 import { num, useStepNav, useStoredAnswers } from './stepNav';
-import { usePosture, usePrefersReducedMotion } from '../useActivation';
+import {
+  useCompleteOnboarding,
+  usePosture,
+  usePrefersReducedMotion,
+  useSaveOnboardingStep,
+} from '../useActivation';
 import type { PostureRiskView } from '../../../services/activationService';
 
 // ---------------------------------------------------------------------------
@@ -283,8 +288,17 @@ export function CoverStep() {
   const lang = useUIStore((s) => s.lang);
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   const stored = useStoredAnswers('cover');
-  const { go, busy, error, retry } = useStepNav('cover');
-  const user = useAuthStore((s) => s.user);
+  const { go, busy: navBusy, error: navError } = useStepNav('cover');
+  const navigate = useNavigate();
+
+  // `cover` is the LAST step, so it does not merely advance a cursor: it is the
+  // only place that can lift the route guard. Without the complete call the
+  // tunnel has no exit — and because OnboardingGuard denies /app until
+  // onboarding.completed is true, a user who reaches this screen is locked out
+  // of the product entirely. That is the failure #438's own Risk section warns
+  // about, and it is why this step does not use `go(..., 1)` like the others.
+  const save = useSaveOnboardingStep();
+  const complete = useCompleteOnboarding();
 
   // The posture is read here so the residual shown is the REAL one, computed by
   // the server from this tenant's own control mappings (ADR 0003). A number
@@ -299,6 +313,24 @@ export function CoverStep() {
 
   const risk: PostureRiskView | undefined = useMemo(() => posture?.top_risks?.[0], [posture]);
 
+  /**
+   * Save, then lift the guard, then land on the reveal.
+   *
+   * `onSuccess`, not `onSettled`: completing after a failed save would lift the
+   * guard on an answer that was never stored. And the tunnel ends on /posture
+   * because that is the whole point of #438 — five screens collected facts, and
+   * this is the screen that returns something computed in exchange.
+   */
+  const finish = () => {
+    save.mutate(
+      { step: 'cover', answers: { accepted } },
+      { onSuccess: () => complete.mutate(undefined, { onSuccess: () => navigate('/posture') }) },
+    );
+  };
+
+  const busy = navBusy || save.isPending || complete.isPending;
+  const error = navError || save.isError || complete.isError;
+
   return (
     <StepShell
       title={tr('Couvrez ce risque', 'Cover this risk')}
@@ -307,11 +339,11 @@ export function CoverStep() {
         'Accept the proposed control: the residual risk is recomputed from your own controls.',
       )}
       onBack={() => go({ accepted }, -1)}
-      onNext={() => go({ accepted, by: user?.id ?? '' }, 1)}
+      onNext={finish}
       nextLabel={tr('Voir ma posture', 'See my posture')}
       busy={busy}
       error={error}
-      onRetry={retry}
+      onRetry={finish}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
       errorHint={tr(
         'Vos réponses sont conservées — réessayez, rien n’est perdu.',

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -193,7 +193,7 @@ export function ScoreStep() {
           </p>
         </div>
 
-        <Matrix pIndex={pIndex} iIndex={iIndex} tr={tr} />
+        <Matrix pIndex={pIndex} iIndex={iIndex} score={score} tr={tr} />
       </div>
     </StepShell>
   );
@@ -252,10 +252,13 @@ function Slider({
 function Matrix({
   pIndex,
   iIndex,
+  score,
   tr,
 }: {
   pIndex: number;
   iIndex: number;
+  /** The live P × I the sliders produce — what the readout shows. */
+  score: number;
   tr: (fr: string, en: string) => string;
 }) {
   const reduced = usePrefersReducedMotion();
@@ -294,7 +297,12 @@ function Matrix({
                       transition: reduced ? 'none' : 'background .18s ease, outline .18s ease',
                     }}
                   >
-                    {active ? (p * impact).toFixed(1) : ''}
+                    {/* The score the user actually set, not this cell's own
+                        band product. The cell marks WHERE they are; the number
+                        is WHAT they scored. Showing the band's arithmetic put
+                        two different figures on screen for one thing — the
+                        readout said 6.30 beside a cell saying 5.6. */}
+                    {active ? score.toFixed(1) : ''}
                   </td>
                 );
               })}

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -24,7 +24,9 @@ import {
   useCompleteOnboarding,
   usePrefersReducedMotion,
   useSaveOnboardingStep,
+  useStarterRisks,
 } from '../useActivation';
+import { i18n } from '../../../services/activationService';
 
 // ---------------------------------------------------------------------------
 // The matrix
@@ -37,6 +39,31 @@ import {
 
 const PROBABILITY_BANDS = [0.1, 0.3, 0.5, 0.7, 0.9];
 const IMPACT_BANDS = [2, 4, 6, 8, 10];
+
+/**
+ * The risk these two steps are about.
+ *
+ * Both screens said "this risk" without ever naming one, on the step right after
+ * the user picked THREE — so they were scoring and covering an anonymous thing.
+ * The name comes from the selection stored in step 2 plus the catalogue the
+ * server already served; nothing is fetched that could record anything.
+ *
+ * Returns '' rather than a placeholder when the selection is not there yet: a
+ * made-up title on a screen about the user's own register is exactly what
+ * criterion 7 forbids.
+ */
+function useScoredRiskTitle(): string {
+  const lang = useUIStore((s) => s.lang);
+  const goalAnswers = useStoredAnswers('goal');
+  const { data: offer } = useStarterRisks();
+
+  return useMemo(() => {
+    const picked = goalAnswers.starter_risks;
+    if (!Array.isArray(picked) || picked.length === 0 || !offer) return '';
+    const first = offer.risks.find((r) => r.key === picked[0]);
+    return first ? i18n(first.title_i18n, lang) : '';
+  }, [goalAnswers, offer, lang]);
+}
 
 /** Score Engine bands, on the P×I×AC scale with AC unknown (so 0–10 here). */
 function bandOf(score: number): 'low' | 'medium' | 'high' | 'critical' {
@@ -68,6 +95,7 @@ export function ScoreStep() {
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
   const stored = useStoredAnswers('score');
   const { go, busy, error, retry } = useStepNav('score');
+  const riskTitle = useScoredRiskTitle();
 
   const [probability, setProbability] = useState(0.5);
   const [impact, setImpact] = useState(6);
@@ -93,7 +121,7 @@ export function ScoreStep() {
 
   return (
     <StepShell
-      title={tr('Évaluez ce risque', 'Score this risk')}
+      title={riskTitle || tr('Évaluez ce risque', 'Score this risk')}
       subtitle={tr(
         'Probabilité et impact. La matrice se met à jour pendant que vous bougez les curseurs — c’est le score que le moteur calculera.',
         'Likelihood and impact. The matrix updates as you move the sliders — this is the score the engine will compute.',
@@ -311,6 +339,7 @@ export function CoverStep() {
   // owns, and says plainly that the residual is computed on the next screen.
   // Nothing here is invented: the number comes from their own answers.
   const scored = useStoredAnswers('score');
+  const riskTitle = useScoredRiskTitle();
   const [accepted, setAccepted] = useState(false);
 
   useEffect(() => {
@@ -363,7 +392,7 @@ export function CoverStep() {
       )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
-      <InherentCard inherent={inherent} tr={tr} />
+      <InherentCard inherent={inherent} title={riskTitle} tr={tr} />
 
       <label
         className="mt-5 flex items-start gap-3 cursor-pointer"
@@ -395,13 +424,22 @@ export function CoverStep() {
  * records the Aha. Showing a client-computed figure instead would be the
  * placeholder criterion 7 forbids, on the screen that leads into the reveal.
  */
-function InherentCard({ inherent, tr }: { inherent: number; tr: (fr: string, en: string) => string }) {
+function InherentCard({
+  inherent,
+  title,
+  tr,
+}: {
+  inherent: number;
+  title: string;
+  tr: (fr: string, en: string) => string;
+}) {
   return (
     <div
       className="rounded-xl p-5"
       style={{ background: 'var(--bg-surface)', border: '1px solid var(--border-subtle)' }}
       data-testid="cover-residual"
     >
+      {title && <div className="text-[13.5px] font-semibold text-ink mb-3">{title}</div>}
       <div className="flex items-end gap-5">
         <Figure label={tr('Inhérent', 'Inherent')} value={inherent} />
         <ShieldCheck size={18} aria-hidden="true" style={{ color: 'var(--fg-muted)', marginBottom: 6 }} />

--- a/frontend/src/features/reports/ReportConfigurator.tsx
+++ b/frontend/src/features/reports/ReportConfigurator.tsx
@@ -98,12 +98,21 @@ export function ReportConfigurator({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative w-full max-w-[620px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-configurator-title"
+        className="relative w-full max-w-[620px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein"
+      >
         <header className="px-5 py-4 border-b border-line flex items-center justify-between shrink-0">
-          <h2 className="text-ink font-semibold text-[15px]">
+          <h2 id="report-configurator-title" className="text-ink font-semibold text-[15px]">
             {tr('Générer un rapport', 'Generate a report')}
           </h2>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
+          <button
+            aria-label={tr('Fermer', 'Close')}
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+          >
             <X size={16} />
           </button>
         </header>

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -405,9 +405,9 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                       </label>
                       <div className="rounded-3xl border border-border bg-app p-3 min-h-[120px] overflow-y-auto">
                         {assetsLoading ? (
-                          <p className="text-xs text-ink-muted">Chargement des assets...</p>
+                          <p className="text-xs text-ink-muted">{t('common.loading')}</p>
                         ) : assets.length === 0 ? (
-                          <p className="text-xs text-ink-muted">Aucun asset disponible</p>
+                          <p className="text-xs text-ink-muted">{t('assets.noAssets')}</p>
                         ) : (
                           <div className="grid gap-2">
                             {assets.map((asset) => (

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -203,6 +203,14 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
             exit={{ opacity: 0, scale: 0.96, y: 40 }}
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            // The app's primary creation flow was a bare <div>: no dialog role,
+            // no aria-modal, no accessible name. Assistive technology never
+            // announced it as a dialog and never trapped into it, so a screen
+            // reader could walk straight out into the register behind it while
+            // the form sat open on top.
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-risk-title"
           >
             {/* Bounded height + scrollable body so a tall form never pushes the header
                 or the submit button off-screen (the modal used to be vertically centered
@@ -210,10 +218,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
             <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div>
-                  <h2 className="text-2xl font-semibold text-ink">{t('risks.createRisk')}</h2>
-                  <p className="text-sm text-ink-muted">
-                    Créez un risque avec score en temps réel.
-                  </p>
+                  <h2 id="create-risk-title" className="text-2xl font-semibold text-ink">
+                    {t('risks.createRisk')}
+                  </h2>
+                  <p className="text-sm text-ink-muted">{t('risks.createRiskSubtitle')}</p>
                 </div>
                 <button
                   type="button"
@@ -272,7 +280,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
 
                   <div className="grid gap-4 sm:grid-cols-3">
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-probability"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.probability')}
                         <FieldHelp field="probability" lang={lang} sector={sector} />
                       </label>
@@ -281,7 +292,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={0}
                         max={1}
                         step={0.05}
+                        id="create-risk-probability"
                         {...register('probability', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={watchedProbability.toFixed(2)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -292,7 +308,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     </div>
 
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-impact"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.impact')}
                         <FieldHelp field="impact" lang={lang} sector={sector} />
                       </label>
@@ -301,7 +320,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={1}
                         max={10}
                         step={1}
+                        id="create-risk-impact"
                         {...register('impact', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={String(watchedImpact)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -312,7 +336,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     </div>
 
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-asset-criticality"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.riskAssetCriticality')}
                         <FieldHelp field="asset_criticality" lang={lang} sector={sector} />
                       </label>
@@ -321,7 +348,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={0.1}
                         max={3}
                         step={0.1}
+                        id="create-risk-asset-criticality"
                         {...register('assetCriticality', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={watchedCriticality.toFixed(1)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -365,15 +397,19 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     fields. Conflating them is what put a user's label in the
                     "Référentiel" column wearing a framework badge. */}
                   <div className="space-y-2">
-                    <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                      Catégorie
+                    <label
+                      htmlFor="create-risk-category"
+                      className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                    >
+                      {t('risks.category')}
                     </label>
                     <select
+                      id="create-risk-category"
                       {...register('category_id')}
                       className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink"
                       disabled={isSubmitting}
                     >
-                      <option value="">Non classé</option>
+                      <option value="">{t('risks.uncategorised')}</option>
                       {(categories ?? []).map((c) => (
                         <option key={c.id} value={c.id}>
                           {c.name}

--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -1363,6 +1363,9 @@ function RiskDrawer({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="risk-drawer-title"
         onClick={(e) => e.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -1377,10 +1380,13 @@ function RiskDrawer({
           <div className="flex items-start gap-3 mb-3">
             <div className="flex-1">
               <div className="mono text-[11px] text-ink-muted mb-[5px]">#{r.id.slice(0, 8)}</div>
-              <div className="disp text-[18px] font-bold text-ink leading-snug">{r.name}</div>
+              <h2 id="risk-drawer-title" className="disp text-[18px] font-bold text-ink leading-snug">
+                {r.name}
+              </h2>
             </div>
             <button
               onClick={onClose}
+              aria-label={tr('Fermer', 'Close')}
               className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft"
               style={{ background: 'var(--bg-hover)' }}
             >

--- a/frontend/src/features/risks/components/EditRiskModal.tsx
+++ b/frontend/src/features/risks/components/EditRiskModal.tsx
@@ -15,6 +15,7 @@ import { apiErrorMessage } from '../../../lib/apiError';
 import { useRiskStore } from '../../../hooks/useRiskStore';
 import { useAssetStore } from '../../../hooks/useAssetStore';
 import { Button, Field, Input } from '../../../shared/ds';
+import { useI18n } from '../../../hooks/useI18n';
 
 const riskSchema = z.object({
   title: z.string().min(5).max(100),
@@ -47,6 +48,7 @@ interface EditRiskModalProps {
 
 export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModalProps) => {
   const { updateRisk, isLoading } = useRiskStore();
+  const { t } = useI18n();
   const { assets, fetchAssets } = useAssetStore();
 
   const {
@@ -142,13 +144,13 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
           .filter(Boolean),
       };
       await updateRisk(risk.id, payload);
-      toast.success('Risque mis à jour');
+      toast.success(t('risks.updated'));
       onClose();
       onSuccess?.();
     } catch (err) {
       // Show what the server actually said. A generic message hides the one
       // sentence that names the offending field.
-      toast.error(apiErrorMessage(err) || 'Erreur lors de la mise à jour');
+      toast.error(apiErrorMessage(err) || t('risks.updateFailed'));
     }
   };
 
@@ -174,17 +176,25 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 50 }}
             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="edit-risk-title"
             className="fixed inset-0 m-auto w-full max-w-lg h-fit max-h-[90vh] bg-surface border border-border rounded-xl shadow-2xl p-6 z-90 overflow-hidden"
           >
             <div className="flex justify-between items-center mb-6 border-b border-border-strong/5 pb-4">
-              <h2 className="text-xl font-bold text-fg-primary flex items-center gap-2">
-                <ShieldAlert className="text-primary" size={20} /> Modifier le Risque
+              <h2
+                id="edit-risk-title"
+                className="text-xl font-bold text-fg-primary flex items-center gap-2"
+              >
+                <ShieldAlert className="text-primary" size={20} aria-hidden="true" />{' '}
+                {t('risks.editRisk')}
               </h2>
               <button
                 onClick={handleClose}
+                aria-label={t('common.close')}
                 className="text-fg-muted hover:text-fg-primary transition-colors"
               >
-                <X size={24} />
+                <X size={24} aria-hidden="true" />
               </button>
             </div>
 
@@ -193,7 +203,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
               className="space-y-4 overflow-y-auto pr-2 max-h-[calc(90vh-140px)]"
             >
               <Field
-                label="Titre"
+                label={t('risks.fieldTitle')}
                 message={errors.title?.message}
                 status={errors.title?.message ? 'invalid' : 'default'}
               >
@@ -201,10 +211,14 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
               </Field>
 
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                  Description
+                <label
+                  htmlFor="edit-risk-description"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                >
+                  {t('risks.fieldDescription')}
                 </label>
                 <textarea
+                  id="edit-risk-description"
                   {...register('description')}
                   rows={4}
                   disabled={isLoading}
@@ -217,15 +231,22 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               <div className="grid grid-cols-2 gap-4 pt-2">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                    Impact (0 – 10)
+                  <label
+                    htmlFor="edit-risk-impact"
+                    className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                  >
+                    {t('risks.impact')} (0 – 10)
                   </label>
+                  {/* The visible value sits in a separate row below, which is read
+                      as loose text rather than as the slider's value. */}
                   <input
+                    id="edit-risk-impact"
                     type="range"
                     min={0}
                     max={10}
                     step={0.5}
                     disabled={isLoading}
+                    aria-valuetext={(watch('impact') ?? 0).toFixed(1)}
                     {...register('impact', { valueAsNumber: true })}
                     className="w-full"
                   />
@@ -242,15 +263,20 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                 </div>
 
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                    Probabilité (0 – 1)
+                  <label
+                    htmlFor="edit-risk-probability"
+                    className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                  >
+                    {t('risks.probability')} (0 – 1)
                   </label>
                   <input
+                    id="edit-risk-probability"
                     type="range"
                     min={0}
                     max={1}
                     step={0.05}
                     disabled={isLoading}
+                    aria-valuetext={(watch('probability') ?? 0).toFixed(2)}
                     {...register('probability', { valueAsNumber: true })}
                     className="w-full"
                   />
@@ -269,16 +295,21 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               {/* Assets selector */}
               <div className="space-y-2 pt-2">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between">
-                  Assets Affectés
+                {/* A <label> with no control names nothing. These are toggle
+                    buttons, so the set is a group named by its own text. */}
+                <div
+                  id="edit-risk-assets-label"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between"
+                >
+                  {t('risks.affectedAssets')}
                   <span className="text-[10px] bg-surface-2 px-2 py-0.5 rounded-full">
-                    {selectedAssetIds.length} sélectionné(s)
+                    {t('risks.selectedCount', { count: selectedAssetIds.length })}
                   </span>
-                </label>
+                </div>
                 <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto p-2 border border-border rounded-lg bg-surface-1/30">
                   {assets.length === 0 ? (
                     <div className="text-fg-muted text-xs w-full text-center py-2">
-                      Aucun asset.
+                      {t('risks.noAssets')}
                     </div>
                   ) : (
                     assets.map((a) => (
@@ -287,6 +318,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                         type="button"
                         onClick={() => toggleAsset(a.id)}
                         disabled={isLoading}
+                        aria-pressed={selectedAssetIds.includes(a.id)}
                         className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedAssetIds.includes(a.id) ? 'bg-accent-soft border-accent text-info-text' : 'bg-surface-2 border-border-default text-fg-secondary'} ${isLoading ? 'opacity-70' : ''}`}
                       >
                         {a.name}
@@ -296,7 +328,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                 </div>
               </div>
 
-              <Field label="Tags (séparés par des virgules)">
+              <Field label={t('risks.tags')}>
                 <Input
                   {...register('tags')}
                   placeholder="ex: critical, web-app, legacy"
@@ -306,12 +338,15 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               {/* Frameworks selector */}
               <div className="space-y-2 pt-2">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between">
-                  Frameworks
+                <div
+                  id="edit-risk-frameworks-label"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between"
+                >
+                  {t('risks.frameworks')}
                   <span className="text-[10px] bg-surface-2 px-2 py-0.5 rounded-full">
-                    {selectedFrameworks.length} sélectionné(s)
+                    {t('risks.selectedCount', { count: selectedFrameworks.length })}
                   </span>
-                </label>
+                </div>
                 <div className="flex flex-wrap gap-2 p-2">
                   {frameworksList.map((f) => (
                     <button
@@ -319,6 +354,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                       type="button"
                       onClick={() => toggleFramework(f)}
                       disabled={isLoading}
+                      aria-pressed={selectedFrameworks.includes(f)}
                       className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedFrameworks.includes(f) ? 'bg-success/20 border-success text-success-text' : 'bg-surface-2 border-border-default text-fg-secondary hover:border-border-strong'}`}
                     >
                       {f}
@@ -329,10 +365,10 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               <div className="flex justify-end gap-3 mt-6 pt-4 border-t border-border-strong/5 sticky bottom-0 bg-surface">
                 <Button type="button" variant="ghost" onClick={handleClose} disabled={isLoading}>
-                  Annuler
+                  {t('common.cancel')}
                 </Button>
                 <Button variant="primary" type="submit" loading={isLoading || isSubmitting}>
-                  Enregistrer
+                  {t('common.save')}
                 </Button>
               </div>
             </form>

--- a/frontend/src/features/vulnerabilities/IngestModal.tsx
+++ b/frontend/src/features/vulnerabilities/IngestModal.tsx
@@ -80,7 +80,12 @@ export function IngestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
       style={{ background: 'rgba(0,0,0,.5)', backdropFilter: 'blur(3px)' }}
       onClick={onClose}
     >
+      {/* Announced as a dialog and named by its heading; the findings table
+          behind it stays in the accessibility tree otherwise. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ingest-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[560px] rounded-[16px] flex flex-col"
         style={{
@@ -94,15 +99,17 @@ export function IngestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="flex items-center gap-2 text-[15px] font-bold text-ink">
-            <Upload size={17} /> {tr('Importer des findings', 'Import findings')}
-          </div>
+          {/* A dialog's name should come from a heading, not a styled div. */}
+          <h2 id="ingest-title" className="flex items-center gap-2 text-[15px] font-bold text-ink">
+            <Upload size={17} aria-hidden="true" /> {tr('Importer des findings', 'Import findings')}
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >
-            <X size={18} />
+            <X size={18} aria-hidden="true" />
           </button>
         </div>
 

--- a/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
+++ b/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
@@ -83,6 +83,9 @@ export function IntegrationsPanel({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="integrations-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[640px] rounded-[16px] flex flex-col"
         style={{
@@ -105,9 +108,12 @@ export function IntegrationsPanel({
               <ChevronLeft size={18} />
             </button>
           )}
-          <div className="text-[15px] font-bold text-ink flex-1">{title}</div>
+          <h2 id="integrations-title" className="text-[15px] font-bold text-ink flex-1">
+            {title}
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >

--- a/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
+++ b/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
@@ -669,6 +669,9 @@ function VulnDrawer({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="vuln-drawer-title"
         onClick={(e) => e.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -685,10 +688,13 @@ function VulnDrawer({
               <div className="mono text-[12px] text-ink-muted mb-1">
                 {v.cve_id || v.external_id || '—'}
               </div>
-              <div className="disp text-[17px] font-bold text-ink leading-snug">{v.title}</div>
+              <h2 id="vuln-drawer-title" className="disp text-[17px] font-bold text-ink leading-snug">
+                {v.title}
+              </h2>
             </div>
             <button
               onClick={onClose}
+              aria-label={tr('Fermer', 'Close')}
               className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft"
               style={{ background: 'var(--bg-hover)' }}
             >

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -462,7 +462,8 @@
         "inherent": "Inherent risk",
         "residual": "Residual risk",
         "reduction": "Down by {value}"
-      }
+      },
+      "back": "Back"
     },
     "posture": {
       "title": "Your posture",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -505,7 +505,8 @@
       "members": "members",
       "action": "See my posture",
       "loading": "Reading your data…",
-      "error": "Your data could not be read."
+      "error": "Your data could not be read.",
+      "completeFailed": "Could not finish. Try again."
     },
     "checklist": {
       "close": "Hide the getting-started list",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -491,7 +491,8 @@
         "body": "Share this link. Roles are chosen in Settings › Members.",
         "copy": "Copy link",
         "copied": "Copied"
-      }
+      },
+      "continue": "Continue into OpenRisk"
     },
     "recognition": {
       "title": "What OpenRisk already knows about you",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -93,7 +93,10 @@
     "templateDownload": "Download CSV Template",
     "noRisks": "No Risks Found",
     "noRisksDescription": "Start by creating your first risk to manage it here.",
-    "createFirstRisk": "Create My First Risk"
+    "createFirstRisk": "Create My First Risk",
+    "createRiskSubtitle": "Create a risk with its score computed as you type.",
+    "category": "Category",
+    "uncategorised": "Uncategorised"
   },
   "statuses": {
     "open": "Open",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -225,7 +225,13 @@
     "closeDrawer": "Close",
     "save": "Save",
     "dragHint": "Drag plans here",
-    "reviewPending": "overdue"
+    "reviewPending": "overdue",
+    "createTitle": "Create a mitigation plan",
+    "createSubtitle": "Create a plan to mitigate a risk",
+    "fieldTitle": "Title",
+    "fieldDescription": "Description",
+    "fieldDeadline": "Deadline",
+    "fieldPriority": "Priority"
   },
   "compliance": {
     "title": "Compliance",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -73,7 +73,7 @@
     "acceptanceReason": "Acceptance Reason",
     "duplicateRisk": "Duplicate Risk",
     "bulkActions": "Bulk Actions",
-    "selectedCount": "{count} risk(s) selected",
+    "selectedCount": "{count} selected",
     "bulkDelete": "Delete",
     "bulkChangeStatus": "Change Status",
     "bulkAssignTo": "Assign To",
@@ -96,7 +96,15 @@
     "createFirstRisk": "Create My First Risk",
     "createRiskSubtitle": "Create a risk with its score computed as you type.",
     "category": "Category",
-    "uncategorised": "Uncategorised"
+    "uncategorised": "Uncategorised",
+    "fieldTitle": "Title",
+    "tags": "Tags (comma separated)",
+    "frameworks": "Frameworks",
+    "affectedAssets": "Affected assets",
+    "noAssets": "No asset.",
+    "updated": "Risk updated",
+    "updateFailed": "Update failed",
+    "fieldDescription": "Description"
   },
   "statuses": {
     "open": "Open",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -505,7 +505,8 @@
       "members": "membres",
       "action": "Voir ma posture",
       "loading": "Lecture de vos données…",
-      "error": "Impossible de lire vos données."
+      "error": "Impossible de lire vos données.",
+      "completeFailed": "Impossible de terminer. Réessayez."
     },
     "checklist": {
       "close": "Masquer la liste de démarrage",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -225,7 +225,13 @@
     "closeDrawer": "Fermer",
     "save": "Sauvegarder",
     "dragHint": "Glissez des plans ici",
-    "reviewPending": "en retard"
+    "reviewPending": "en retard",
+    "createTitle": "Créer un plan d'atténuation",
+    "createSubtitle": "Créez un plan pour atténuer un risque",
+    "fieldTitle": "Titre",
+    "fieldDescription": "Description",
+    "fieldDeadline": "Échéance",
+    "fieldPriority": "Priorité"
   },
   "compliance": {
     "title": "Conformité",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -73,7 +73,7 @@
     "acceptanceReason": "Justification de l'acceptation",
     "duplicateRisk": "Dupliquer le risque",
     "bulkActions": "Actions en masse",
-    "selectedCount": "{count} risque(s) sélectionné(s)",
+    "selectedCount": "{count} sélectionné(s)",
     "bulkDelete": "Supprimer",
     "bulkChangeStatus": "Changer le statut",
     "bulkAssignTo": "Assigner à",
@@ -96,7 +96,15 @@
     "createFirstRisk": "Créer mon premier risque",
     "createRiskSubtitle": "Créez un risque avec score en temps réel.",
     "category": "Catégorie",
-    "uncategorised": "Non classé"
+    "uncategorised": "Non classé",
+    "fieldTitle": "Titre",
+    "tags": "Étiquettes (séparées par des virgules)",
+    "frameworks": "Référentiels",
+    "affectedAssets": "Actifs affectés",
+    "noAssets": "Aucun actif.",
+    "updated": "Risque mis à jour",
+    "updateFailed": "Erreur lors de la mise à jour",
+    "fieldDescription": "Description"
   },
   "statuses": {
     "open": "Ouvert",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -93,7 +93,10 @@
     "templateDownload": "Télécharger le modèle CSV",
     "noRisks": "Aucun risque trouvé",
     "noRisksDescription": "Commencez par créer votre premier risque pour le gérer ici.",
-    "createFirstRisk": "Créer mon premier risque"
+    "createFirstRisk": "Créer mon premier risque",
+    "createRiskSubtitle": "Créez un risque avec score en temps réel.",
+    "category": "Catégorie",
+    "uncategorised": "Non classé"
   },
   "statuses": {
     "open": "Ouvert",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -462,7 +462,8 @@
         "inherent": "Risque inhérent",
         "residual": "Risque résiduel",
         "reduction": "Réduction de {value}"
-      }
+      },
+      "back": "Retour"
     },
     "posture": {
       "title": "Votre posture",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -491,7 +491,8 @@
         "body": "Partagez ce lien. Les rôles se choisissent dans Paramètres › Membres.",
         "copy": "Copier le lien",
         "copied": "Copié"
-      }
+      },
+      "continue": "Continuer dans OpenRisk"
     },
     "recognition": {
       "title": "Ce qu'OpenRisk sait déjà de vous",

--- a/frontend/src/services/activationService.ts
+++ b/frontend/src/services/activationService.ts
@@ -308,9 +308,19 @@ export const activationService = {
    *
    * A 409 means this tenant already adopted — the tunnel is resumable, so that
    * is an expected answer and not a failure to retry.
+   *
+   * `lang` decides the language the rows are WRITTEN in. Getting it wrong writes
+   * statements a customer's colleagues may not read into their own register.
    */
-  async adoptStarterRisks(keys: string[]): Promise<AdoptStarterRisksResult> {
-    const { data } = await api.post<AdoptStarterRisksResult>('/onboarding/starter-risks', { keys });
+  async adoptStarterRisks(keys: string[], lang: Lang): Promise<AdoptStarterRisksResult> {
+    const { data } = await api.post<AdoptStarterRisksResult>('/onboarding/starter-risks', {
+      keys,
+      // Which of the two SERVER-AUTHORED strings to store. A preference, not
+      // content: it cannot introduce text of our own, and the server falls back
+      // to French on anything it does not recognise. Sent because the client is
+      // the only party that knows which language the person is reading.
+      lang,
+    });
     return data;
   },
 };

--- a/frontend/src/shared/ui.tsx
+++ b/frontend/src/shared/ui.tsx
@@ -165,15 +165,21 @@ export function Chip({
   active,
   onClick,
   color,
+  testId,
 }: {
   label: string;
   active?: boolean;
   onClick?: () => void;
   color?: string;
+  /** Optional hook for the E2E gates. A filter nobody can address from a test
+   *  is a filter whose behaviour nothing protects. */
+  testId?: string;
 }) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
+      aria-pressed={active}
       className="h-(--control-h-sm) px-3 rounded-full text-xs font-semibold inline-flex items-center gap-1.5 transition-colors duration-fast ease-out"
       style={{
         border: `1px solid ${active ? 'transparent' : 'var(--border)'}`,


### PR DESCRIPTION
Five defects found by **walking the onboarding journey in a browser**, as the owner asked.
Every one of them was in code from this stack; four are blockers or near-blockers a user hits
in the first five minutes.

Part of #438. Stacked on #634.

## What was broken

**1. The tunnel had no exit — it never completed onboarding.** `CoverStep` used the shared
`go(..., 1)` helper like every other step. That advances a cursor; it does not call
`POST /onboarding/complete`. `cover` is the last step, so **nothing ever completed the wizard**.
The primary button did nothing: no navigation, no error. And because `OnboardingGuard` denies
`/app` until `onboarding.completed` is true, the user was locked out of the product entirely —
the failure #438's own Risk section warns about.

This is almost certainly what the owner hit. It also explains the two symptoms they described:
`/` kept redirecting to `/onboarding/organization` (they had a session and were trapped in the
tunnel), and the account felt impossible to create (it was created; it just led nowhere).

**2. It exited to the wrong place.** `OnboardingCompletedRedirect` sent a completed user to
`data.landing`, the screen derived from their goal. It fires on the render right after the
complete call, so it beat the reveal to the punch: five screens collected facts and the user
was dropped on a register — the exact activation cliff #438 exists to remove. Completed users
now go to the reveal; `landing` is what the reveal offers, and the reveal now carries that CTA
rather than being a dead end.

**3. Starter risks were written in French for every tenant.** The write language was read off a
`language` answer on the `profile` step. #438 retired that route and nothing writes that answer
any more, so the lookup always missed and always fell back to French — for English readers too.
Rows a customer did not author, in a language their colleagues may not read, is precisely what
the "keys only, re-read server-side" design exists to prevent. The provenance was right; the
content was not.

The language now comes from the caller, because it is a **preference and not content**: it
selects which of two server-authored strings to store and cannot introduce text of the client's
own. `normaliseLang` takes fr/en case- and padding-insensitively and falls back to French on
anything else.

**4. The coverage step fired the Aha moment one step early.** `GET /posture` is what records
`posture.revealed`, and D-010 makes that event the Aha — the endpoint behind the eight-minute
promise and behind `openrisk_time_to_aha_seconds{aha_definition="v2"}`. Step 5 fetched it to
decorate a card, so the metric the launch gate reads was systematically **early by one step**,
and `first_reveal` was already false by the time the reveal mounted — the screen that exists to
celebrate never celebrated.

Step 5 now fetches nothing. It shows the score the user set in step 4 — their own answers,
P × I — and says the residual is computed on the next screen. It deliberately does **not**
compute a residual client-side: that needs the tenant's control mappings, the only endpoint
returning them is the reveal, and an invented figure is the placeholder criterion 7 forbids.

**5. Steps 4 and 5 never said which risk they were about.** "Score this risk" on the step right
after the user picked *three*. Both now name the first adopted statement, from the selection
stored in step 2 plus the catalogue the server already served — nothing fetched that could
record anything.

**6. The back button was hard-coded in French.** `StepShell` is the one component every step is
built from, so "Retour" shipped next to "Continue" on all five screens for every English reader.

## Verification — walked in a browser, then re-run

Full journey, twice (English and French UI), against a backend compiled from this branch:

```
register → /onboarding/organization → goal (+3 starter risks, 201 Created)
        → framework (COBAC imported) → score → cover → /posture
```

- The tunnel completes and lands on **/posture**.
- The reveal renders 3 risks, 0% coverage of 45 applicable controls, three residual scores and
  `residual-v1`, plus the landing CTA and the invite block.
- `revealed_at` equals the moment the reveal mounted; a second call returns
  `first_reveal: false`. **No `/posture` request is made anywhere inside the tunnel.**
- Against a fresh English tenant the rows come back as "Core banking system outage",
  "Fraudulent transfer executed", "Screening gap on a business relationship".
- Step 4's heading reads the adopted risk's name; step 5's card carries the same one.
- With the UI in English the back button reads "Back"; in French, "Retour".

```
$ go build ./... && go vet ./internal/... ./pkg/...      (clean)
$ go test ./internal/application/activation/ ./internal/application/risk/ ./pkg/scoring/ ./pkg/onboarding/
ok  …/internal/application/activation   ok  …/internal/application/risk
ok  …/pkg/scoring                       ok  …/pkg/onboarding

$ npx tsc -b        (clean)
$ npx vitest run
 Test Files  55 passed (55)
      Tests  587 passed (587)

$ npx playwright test tests/e2e/activation.spec.ts -g "newcomer|resumable|empty posture|revealed posture|provenance"
  5 passed (53.2s)

$ npm run lint:ceiling
ESLint errors: 313 (ceiling 321)   # only the pre-existing no-irregular-whitespace entry, #627
```

Two new backend tests pin the language defect: one asserts the stored title matches the
catalogue in the requested language, the other that an unrecognised value falls back to French
rather than storing something half-translated.

## A note on measuring

A first `vitest run` reported 22 failures across 12 files I never touched, each file taking
32–39s. That was the machine saturated by the Go backend, the Vite dev server and Chromium all
running beside it. Re-run on an idle machine: **587/587 in 10s**. Worth knowing before anyone
reads a red local run as a regression.

## Honest remainders

- **Step 5 no longer shows a residual number.** It shows the inherent score and says the
  residual comes next. Restoring a real one there needs the residual on an existing per-risk
  endpoint — "extend their payloads instead", as #438 puts it — because the only endpoint
  returning it today is the one that records the Aha. Worth its own change.
- **Step 4's score is still not written to the risk** (PR 5's remainder, unchanged).
- **Step 3 does not count the control import up from zero**, which #438's table asks for. The
  button flips to "Imported".
