### PR TITLE
fix: app review — a customer lock-out, two red security gates, and four smaller defects

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2898,7 +2898,16 @@ func main() {
 	protected.Post("/onboarding/complete", activationHandler.CompleteOnboarding)
 	protected.Get("/onboarding/recognition", activationHandler.GetRecognition)
 	protected.Get("/onboarding/starter-risks", activationHandler.GetStarterRisks)
-	protected.Post("/onboarding/starter-risks", activationHandler.AdoptStarterRisks)
+	// The POST WRITES REAL RISKS into the tenant's register, so it carries the
+	// same permission as every other risk-creation path. The tunnel is walked by
+	// invited members too, and one without `risks:create` must not be able to
+	// put three rows in a register they may not write to.
+	//
+	// The client treats the resulting 403 the way it treats a 409: the step
+	// advances without adopting. A blocking tunnel that refuses to advance
+	// because of a permission the user will never have would lock them out of
+	// the product — the failure #438's Risk section names.
+	protected.Post("/onboarding/starter-risks", riskCreate, activationHandler.AdoptStarterRisks)
 	protected.Put("/onboarding/steps/:step", activationHandler.SaveOnboardingStep)
 
 	// The Posture Reveal (#438). Outside the /onboarding group on purpose: it is

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -925,12 +925,44 @@ func main() {
 		})
 	})
 
+	// Liveness/readiness. This is what docker-compose, the Helm probes and the
+	// E2E webServer wait on, so it must PROBE rather than assert.
+	//
+	// It used to return a hardcoded {"status":"UP","db":"CONNECTED"} — twelve
+	// lines below /status, whose own comment says it probes "so the public status
+	// page reflects reality, not a hardcoded UP". With Postgres stopped, this
+	// endpoint went on reporting a healthy database while every query failed with
+	// connection refused: an orchestrator would keep a dead instance in rotation
+	// and an operator debugging an outage would be told the database is fine.
+	//
+	// A failed probe answers 503, because a readiness probe that cannot fail is
+	// not a readiness probe.
 	api.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{
-			"status":  "UP",
+		dbUp := true
+		if sqlDB, err := database.DB.DB(); err != nil {
+			dbUp = false
+		} else {
+			// Bounded: a probe that blocks on a wedged connection turns a health
+			// check into an outage of its own.
+			ctx, cancel := context.WithTimeout(c.UserContext(), 2*time.Second)
+			defer cancel()
+			if sqlDB.PingContext(ctx) != nil {
+				dbUp = false
+			}
+		}
+
+		status := "UP"
+		code := fiber.StatusOK
+		if !dbUp {
+			status = "DOWN"
+			code = fiber.StatusServiceUnavailable
+		}
+
+		return c.Status(code).JSON(fiber.Map{
+			"status":  status,
 			"version": Version,
 			"commit":  Commit,
-			"db":      "CONNECTED",
+			"db":      map[bool]string{true: "CONNECTED", false: "DISCONNECTED"}[dbUp],
 			// Drives the permanent "demonstration data" banner. Served from the
 			// backend rather than a frontend build flag so the two cannot disagree
 			// about whether the data on screen is real.

--- a/backend/internal/auth/token_test.go
+++ b/backend/internal/auth/token_test.go
@@ -10,6 +10,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
+	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -22,21 +24,24 @@ import (
 	authpkg "github.com/opendefender/openrisk/pkg/auth"
 )
 
-// newTokenHarness builds a TokenManager over an in-memory sqlite refresh_tokens
+// newTokenHarness builds a TokenManager over a temporary sqlite refresh_tokens
 // table with an org resolver that yields claims for whichever org it is asked
 // about (recording the last org it saw, so tests can assert org preservation).
 func newTokenHarness(t *testing.T) (*TokenManager, *gorm.DB, *resolverSpy) {
 	t.Helper()
 
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	// Use a per-test temp file instead of ":memory:" so that concurrent
+	// goroutines (TestRefresh_ConcurrentRotation_OneWinner) share a single
+	// database through WAL mode and busy_timeout, which models the real
+	// Postgres serialisation. ":memory:" with MaxOpenConns(1) was flaky
+	// under make test's inter-package parallelism.
+	dbPath := filepath.Join(t.TempDir(), "token_test.db")
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=5000", dbPath)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	// Pin to a single connection: sqlite ":memory:" is per-connection, so an
-	// unbounded pool would give each concurrent goroutine its OWN database and
-	// every one of them would "win" the rotation. One connection models the single
-	// logical database (Postgres) where the atomic UPDATE genuinely serialises.
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxOpenConns(4)
 	require.NoError(t, db.Exec(`
 		CREATE TABLE refresh_tokens (
 			id TEXT PRIMARY KEY,

--- a/backend/internal/domain/business_roles.go
+++ b/backend/internal/domain/business_roles.go
@@ -203,7 +203,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Chief information security officer: cyber risks, vulnerabilities, incidents, security controls and KPIs.",
 		DefaultLanding: "/",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"vulnerabilities:read", "vulnerabilities:update",
 			"incidents:read", "incidents:create", "incidents:update",
@@ -223,7 +222,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "IT director: global IT view, assets, availability and IT risks.",
 		DefaultLanding: "/assets",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"assets:read", "assets:create", "assets:update", "assets:delete",
 			"mitigations:read", "mitigations:create", "mitigations:update",
@@ -243,7 +241,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Risk management: register, assessments, treatments, heatmaps and reporting.",
 		DefaultLanding: "/risks",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update", "risks:delete",
 			"mitigations:read", "mitigations:create", "mitigations:update", "mitigations:delete",
 			"assets:read",
@@ -261,7 +258,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Audit: audit campaigns, findings, evidences, action plans and history (broad read + audit management).",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",
@@ -281,7 +277,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Compliance: frameworks, controls, evidences, remediation plans and regulatory obligations.",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",
@@ -302,7 +297,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Internal control: control testing, evidences, audits and remediation plans.",
 		DefaultLanding: "/compliance",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read", "mitigations:update",
@@ -323,7 +317,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Asset owner: manages their asset scope and tracks associated risks.",
 		DefaultLanding: "/assets",
 		Permissions: []PermissionKey{
-			"events:read",
 			"assets:read", "assets:create", "assets:update",
 			"risks:read",
 			"mitigations:read", "mitigations:update",
@@ -339,7 +332,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Risk owner: treats the risks they own and their mitigation plans.",
 		DefaultLanding: "/risks",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:update",
 			"mitigations:read", "mitigations:create", "mitigations:update",
 			"assets:read",
@@ -355,7 +347,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "SOC analyst: vulnerabilities, incidents, scans, automation and risk treatment.",
 		DefaultLanding: "/vulnerabilities",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read", "risks:create", "risks:update",
 			"vulnerabilities:read", "vulnerabilities:update", "vulnerabilities:delete",
 			"incidents:read", "incidents:create", "incidents:update", "incidents:delete",
@@ -374,7 +365,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Executive / board: strategic dashboard, financial exposure and reports — no technical detail.",
 		DefaultLanding: "/analytics",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"compliance:read",
 			"reports:board:read",
@@ -388,7 +378,6 @@ var businessRoles = []BusinessRole{
 		DescriptionEN:  "Read-only access to the whole GRC posture.",
 		DefaultLanding: "/",
 		Permissions: []PermissionKey{
-			"events:read",
 			"risks:read",
 			"assets:read",
 			"mitigations:read",

--- a/backend/internal/handler/authz_route_coverage_test.go
+++ b/backend/internal/handler/authz_route_coverage_test.go
@@ -83,6 +83,26 @@ var routesWithoutPermissionGuard = []string{
 	"DELETE /tokens/:id",
 	"GET /action-center",
 	"GET /activation/state",
+	// #438 — the Posture Reveal, the recognition screen and the starter
+	// catalogue READ.
+	//
+	// Session-sufficient for the same reason as GET /activation/state, which
+	// this list already carries: they are the product's own account of where
+	// THIS user stands, resolved from (tenant, user) on the session with no id
+	// taken from the request. Gating a user's own posture behind a permission
+	// would hide their own data from them, and there is no permission that
+	// means "may look at yourself".
+	//
+	// The catalogue READ returns compiled-in statements (pkg/onboarding)
+	// filtered by the caller's own stored sector; the only tenant-derived field
+	// is already_adopted. The catalogue WRITE is NOT here — POST
+	// /onboarding/starter-risks carries risks:create, like every other risk
+	// write.
+	//
+	// NEEDS A REVIEWER'S AGREEMENT per this list's contract.
+	"GET /onboarding/recognition",
+	"GET /onboarding/starter-risks",
+	"GET /posture",
 	"GET /ai/status",
 	"GET /analytics/dashboard",
 	"GET /analytics/export",

--- a/backend/internal/security/isolation/registry.go
+++ b/backend/internal/security/isolation/registry.go
@@ -499,6 +499,28 @@ var decisions = []Decision{
 	{"/api/v1/activation/state", Pending,
 		"assessed, not pinned: same (tenant, user) gate, 401 when either is missing. Unresolved: the activation state aggregates progress across several modules and this sweep did not read each source. Settled by a two-tenant test over the activation state use case"},
 
+	// --- Posture reveal and recognition (#438) ----------------------------
+	//
+	// All three resolve (tenant, user) from the session and take no id from the
+	// request, and every query in gorm_posture_repository.go filters on the
+	// table's own tenant column — the control-mapping join carries a second
+	// guard, c.tenant_id = m.tenant_id, so a corrupt mapping row cannot pull
+	// another tenant's control status into this tenant's score.
+	//
+	// Pending rather than Covered, deliberately: the use-case tests
+	// (TestPostureSummary_NeverReadsAnotherTenant,
+	// TestRecognition_NeverReadsAnotherTenant,
+	// TestAdoptStarterRisks_NeverWritesToAnotherTenant) drive a reader double
+	// keyed BY TENANT, which proves the use case passes the caller's tenant
+	// down. It does NOT exercise the SQL. Claiming Covered on that basis would
+	// be exactly the guess this register exists to prevent.
+	{"/api/v1/posture", Pending,
+		"assessed, not pinned: (tenant, user) resolved from the session, 401 when either is missing; every query in gorm_posture_repository.go filters on tenant_id and the compliance_controls join carries c.tenant_id = m.tenant_id. Unresolved: application/activation TestPostureSummary_NeverReadsAnotherTenant asserts the use case reads only the caller's tenant, but it drives a double — the repository SQL itself has no cross-tenant test. Settled by a two-tenant repository test over RiskCounts, TopRisks, ControlCounts and ControlCreditsByRisk"},
+	{"/api/v1/onboarding/recognition", Pending,
+		"assessed, not pinned: same (tenant, user) gate; RecognitionCounts counts five tables, each on its own tenant column (organization_members on organization_id, which is that table's tenant column). Unresolved: application/activation TestRecognition_NeverReadsAnotherTenant drives a double, not the SQL. Settled by the same two-tenant repository test"},
+	{"/api/v1/onboarding/starter-risks", Pending,
+		"assessed, not pinned: GET returns a COMPILED-IN catalogue (pkg/onboarding) filtered by the caller's own stored sector and country, so the response body holds no tenant rows; the only tenant-derived field is already_adopted, read through the tenant-scoped risk repository. POST writes through application/risk CreateRiskUseCase, which stamps TenantID from the caller. Unresolved: TestAdoptStarterRisks_NeverWritesToAnotherTenant drives a writer double. Settled by a repository-level test asserting an adopted row lands on the caller's tenant only"},
+
 	// --- Risks and scoring (5) --------------------------------------------
 	{"/api/v1/risks", Covered,
 		"handler/risk_isolation_test TestRiskIsolation_ListLeaksNothing drives GET /risks over the real handler and repository from one tenant against another's register; TestRiskIsolation_NilTenantIsDenied covers the unresolved-tenant case"},

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,41 @@ recommends, and surfaces these in the daily brief. Run `/decide` to clear them.
 
 ## Open
 
+### D-043 — the sidebar shows five destinations twice · raised 2026-09-11
+**Context** — `frontend/src/shared/navModel.ts` defines seven nav groups. The
+first, `g_pilot`, holds exactly `risks · vulnerabilities · mitigations ·
+incidents · automation` — and every one of those five is a verbatim duplicate
+(same key, path, label, icon and permission) of an item in `g_identify`,
+`g_evaluate` or `g_treat`. The live sidebar renders 28 links of which 5 pairs
+point at the same route, and on `/risks` TWO sidebar links carry
+`aria-current="page"` at once.
+
+The model contradicts its own documentation twice. `g_pilot`'s comment says it
+is "« Où en suis-je ? » (dashboard par rôle, exécutif, financier)" — those five
+screens are in `g_monitor`, not here. And the block comment says the core
+intention "identify → score → treat → prove" **leads** the order; `g_pilot`
+leads instead.
+
+**Options**
+- **A — delete `g_pilot`.** The GRC flow (identify → evaluate → treat → prove)
+  becomes the navigation, matching what the file says it wanted. Five links
+  disappear from the sidebar; nobody loses a destination.
+- **B — keep `g_pilot` as a deliberate quick-access group, and remove the five
+  duplicates from the flow groups.** `g_evaluate` would then be empty and would
+  have to go, and "Traiter" would lose its whole contents.
+- **C — keep both and mark only one instance current.** The duplication stays;
+  only the `aria-current` defect is fixed.
+
+**Recommendation** — A. It is the only option under which the file's own stated
+intent and its contents agree, and it is the one that removes the duplication
+rather than hiding it.
+
+**Cost of delay** — Low but compounding: every new operational screen has to be
+added in two places, and the "is this group the dashboards or the registers?"
+question is re-asked by each person who edits the file.
+
+**Reversible?** — Yes, entirely. One array in one file.
+
 ### D-041 — may the backend container generate its own RS256 keypair? · raised 2026-09-09
 **Context** — #328's criterion 5 wants a one-click deploy to a third-party
 platform (Render/Railway/Fly). It cannot be built today: the backend panics at

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -93,6 +93,38 @@ optional keys:
 - **Public URL / CORS:** `APP_BASE_URL`, `CORS_ORIGINS`, `VITE_API_URL` when you
   put OpenRisk behind a real domain / reverse proxy.
 
+## Capabilities
+
+<!-- BEGIN GENERATED: entitlements matrix -->
+<!-- Generated from backend/pkg/entitlements/entitlements.go.
+     Do not edit by hand: `go test ./pkg/entitlements/ -run TestSelfHostDoc -update`. -->
+
+| Capability | Free | Pro | Business | Enterprise |
+|---|---|---|---|---|
+| Users | 2 | 10 | 50 | unlimited |
+| Risks | 50 | 500 | unlimited | unlimited |
+| Assets | 50 | unlimited | unlimited | unlimited |
+| Integrations | 1 | 10 | unlimited | unlimited |
+| REST API | limited | yes | yes | yes |
+| Automation rules | — | yes | advanced | advanced |
+| AI advisor | — | yes | advanced | advanced |
+| Compliance frameworks | basic | standard | advanced | custom |
+| SSO (SAML / OIDC) | — | — | yes | advanced |
+| Multi-tenant | — | — | — | yes |
+| On-premise entitlement | — | — | — | yes |
+| Financial quantification | — | yes | yes | yes |
+| SmartScore | — | yes | yes | yes |
+| Executive dashboard | — | yes | yes | yes |
+| Scanner | — | yes | yes | yes |
+| Threat intelligence (CTI) | — | — | yes | advanced |
+| Governance | — | — | yes | advanced |
+| SLA | — | — | 99.5% | 99.9% |
+| Support | community | email | priority | dedicated |
+
+A self-hosted instance registers its first organisation with no plan set, so it resolves to **Free**: 2 users, 50 risks, 50 assets, 1 integration(s).
+
+<!-- END GENERATED: entitlements matrix -->
+
 ## Upgrade
 
 ```bash

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -415,7 +415,17 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
       offline: { color: 'var(--fg-muted)', label: ['Hors ligne', 'Offline'], pulse: false },
     };
   let m = meta[status.state];
-  let state: string = status.state;
+  // `live` is the realtime stream's own state, reported SEPARATELY from the
+  // connection state below. It used to overwrite `data-state`, which meant the
+  // attribute never read "online" while the API was reachable — it always
+  // carried a live-* value instead. That silently broke the contract
+  // tests/e2e/dead-controls.spec.ts reads ("the status dot reports the REAL
+  // connection"), and conflated two questions a user asks separately: can the
+  // app reach the server, and are updates arriving by themselves.
+  //
+  // The colour and the label still combine both, because one dot is the right
+  // amount of chrome. Only the machine-readable attributes are split.
+  let liveState: string = 'none';
 
   if (status.state === 'online') {
     switch (live.state) {
@@ -425,7 +435,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Mises à jour en direct', 'Live updates on'],
           pulse: true,
         };
-        state = 'live';
+        liveState = 'live';
         break;
       case 'RECONNECTING':
       case 'INITIALIZING':
@@ -434,7 +444,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Reconnexion au flux…', 'Reconnecting to the live stream…'],
           pulse: false,
         };
-        state = 'live-reconnecting';
+        liveState = 'live-reconnecting';
         break;
       case 'RESYNCING':
         m = {
@@ -442,7 +452,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           label: ['Resynchronisation en cours', 'Resynchronising'],
           pulse: false,
         };
-        state = 'live-resyncing';
+        liveState = 'live-resyncing';
         break;
       case 'FORBIDDEN':
         // Said plainly rather than shown as a fault: nothing is broken, this
@@ -455,7 +465,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           ],
           pulse: false,
         };
-        state = 'live-forbidden';
+        liveState = 'live-forbidden';
         break;
       case 'ERROR':
       case 'DISCONNECTED':
@@ -467,7 +477,7 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
           ],
           pulse: false,
         };
-        state = 'live-off';
+        liveState = 'live-off';
         break;
     }
   }
@@ -478,7 +488,8 @@ function ConnectionDot({ lang }: { lang: LocaleCode }) {
       className="flex items-center px-2"
       title={label}
       data-testid="connection-status"
-      data-state={state}
+      data-state={status.state}
+      data-live={liveState}
     >
       <span
         className="w-[7px] h-[7px] rounded-full"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@
 // the terms of the GNU Affero General Public License v3.0 (see LICENSE).
 
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router';
+import { Link, useNavigate, useLocation } from 'react-router';
 import {
   ChevronsUpDown,
   PanelLeftClose,
@@ -152,12 +152,23 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
     const active = item.key === activeKey;
     const Icon = item.icon;
     return (
-      <button
+      // A LINK, not a button. Every nav entry used to be `<button
+      // onClick={navigate(...)}>`, which renders no href — so Ctrl/Cmd+click,
+      // middle-click and "copy link address" all did nothing, and a screen
+      // reader announced 27 buttons where a user expects a list of links.
+      //
+      // A risk manager comparing two registers side by side needs a second tab,
+      // and there was no way to open one. `Link` keeps the SPA navigation for a
+      // plain click and lets the browser handle the modified ones itself.
+      <Link
         key={item.key}
+        to={item.href ?? item.path}
         data-testid={`nav-${item.key}`}
         // Anchor for the product tour's third coach mark (features/onboarding/ProductTour).
         data-tour={`nav-${item.key}`}
-        onClick={() => navigate(item.href ?? item.path)}
+        // The visual highlight told sighted users which page they were on; this
+        // is the same fact, for everyone else.
+        aria-current={active ? 'page' : undefined}
         title={L[item.labelKey]}
         className={cn(
           'w-full flex items-center gap-[11px] px-[11px] py-2 rounded-[9px] relative mb-0.5 transition-colors',
@@ -203,7 +214,7 @@ export const Sidebar = ({ mobileOpen = false, onMobileClose }: SidebarProps) => 
               {navCounts[item.badge.count]}
             </span>
           ))}
-      </button>
+      </Link>
     );
   };
 

--- a/frontend/src/features/ai/AiAdvisor.tsx
+++ b/frontend/src/features/ai/AiAdvisor.tsx
@@ -96,6 +96,14 @@ export function AiAdvisor() {
 
   return (
     <div className="flex flex-col" style={{ height: 'calc(100vh - 58px)' }}>
+      {/* The page had no heading at all — no h1, no h2, nothing. Every other
+          screen in the app opens with one, and without it a screen-reader user
+          landing here has no way to tell which page they are on, nor to jump to
+          it from the headings list. It is visually hidden because the screen's
+          own chrome (the provenance badge, the conversation) already tells a
+          sighted user where they are. */}
+      <h1 className="sr-only">{tr('IA Advisor', 'AI Advisor')}</h1>
+
       {/* Provenance badge */}
       <div
         className="shrink-0 flex items-center justify-center gap-2 py-2.5"
@@ -213,13 +221,25 @@ export function AiAdvisor() {
               className="flex-1 h-12 px-[18px] rounded-[14px] text-[14px] text-ink outline-none disabled:opacity-60"
               style={{ border: '1px solid var(--border-strong)', background: 'var(--bg-elevated)' }}
             />
+            {/* An icon-only control needs a name, or it is announced as
+                "button" and nothing more — the one control that sends the
+                message. The label follows the state so a screen reader is told
+                the send is in flight rather than silently ignored. */}
             <button
               onClick={() => send()}
               disabled={ask.isPending}
+              aria-label={
+                ask.isPending ? tr('Envoi en cours…', 'Sending…') : tr('Envoyer', 'Send')
+              }
+              title={ask.isPending ? tr('Envoi en cours…', 'Sending…') : tr('Envoyer', 'Send')}
               className="w-12 h-12 rounded-[14px] flex items-center justify-center text-fg-primary shrink-0 disabled:opacity-60"
               style={{ background: 'var(--accent-solid)', color: 'var(--fg-on-solid)' }}
             >
-              {ask.isPending ? <Loader2 size={20} className="animate-spin" /> : <Send size={20} />}
+              {ask.isPending ? (
+                <Loader2 size={20} className="animate-spin" aria-hidden="true" />
+              ) : (
+                <Send size={20} aria-hidden="true" />
+              )}
             </button>
           </div>
           <div className="text-center text-[11px] text-ink-muted mt-2.5">

--- a/frontend/src/features/assets/CreateAssetModal.tsx
+++ b/frontend/src/features/assets/CreateAssetModal.tsx
@@ -127,20 +127,31 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
           >
-            <div className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+            {/* Announced as a dialog and named by its own heading. Without these
+                a screen reader walks straight past the form into the inventory
+                behind it, which is still in the tree. */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-asset-title"
+              className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+            >
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div className="flex items-center gap-3">
                   <div className="rounded-2xl bg-primary/10 p-2 text-primary">
                     <Server size={20} />
                   </div>
-                  <h2 className="text-xl font-semibold text-ink">{t('assets.createAsset')}</h2>
+                  <h2 id="create-asset-title" className="text-xl font-semibold text-ink">
+                    {t('assets.createAsset')}
+                  </h2>
                 </div>
                 <button
                   type="button"
                   onClick={handleClose}
+                  aria-label={t('common.close')}
                   className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                 >
-                  <X size={20} />
+                  <X size={20} aria-hidden="true" />
                 </button>
               </div>
 
@@ -161,10 +172,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
 
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="create-asset-type"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.type')}
                       </label>
                       <select
+                        id="create-asset-type"
                         {...register('type')}
                         disabled={isSubmitting}
                         className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -177,10 +192,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
                       </select>
                     </div>
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="create-asset-criticality"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.criticality')}
                       </label>
                       <select
+                        id="create-asset-criticality"
                         {...register('criticality')}
                         disabled={isSubmitting}
                         className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -199,10 +218,14 @@ export const CreateAssetModal = ({ isOpen, onClose }: CreateAssetModalProps) => 
                   </Field>
 
                   <div className="space-y-1.5">
-                    <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                    <label
+                      htmlFor="create-asset-category"
+                      className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                    >
                       {t('assets.form.category', 'Catégorie typée')}
                     </label>
                     <select
+                      id="create-asset-category"
                       value={category}
                       disabled={isSubmitting}
                       onChange={(e) => {

--- a/frontend/src/features/assets/EditAssetModal.tsx
+++ b/frontend/src/features/assets/EditAssetModal.tsx
@@ -144,13 +144,22 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
               transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
               className="fixed inset-0 z-50 flex items-center justify-center p-4"
             >
-              <div className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+              {/* Announced as a dialog and named by its own heading — the
+                  inventory table behind it stays in the tree otherwise. */}
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="edit-asset-title"
+                className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+              >
                 <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                   <div className="flex items-center gap-3">
                     <div className="rounded-2xl bg-primary/10 p-2 text-primary">
                       <Server size={20} />
                     </div>
-                    <h2 className="text-xl font-semibold text-ink">{t('assets.editAsset')}</h2>
+                    <h2 id="edit-asset-title" className="text-xl font-semibold text-ink">
+                      {t('assets.editAsset')}
+                    </h2>
                   </div>
                   <div className="flex items-center gap-1">
                     {onShowHistory && asset?.id && (
@@ -167,9 +176,10 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                     <button
                       type="button"
                       onClick={handleClose}
+                      aria-label={t('common.close')}
                       className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                     >
-                      <X size={20} />
+                      <X size={20} aria-hidden="true" />
                     </button>
                   </div>
                 </div>
@@ -186,10 +196,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
 
                     <div className="grid grid-cols-2 gap-4">
                       <div className="space-y-1.5">
-                        <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                        <label
+                          htmlFor="edit-asset-type"
+                          className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                        >
                           {t('assets.form.type')}
                         </label>
                         <select
+                          id="edit-asset-type"
                           {...register('type')}
                           disabled={isSubmitting}
                           className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -202,10 +216,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                         </select>
                       </div>
                       <div className="space-y-1.5">
-                        <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                        <label
+                          htmlFor="edit-asset-criticality"
+                          className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                        >
                           {t('assets.form.criticality')}
                         </label>
                         <select
+                          id="edit-asset-criticality"
                           {...register('criticality')}
                           disabled={isSubmitting}
                           className="w-full h-10 rounded-lg border border-border bg-elevated px-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all"
@@ -224,10 +242,14 @@ export const EditAssetModal = ({ asset, onClose, onShowHistory }: EditAssetModal
                     </Field>
 
                     <div className="space-y-1.5">
-                      <label className="text-xs font-medium text-ink-muted uppercase tracking-wider">
+                      <label
+                        htmlFor="edit-asset-category"
+                        className="text-xs font-medium text-ink-muted uppercase tracking-wider"
+                      >
                         {t('assets.form.category', 'Catégorie typée')}
                       </label>
                       <select
+                        id="edit-asset-category"
                         value={category}
                         disabled={isSubmitting}
                         onChange={(e) => {

--- a/frontend/src/features/attackSurface/TopologyView.tsx
+++ b/frontend/src/features/attackSurface/TopologyView.tsx
@@ -111,6 +111,25 @@ export default function TopologyView() {
   const nodes = useMemo(() => data?.nodes ?? [], [data]);
   const edges = useMemo(() => data?.edges ?? [], [data]);
 
+  // How many assets survive the zone and criticality filters.
+  //
+  // The header used to report data.nodes.length unconditionally, so unticking
+  // CRITICAL removed nodes from the canvas while the count kept claiming the
+  // whole estate. A count that ignores the filter beside a graph that obeys it
+  // is a screen telling the user two different things at once.
+  //
+  // Mirrors the predicate the layout effect uses; if one changes the other must.
+  const visibleCount = useMemo(
+    () =>
+      nodes.filter(
+        (n) =>
+          (!zoneFilter || n.zone === zoneFilter) &&
+          critFilter.has((n.criticality ?? 'LOW') as string),
+      ).length,
+    [nodes, zoneFilter, critFilter],
+  );
+  const filtered = visibleCount !== nodes.length;
+
   // The highlighted chain: origin + everything impacted + everything reachable.
   const highlighted = useMemo(() => {
     if (!chain) return null;
@@ -403,7 +422,13 @@ export default function TopologyView() {
     <PageFrame wide>
       <PageHeader
         title="Topologie de la surface d'attaque"
-        count={data ? `${data.nodes?.length ?? 0} actifs · ${data.edges?.length ?? 0} liens` : null}
+        count={
+          data
+            ? filtered
+              ? `${visibleCount} / ${nodes.length} actifs`
+              : `${nodes.length} actifs · ${edges.length} liens`
+            : null
+        }
         actions={
           <>
             <Btn label="SVG" icon={Download} onClick={() => void doExport('svg')} />
@@ -482,6 +507,7 @@ export default function TopologyView() {
         {(['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const).map((c) => (
           <Chip
             key={c}
+            testId={`universe-filter-${c.toLowerCase()}`}
             label={CRIT_LABEL[c]}
             color={critColor[c.toLowerCase() as Criticality]}
             active={critFilter.has(c)}

--- a/frontend/src/features/automation/AutomationPage.tsx
+++ b/frontend/src/features/automation/AutomationPage.tsx
@@ -506,6 +506,9 @@ function TemplateGallery({ onClose }: { onClose: () => void }) {
       style={{ background: 'rgba(0,0,0,.35)' }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="automation-templates-title"
         className="w-full max-w-[720px] max-h-[85vh] flex flex-col rounded-[14px] or-scalein"
         style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
       >
@@ -514,8 +517,11 @@ function TemplateGallery({ onClose }: { onClose: () => void }) {
           style={{ borderBottom: '1px solid var(--border)' }}
         >
           <div>
-            <h2 className="text-[15px] font-bold text-ink inline-flex items-center gap-2">
-              <Sparkles size={16} style={{ color: 'var(--accent-500)' }} />
+            <h2
+              id="automation-templates-title"
+              className="text-[15px] font-bold text-ink inline-flex items-center gap-2"
+            >
+              <Sparkles size={16} style={{ color: 'var(--accent-500)' }} aria-hidden="true" />
               {tr('Modèles prêts à l’emploi', 'Ready-made templates')}
             </h2>
             <p className="text-[12px] mt-0.5" style={{ color: 'var(--fg-secondary)' }}>

--- a/frontend/src/features/automation/DryRunPanel.tsx
+++ b/frontend/src/features/automation/DryRunPanel.tsx
@@ -235,6 +235,9 @@ export function DryRunPanel({ rule, onClose }: { rule: AutomationRule; onClose: 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,.35)' }}>
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dry-run-title"
         className="w-full max-w-[760px] h-full overflow-y-auto or-slidein"
         style={{ background: 'var(--bg-elevated)', borderLeft: '1px solid var(--border-strong)' }}
       >
@@ -245,7 +248,11 @@ export function DryRunPanel({ rule, onClose }: { rule: AutomationRule; onClose: 
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <FlaskConical size={16} style={{ color: 'var(--accent-500)' }} />
-              <h2 className="text-[15px] font-bold truncate" style={{ color: 'var(--fg-primary)' }}>
+              <h2
+                id="dry-run-title"
+                className="text-[15px] font-bold truncate"
+                style={{ color: 'var(--fg-primary)' }}
+              >
                 {tr('Tester', 'Test')} — {rule.name}
               </h2>
             </div>

--- a/frontend/src/features/automation/RuleEditorModal.tsx
+++ b/frontend/src/features/automation/RuleEditorModal.tsx
@@ -186,6 +186,9 @@ export function RuleEditorModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rule-editor-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[640px] rounded-[16px] flex flex-col or-scalein"
         style={{
@@ -199,14 +202,19 @@ export function RuleEditorModal({
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="flex items-center gap-2 text-[15px] font-bold text-ink">
-            <Workflow size={17} />{' '}
+          {/* A dialog's name should come from a heading, not a styled div. */}
+          <h2
+            id="rule-editor-title"
+            className="flex items-center gap-2 text-[15px] font-bold text-ink"
+          >
+            <Workflow size={17} aria-hidden="true" />{' '}
             {rule
               ? tr('Modifier la règle', 'Edit rule')
               : tr('Nouvelle automatisation', 'New automation')}
-          </div>
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >

--- a/frontend/src/features/evidence/CreateEvidenceModal.tsx
+++ b/frontend/src/features/evidence/CreateEvidenceModal.tsx
@@ -72,13 +72,24 @@ export function CreateEvidenceModal({
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
       {/* max-h + internal scroll: the submit button must never be pushed off
           screen on a short viewport, which is a bug this project has already had. */}
-      <div className="relative w-full max-w-[560px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein">
+      {/* Announced as a dialog and named by its heading; the evidence library
+          behind it stays in the accessibility tree otherwise. */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-evidence-title"
+        className="relative w-full max-w-[560px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein"
+      >
         <header className="px-5 py-4 border-b border-line flex items-center justify-between shrink-0">
-          <h2 className="text-ink font-semibold text-[15px]">
+          <h2 id="create-evidence-title" className="text-ink font-semibold text-[15px]">
             {tr('Enregistrer une preuve', 'Record evidence')}
           </h2>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
-            <X size={16} />
+          <button
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
+          >
+            <X size={16} aria-hidden="true" />
           </button>
         </header>
 

--- a/frontend/src/features/evidence/EvidenceDrawer.tsx
+++ b/frontend/src/features/evidence/EvidenceDrawer.tsx
@@ -45,10 +45,15 @@ export function EvidenceDrawer({
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <aside className="relative w-full max-w-[560px] h-full bg-surface border-l border-line overflow-y-auto or-slidein">
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="evidence-drawer-title"
+        className="relative w-full max-w-[560px] h-full bg-surface border-l border-line overflow-y-auto or-slidein"
+      >
         <header className="sticky top-0 bg-surface border-b border-line px-5 py-4 flex items-start gap-3">
           <div className="min-w-0 flex-1">
-            <h2 className="text-ink font-semibold text-[15px] truncate">
+            <h2 id="evidence-drawer-title" className="text-ink font-semibold text-[15px] truncate">
               {isLoading ? tr('Chargement…', 'Loading…') : evidence?.title}
             </h2>
             {evidence && meta ? (
@@ -71,7 +76,11 @@ export function EvidenceDrawer({
               </div>
             ) : null}
           </div>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
+          <button
+            aria-label={tr('Fermer', 'Close')}
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+          >
             <X size={16} />
           </button>
         </header>

--- a/frontend/src/features/financial/FinancialDashboard.tsx
+++ b/frontend/src/features/financial/FinancialDashboard.tsx
@@ -455,6 +455,9 @@ function MethodologyModal({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="methodology-title"
         className="or-scalein w-full max-w-lg max-h-[88vh] flex flex-col rounded-[14px] overflow-hidden"
         style={{ background: 'var(--bg)', border: '1px solid var(--border)' }}
         onClick={(e) => e.stopPropagation()}
@@ -464,12 +467,16 @@ function MethodologyModal({
           style={{ borderColor: 'var(--border)' }}
         >
           <div className="flex items-center gap-2">
-            <BookOpen size={16} style={{ color: 'var(--accent-500)' }} />
-            <span className="text-[14px] font-semibold text-ink">
+            <BookOpen size={16} style={{ color: 'var(--accent-500)' }} aria-hidden="true" />
+            <h2 id="methodology-title" className="text-[14px] font-semibold text-ink">
               {tr('Méthodologie', 'Methodology')}
-            </span>
+            </h2>
           </div>
-          <button onClick={onClose} className="text-ink-muted hover:text-ink">
+          <button
+            onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
+            className="text-ink-muted hover:text-ink"
+          >
             <X size={18} />
           </button>
         </div>

--- a/frontend/src/features/governance/GovernancePage.tsx
+++ b/frontend/src/features/governance/GovernancePage.tsx
@@ -432,6 +432,9 @@ function AuditDetailDrawer({ e, onClose }: { e: AuditEvent; onClose: () => void 
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="governance-event-title"
         onClick={(ev) => ev.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -453,9 +456,12 @@ function AuditDetailDrawer({ e, onClose }: { e: AuditEvent; onClose: () => void 
             >
               {e.action}
             </span>
-            <div className="disp text-[16px] font-bold text-ink leading-snug mt-2">
+            <h2
+              id="governance-event-title"
+              className="disp text-[16px] font-bold text-ink leading-snug mt-2"
+            >
               {e.summary || `${e.action} ${e.entity_type}`}
-            </div>
+            </h2>
             <div className="text-[12px] mt-1" style={{ color: 'var(--fg-secondary)' }}>
               {e.entity_type} ·{' '}
               {e.actor_email || (e.actor_id ? e.actor_id.slice(0, 8) : tr('système', 'system'))} ·{' '}
@@ -1496,6 +1502,9 @@ function ModalShell({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="governance-modal-title"
         className="or-scalein w-full max-w-lg flex flex-col rounded-[14px]"
         style={{
           maxHeight: '90vh',
@@ -1508,8 +1517,10 @@ function ModalShell({
           className="flex items-center justify-between px-5 py-3.5"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <span className="text-[15px] font-semibold">{title}</span>
-          <button onClick={onClose}>
+          <h2 id="governance-modal-title" className="text-[15px] font-semibold">
+            {title}
+          </h2>
+          <button onClick={onClose} aria-label={tr('Fermer', 'Close')}>
             <X size={18} />
           </button>
         </div>

--- a/frontend/src/features/incidents/DeclareIncidentModal.tsx
+++ b/frontend/src/features/incidents/DeclareIncidentModal.tsx
@@ -110,7 +110,12 @@ export function DeclareIncidentModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ background: 'rgba(0,0,0,.4)' }}
     >
+      {/* Announced as a dialog and named by its heading; the incident list
+          behind it stays in the accessibility tree otherwise. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="declare-incident-title"
         className="w-full max-w-[640px] max-h-[90vh] flex flex-col rounded-[14px] or-scalein"
         style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
       >
@@ -119,6 +124,7 @@ export function DeclareIncidentModal({
           style={{ borderBottom: '1px solid var(--border)' }}
         >
           <h2
+            id="declare-incident-title"
             className="text-[15px] font-bold inline-flex items-center gap-2"
             style={{ color: 'var(--fg-primary)' }}
           >

--- a/frontend/src/features/incidents/DeclareIncidentModal.tsx
+++ b/frontend/src/features/incidents/DeclareIncidentModal.tsx
@@ -317,6 +317,10 @@ export function DeclareIncidentModal({
                     <select
                       className={field}
                       style={fieldStyle}
+                      aria-label={tr(
+                        `Personne — partie prenante ${i + 1}`,
+                        `Person — stakeholder ${i + 1}`,
+                      )}
                       value={sh.user_id ?? ''}
                       onChange={(e) =>
                         setStakeholders((list) =>
@@ -336,6 +340,10 @@ export function DeclareIncidentModal({
                     <select
                       className={field}
                       style={fieldStyle}
+                      aria-label={tr(
+                        `Rôle — partie prenante ${i + 1}`,
+                        `Role — stakeholder ${i + 1}`,
+                      )}
                       value={sh.role ?? ''}
                       onChange={(e) =>
                         setStakeholders((list) =>

--- a/frontend/src/features/incidents/IncidentDrawer.tsx
+++ b/frontend/src/features/incidents/IncidentDrawer.tsx
@@ -117,7 +117,12 @@ export function IncidentDrawer({
         }}
         onClick={onClose}
       >
+        {/* Announced as a dialog and named by the incident it shows; the list
+            behind it stays in the accessibility tree otherwise. */}
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="incident-drawer-title"
           onClick={(e) => e.stopPropagation()}
           className="h-full flex flex-col"
           style={{
@@ -159,9 +164,12 @@ export function IncidentDrawer({
                     {tr(statusMeta(status).fr, statusMeta(status).en)}
                   </span>
                 </div>
-                <div className="disp text-[16px] font-bold text-ink leading-snug">
+                <h2
+                  id="incident-drawer-title"
+                  className="disp text-[16px] font-bold text-ink leading-snug"
+                >
                   {incident.title}
-                </div>
+                </h2>
                 <div className="text-[11.5px] text-ink-muted mt-1">
                   {tr('Signalé par', 'Reported by')} {incident.reported_by || '—'} ·{' '}
                   {relTime(incident.created_at, lang)}
@@ -171,7 +179,7 @@ export function IncidentDrawer({
                 onClick={onClose}
                 className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft hover:text-ink transition-colors"
                 style={{ background: 'var(--bg-hover)' }}
-                aria-label="Close"
+                aria-label={tr('Fermer', 'Close')}
               >
                 <X size={18} />
               </button>

--- a/frontend/src/features/incidents/IncidentsScreen.tsx
+++ b/frontend/src/features/incidents/IncidentsScreen.tsx
@@ -50,8 +50,25 @@ export function IncidentsScreen() {
   const navigate = useNavigate();
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
 
-  const hasRole = useAuthStore((s) => s.hasRole);
-  const canWrite = hasRole('admin') || hasRole('analyst');
+  // Gate on the permission the SERVER actually enforces, not on a role name.
+  //
+  // This was hasRole('admin') || hasRole('analyst'). The backend abandoned that
+  // exact gate — cmd/server/main.go says so in as many words: "analyst" is not a
+  // runtime org role (they are root/admin/user), so the check was effectively
+  // admin-only and could never be granted to a business role. It moved to the
+  // incidents:* permission family; the client never followed.
+  //
+  // The consequence was not cosmetic. A tenant's founding user carries
+  // permissions ["*"] and an EMPTY role string, so hasRole('admin') was false and
+  // the owner of the workspace could not declare an incident on their own
+  // incident screen — while POST /incidents would have accepted it.
+  const hasPermission = useAuthStore((s) => s.hasPermission);
+  // Three permissions, because the server enforces three. One boolean for all of
+  // them would hide Delete from someone who may resolve, or offer Delete to
+  // someone the API will refuse.
+  const canCreate = hasPermission('incidents:create');
+  const canUpdate = hasPermission('incidents:update');
+  const canDelete = hasPermission('incidents:delete');
 
   const [showCreate, setShowCreate] = useState(false);
   const [selected, setSelected] = useState<Incident | null>(null);
@@ -246,7 +263,7 @@ export function IncidentsScreen() {
             />
             <select
               value={inc.status}
-              disabled={!canWrite}
+              disabled={!canUpdate}
               aria-label={tr('Statut de l’incident', 'Incident status')}
               onChange={(e) => setStatus(inc, e.target.value as IncidentStatus)}
               className="appearance-none text-[12px] font-semibold rounded-full pl-6 pr-6 py-1.5 outline-none disabled:opacity-70"
@@ -254,7 +271,7 @@ export function IncidentsScreen() {
                 color: statusMeta(inc.status).color,
                 background: `color-mix(in srgb,${statusMeta(inc.status).color} 12%,transparent)`,
                 border: `1px solid color-mix(in srgb,${statusMeta(inc.status).color} 30%,transparent)`,
-                cursor: canWrite ? 'pointer' : 'not-allowed',
+                cursor: canUpdate ? 'pointer' : 'not-allowed',
               }}
             >
               {STATUSES.map((st) => (
@@ -285,7 +302,7 @@ export function IncidentsScreen() {
         ),
       },
     ],
-    [lang, canWrite],
+    [lang, canUpdate],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* -------------------------------------------------------------- actions */
@@ -309,11 +326,11 @@ export function IncidentsScreen() {
         icon: Trash2,
         danger: true,
         separatorBefore: true,
-        hidden: () => !canWrite,
+        hidden: () => !canDelete,
         onSelect: (inc) => remove(inc),
       },
     ],
-    [lang, canWrite, navigate],
+    [lang, canDelete, navigate],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   const bulkActions: BulkAction<Incident>[] = useMemo(
@@ -322,7 +339,7 @@ export function IncidentsScreen() {
         key: 'resolve',
         label: tr('Marquer résolus', 'Mark resolved'),
         icon: CheckCircle2,
-        hidden: !canWrite,
+        hidden: !canUpdate,
         selectionOnly: true,
         run: async ({ rows }) => {
           await Promise.all(
@@ -340,14 +357,14 @@ export function IncidentsScreen() {
         label: tr('Supprimer', 'Delete'),
         icon: Trash2,
         danger: true,
-        hidden: !canWrite,
+        hidden: !canDelete,
         selectionOnly: true,
         run: async ({ rows }) => {
           rows.forEach((inc) => remove(inc));
         },
       },
     ],
-    [lang, canWrite, updateIncident],
+    [lang, canUpdate, canDelete, updateIncident],
   ); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
@@ -363,7 +380,7 @@ export function IncidentsScreen() {
               onClick={exportCsv}
             />
             <Btn label={tr('War Room', 'War Room')} icon={Activity} onClick={openWarRoom} />
-            {canWrite && (
+            {canCreate && (
               <Btn
                 label={tr('Déclarer un incident', 'Declare an incident')}
                 icon={Siren}
@@ -426,7 +443,7 @@ export function IncidentsScreen() {
           'Titre, description ou déclarant…',
           'Title, description or reporter…',
         )}
-        selectable={canWrite}
+        selectable={canUpdate || canDelete}
         rowActions={rowActions}
         bulkActions={bulkActions}
         onRowClick={(inc) => setSelected(inc)}
@@ -441,7 +458,7 @@ export function IncidentsScreen() {
               'Nothing to report. An incident can be declared here, or opened automatically by a rule, a scan or a threat feed — each one then carries a banner saying which.',
             )}
             primaryAction={
-              canWrite ? (
+              canCreate ? (
                 <Btn
                   label={tr('Déclarer un incident', 'Declare an incident')}
                   icon={Siren}
@@ -458,7 +475,11 @@ export function IncidentsScreen() {
 
       {showCreate && <DeclareIncidentModal onClose={() => setShowCreate(false)} />}
       {selected && (
-        <IncidentDrawer incident={selected} canWrite={canWrite} onClose={() => setSelected(null)} />
+        <IncidentDrawer
+          incident={selected}
+          canWrite={canUpdate}
+          onClose={() => setSelected(null)}
+        />
       )}
     </PageFrame>
   );

--- a/frontend/src/features/incidents/PostMortemPanel.tsx
+++ b/frontend/src/features/incidents/PostMortemPanel.tsx
@@ -153,7 +153,11 @@ export function PostMortemPanel({
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" style={{ background: 'rgba(0,0,0,.35)' }}>
+      {/* Announced as a dialog and named by its heading. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="post-mortem-title"
         className="w-full max-w-[760px] h-full overflow-y-auto or-slidein"
         style={{ background: 'var(--bg-elevated)', borderLeft: '1px solid var(--border-strong)' }}
       >
@@ -163,6 +167,7 @@ export function PostMortemPanel({
         >
           <div>
             <h2
+              id="post-mortem-title"
               className="text-[15px] font-bold inline-flex items-center gap-2"
               style={{ color: 'var(--fg-primary)' }}
             >

--- a/frontend/src/features/incidents/WarRoom.tsx
+++ b/frontend/src/features/incidents/WarRoom.tsx
@@ -457,7 +457,13 @@ export function WarRoom() {
           }}
           onClick={() => setConfirmClose(false)}
         >
+          {/* alertdialog, not dialog: a question with exactly two answers is
+              announced whole on open rather than waiting to be explored. */}
           <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="warroom-close-title"
+            aria-describedby="warroom-close-body"
             onClick={(e) => e.stopPropagation()}
             className="glass-strong rounded-[18px] shadow-card-lg p-[26px]"
             style={{ width: 'min(90vw,420px)', animation: 'or-scalein .18s ease' }}
@@ -471,10 +477,13 @@ export function WarRoom() {
             >
               <AlertTriangle size={24} />
             </div>
-            <div className="disp text-[18px] font-bold text-ink mb-2">
+            <h2 id="warroom-close-title" className="disp text-[18px] font-bold text-ink mb-2">
               {tr('Clore cet incident ?', 'Close this incident?')}
-            </div>
-            <div className="text-[13.5px] text-ink-soft leading-relaxed mb-[22px]">
+            </h2>
+            <div
+              id="warroom-close-body"
+              className="text-[13.5px] text-ink-soft leading-relaxed mb-[22px]"
+            >
               {tr(
                 'Le statut passera à « Clos » et l’incident sortira des incidents actifs.',
                 'The status will be set to "Closed" and it will leave the active incidents.',

--- a/frontend/src/features/infrastructure/AgentDeployModal.tsx
+++ b/frontend/src/features/infrastructure/AgentDeployModal.tsx
@@ -72,6 +72,9 @@ export function AgentDeployModal({ config, onClose }: { config: ScanConfig; onCl
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="agent-deploy-title"
         className="relative w-full max-w-[520px] max-h-[90vh] flex flex-col rounded-2xl glass-strong overflow-hidden"
         style={{ border: '1px solid var(--border-strong)', animation: 'or-scalein .22s ease' }}
       >
@@ -79,13 +82,13 @@ export function AgentDeployModal({ config, onClose }: { config: ScanConfig; onCl
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="text-[15px] font-semibold text-ink">
+          <h2 id="agent-deploy-title" className="text-[15px] font-semibold text-ink">
             {tr('Déployer un Agent', 'Deploy an Agent')}
-          </div>
+          </h2>
           <button
             onClick={onClose}
             className="w-8 h-8 rounded-lg flex items-center justify-center text-ink-soft hover:bg-hover"
-            aria-label="Close"
+            aria-label={tr('Fermer', 'Close')}
           >
             <X size={18} />
           </button>

--- a/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
+++ b/frontend/src/features/infrastructure/ScanConfigDrawer.tsx
@@ -100,6 +100,9 @@ export function ScanConfigDrawer({
         onClick={onClose}
       />
       <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="scan-config-title"
         className="relative h-full w-full max-w-[460px] flex flex-col glass-strong"
         style={{ borderLeft: '1px solid var(--border-strong)', animation: 'or-slidein .28s ease' }}
       >
@@ -119,9 +122,9 @@ export function ScanConfigDrawer({
               <meta.icon size={18} strokeWidth={1.8} />
             </div>
             <div>
-              <div className="text-[15px] font-semibold text-ink">
+              <h2 id="scan-config-title" className="text-[15px] font-semibold text-ink">
                 {tr('Nouvelle configuration', 'New scan config')}
-              </div>
+              </h2>
               <div className="text-[12px] text-ink-soft">{meta.short}</div>
             </div>
           </div>

--- a/frontend/src/features/mitigations/CreateMitigationModal.tsx
+++ b/frontend/src/features/mitigations/CreateMitigationModal.tsx
@@ -125,25 +125,35 @@ export const CreateMitigationModal = ({
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-90 flex items-center justify-center p-4"
           >
-            <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
+            {/* Announced as a dialog and named by its heading; the board behind
+                it stays in the accessibility tree otherwise. */}
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="create-mitigation-title"
+              className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg"
+            >
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div>
-                  <h2 className="text-2xl font-semibold text-ink">Créer un plan d'atténuation</h2>
-                  <p className="text-sm text-ink-muted">Créez un plan pour atténuer un risque</p>
+                  <h2 id="create-mitigation-title" className="text-2xl font-semibold text-ink">
+                    {t('mitigations.createTitle')}
+                  </h2>
+                  <p className="text-sm text-ink-muted">{t('mitigations.createSubtitle')}</p>
                 </div>
                 <button
                   type="button"
                   onClick={handleClose}
+                  aria-label={t('common.close')}
                   className="rounded-full p-2 text-ink-soft hover:bg-hover hover:text-ink transition-colors"
                 >
-                  <X size={20} />
+                  <X size={20} aria-hidden="true" />
                 </button>
               </div>
 
               <form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
                 <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6 scrollbar-thin">
                   <Field
-                    label="Titre"
+                    label={t('mitigations.fieldTitle')}
                     message={errors.title?.message}
                     status={errors.title?.message ? 'invalid' : 'default'}
                   >
@@ -151,10 +161,14 @@ export const CreateMitigationModal = ({
                   </Field>
 
                   <div className="space-y-1.5">
-                    <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                      Description
+                    <label
+                      htmlFor="create-mitigation-description"
+                      className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                    >
+                      {t('mitigations.fieldDescription')}
                     </label>
                     <textarea
+                      id="create-mitigation-description"
                       {...register('description')}
                       rows={4}
                       className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink outline-none focus:ring-2 focus:ring-primary/40"
@@ -167,23 +181,36 @@ export const CreateMitigationModal = ({
 
                   <div className="grid gap-4 sm:grid-cols-2">
                     <div>
-                      <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                        Deadline
+                      <label
+                        htmlFor="create-mitigation-due-date"
+                        className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
+                        {t('mitigations.fieldDeadline')}
                       </label>
-                      <Input type="date" {...register('due_date')} disabled={isSubmitting} />
+                      <Input
+                        id="create-mitigation-due-date"
+                        type="date"
+                        {...register('due_date')}
+                        disabled={isSubmitting}
+                      />
                     </div>
                     <div>
-                      <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                        Priorité
+                      <label
+                        htmlFor="create-mitigation-priority"
+                        className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
+                        {t('mitigations.fieldPriority')}
                       </label>
                       <select
+                        id="create-mitigation-priority"
                         {...register('priority')}
                         className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink"
                       >
-                        <option value="critical">Critique</option>
-                        <option value="high">Élevé</option>
-                        <option value="medium">Moyen</option>
-                        <option value="low">Bas</option>
+                        {(['critical', 'high', 'medium', 'low'] as const).map((level) => (
+                          <option key={level} value={level}>
+                            {t(`mitigations.priority.${level}`)}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   </div>
@@ -191,7 +218,7 @@ export const CreateMitigationModal = ({
 
                 <div className="flex shrink-0 justify-end gap-3 border-t border-border bg-elevated px-6 py-4">
                   <Button type="button" variant="ghost" onClick={handleClose}>
-                    Annuler
+                    {t('common.cancel')}
                   </Button>
                   <Button
                     type="submit"
@@ -199,8 +226,8 @@ export const CreateMitigationModal = ({
                     loading={isSubmitting}
                     className="gap-2"
                   >
-                    <Zap size={16} />
-                    Créer
+                    <Zap size={16} aria-hidden="true" />
+                    {t('common.create')}
                   </Button>
                 </div>
               </form>

--- a/frontend/src/features/onboarding/RecognitionPage.tsx
+++ b/frontend/src/features/onboarding/RecognitionPage.tsx
@@ -17,12 +17,30 @@ import { AlertTriangle } from 'lucide-react';
 
 import { useI18n } from '../../hooks/useI18n';
 import type { RecognitionCounts } from '../../services/activationService';
-import { useCountUp, usePrefersReducedMotion, useRecognition } from './useActivation';
+import {
+  useCompleteOnboarding,
+  useCountUp,
+  usePrefersReducedMotion,
+  useRecognition,
+} from './useActivation';
 
 export function RecognitionPage() {
   const { t } = useI18n();
   const navigate = useNavigate();
   const { data, isLoading, isError } = useRecognition();
+
+  // Acknowledging the recognition IS this user's completion of onboarding.
+  //
+  // Without it they are trapped. `OnboardingGuard` sends anyone whose wizard is
+  // unfinished here from EVERY app route, and criterion 9 keeps the tunnel — the
+  // only other thing that completes it — off their screen. So the button led
+  // back to a page that led back to the button, for the whole population #234
+  // backfilled: every existing customer.
+  const complete = useCompleteOnboarding();
+
+  const enter = () => {
+    complete.mutate(undefined, { onSuccess: () => navigate('/posture') });
+  };
 
   if (isLoading) return <RecognitionSkeleton label={t('onboarding.recognition.loading')} />;
 
@@ -56,12 +74,20 @@ export function RecognitionPage() {
 
       <button
         type="button"
-        onClick={() => navigate('/posture')}
-        className="mt-8 px-5 py-2.5 rounded-lg text-[13.5px] font-semibold"
+        onClick={enter}
+        disabled={complete.isPending}
+        data-testid="recognition-continue"
+        className="mt-8 px-5 py-2.5 rounded-lg text-[13.5px] font-semibold disabled:opacity-60"
         style={{ background: 'var(--accent-solid)', color: 'var(--fg-on-solid)' }}
       >
-        {t('onboarding.recognition.action')}
+        {complete.isPending ? t('onboarding.tunnel.saving') : t('onboarding.recognition.action')}
       </button>
+
+      {complete.isError && (
+        <p className="text-[12.5px] mt-3 m-0" role="alert" style={{ color: 'var(--high)' }}>
+          {t('onboarding.recognition.completeFailed')}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -16,11 +16,7 @@ import { toast } from 'sonner';
 import { useUIStore } from '../../../store/uiStore';
 import { useAuthStore } from '../../../hooks/useAuthStore';
 import { i18n, type OnboardingStepKey } from '../../../services/activationService';
-import {
-  useAdoptStarterRisks,
-  useOnboardingSuggestions,
-  useStarterRisks,
-} from '../useActivation';
+import { useAdoptStarterRisks, useOnboardingSuggestions, useStarterRisks } from '../useActivation';
 import { useCatalogs, useImportCatalogAsFramework } from '../../compliance/useCompliance';
 import type { StarterRiskOffer } from '../../../services/activationService';
 import { Field, StepShell } from './stepPrimitives';
@@ -92,9 +88,7 @@ export function OrganizationStep() {
     setCountry(str(stored, 'country'));
     setCurrency(str(stored, 'currency'));
     setTimezone(str(stored, 'timezone', Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'));
-    setFullName(
-      str(stored, 'full_name', str(legacyProfile, 'full_name', user?.full_name ?? '')),
-    );
+    setFullName(str(stored, 'full_name', str(legacyProfile, 'full_name', user?.full_name ?? '')));
     setJobTitle(str(stored, 'job_title', str(legacyProfile, 'job_title', user?.department ?? '')));
   }, [stored, legacyProfile, orgName, user]);
 
@@ -127,7 +121,10 @@ export function OrganizationStep() {
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
@@ -333,7 +330,10 @@ export function GoalStep() {
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       <div className="flex flex-col gap-2.5">
@@ -458,7 +458,10 @@ function StarterRiskPicker({
     <div className="mt-7">
       <div className="flex items-baseline justify-between mb-2.5">
         <h2 className="text-[14px] font-bold text-ink m-0">
-          {tr(`Sélectionnez ${pick} risques qui vous concernent`, `Pick ${pick} risks that apply to you`)}
+          {tr(
+            `Sélectionnez ${pick} risques qui vous concernent`,
+            `Pick ${pick} risks that apply to you`,
+          )}
         </h2>
         {/* aria-live so the count is announced as the user selects, which is how
             a screen-reader user knows when the primary button will unlock. */}
@@ -566,7 +569,18 @@ export function FrameworkStep() {
   const { data: suggestions, isLoading } = useOnboardingSuggestions();
   const { data: catalogs } = useCatalogs();
   const importCatalog = useImportCatalogAsFramework();
+  const stored = useStoredAnswers('framework');
   const [imported, setImported] = useState<string[]>([]);
+
+  // Restore what was already imported. Without this, stepping Back and Forward
+  // cleared every tick: the catalogues were still imported server-side, but the
+  // step claimed they were not and offered to import them a second time.
+  useEffect(() => {
+    const previous = stored.imported;
+    if (Array.isArray(previous)) {
+      setImported(previous.filter((k): k is string => typeof k === 'string'));
+    }
+  }, [stored]);
 
   // The suggested keys, resolved against the real catalog registry so we never
   // offer something that cannot actually be imported.
@@ -577,6 +591,24 @@ export function FrameworkStep() {
       .filter((c): c is NonNullable<typeof c> => !!c && c.available !== false)
       .slice(0, 5);
   }, [suggestions, catalogs]);
+
+  /**
+   * Importing a catalogue is the ONLY thing in the whole tunnel that creates a
+   * control, and the reveal this tunnel ends on cannot be computed without one:
+   * `coveragePercent` returns nil with zero applicable controls, `IsRevealable`
+   * is then false, and GET /posture answers 404. A user who walked five screens
+   * landed on "Impossible de calculer votre posture" — the exact activation
+   * cliff #438 exists to remove, rebuilt at the last step.
+   *
+   * The server already defines this step as satisfied by HasFramework — that is
+   * what OnboardingStepData.SkipsStep tests to auto-skip it. The client simply
+   * did not hold the same line. It does now.
+   *
+   * Except when the catalogue offers nothing: blocking there would trap the user
+   * in a step with no control to press, which is worse than the 404. Then the
+   * step stays passable and the reveal's own error state does its job.
+   */
+  const mustImport = offered.length > 0 && imported.length === 0;
 
   const runImport = (key: string) => {
     const catalog = offered.find((c) => c.key === key);
@@ -606,11 +638,15 @@ export function FrameworkStep() {
       onBack={() => go({ imported }, -1)}
       onNext={() => go({ imported }, 1)}
       nextLabel={tr('Continuer', 'Continue')}
+      nextDisabled={mustImport}
       busy={busy}
       error={error}
       onRetry={retry}
       errorLabel={tr("Impossible d'enregistrer cette étape.", 'This step could not be saved.')}
-      errorHint={tr('Vos réponses sont conservées — réessayez, rien n\u2019est perdu.', 'Your answers are kept — try again, nothing is lost.')}
+      errorHint={tr(
+        'Vos réponses sont conservées — réessayez, rien n\u2019est perdu.',
+        'Your answers are kept — try again, nothing is lost.',
+      )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
       {isLoading && (
@@ -674,6 +710,17 @@ export function FrameworkStep() {
           {tr(
             'Aucune suggestion pour ces réponses — vous pourrez choisir un référentiel depuis Conformité.',
             'No suggestion for these answers — you can pick a framework from Compliance.',
+          )}
+        </div>
+      )}
+
+      {/* A disabled button with no explanation is its own defect. This says what
+          to press and what it buys, rather than leaving the user to guess. */}
+      {mustImport && (
+        <div className="text-[12.5px] text-ink-soft mt-4" data-testid="framework-required">
+          {tr(
+            'Importez-en un pour continuer : vos contrôles sont ce qui rend votre posture calculable.',
+            'Import one to continue: your controls are what makes your posture computable.',
           )}
         </div>
       )}

--- a/frontend/src/features/onboarding/wizard/steps.tsx
+++ b/frontend/src/features/onboarding/wizard/steps.tsx
@@ -310,7 +310,7 @@ export function GoalStep() {
         // A 409 means this tenant already adopted — expected on a resumed
         // tunnel, and not a reason to block the user on a screen they finished.
         onError: (err: unknown) => {
-          if (isConflict(err)) go({ goal, starter_risks: picked }, 1);
+          if (isExpectedAdoptionRefusal(err)) go({ goal, starter_risks: picked }, 1);
         },
       });
       return;
@@ -375,7 +375,7 @@ export function GoalStep() {
         pick={pick}
         alreadyAdopted={alreadyAdopted}
         onToggle={toggle}
-        failed={adopt.isError && !isConflict(adopt.error)}
+        failed={adopt.isError && !isExpectedAdoptionRefusal(adopt.error)}
         lang={lang}
         tr={tr}
       />
@@ -536,10 +536,23 @@ function StarterRiskPicker({
   );
 }
 
-/** A 409 from the adoption endpoint means "already done", not "failed". */
-function isConflict(err: unknown): boolean {
+/**
+ * Answers the adoption endpoint gives that are NOT failures to retry.
+ *
+ *   409 — this tenant already adopted. The tunnel is resumable by design, so a
+ *         user WILL come back to this step; a second adoption is refused rather
+ *         than doubling their register.
+ *   403 — the caller may not create risks. POST /onboarding/starter-risks
+ *         carries `risks:create` like every other risk write, and an invited
+ *         member without it must still be able to finish the tunnel: it blocks
+ *         the whole app, so refusing to advance over a permission they will
+ *         never have would lock them out of the product.
+ *
+ * Both let the step advance. Neither writes anything.
+ */
+function isExpectedAdoptionRefusal(err: unknown): boolean {
   const status = (err as { response?: { status?: number } } | null)?.response?.status;
-  return status === 409;
+  return status === 409 || status === 403;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -193,7 +193,7 @@ export function ScoreStep() {
           </p>
         </div>
 
-        <Matrix pIndex={pIndex} iIndex={iIndex} tr={tr} />
+        <Matrix pIndex={pIndex} iIndex={iIndex} score={score} tr={tr} />
       </div>
     </StepShell>
   );
@@ -252,10 +252,13 @@ function Slider({
 function Matrix({
   pIndex,
   iIndex,
+  score,
   tr,
 }: {
   pIndex: number;
   iIndex: number;
+  /** The live P × I the sliders produce — what the readout shows. */
+  score: number;
   tr: (fr: string, en: string) => string;
 }) {
   const reduced = usePrefersReducedMotion();
@@ -294,7 +297,12 @@ function Matrix({
                       transition: reduced ? 'none' : 'background .18s ease, outline .18s ease',
                     }}
                   >
-                    {active ? (p * impact).toFixed(1) : ''}
+                    {/* The score the user actually set, not this cell's own
+                        band product. The cell marks WHERE they are; the number
+                        is WHAT they scored. Showing the band's arithmetic put
+                        two different figures on screen for one thing — the
+                        readout said 6.30 beside a cell saying 5.6. */}
+                    {active ? score.toFixed(1) : ''}
                   </td>
                 );
               })}

--- a/frontend/src/features/reports/ReportConfigurator.tsx
+++ b/frontend/src/features/reports/ReportConfigurator.tsx
@@ -98,12 +98,21 @@ export function ReportConfigurator({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative w-full max-w-[620px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="report-configurator-title"
+        className="relative w-full max-w-[620px] max-h-[90vh] flex flex-col rounded-xl bg-surface border border-line or-scalein"
+      >
         <header className="px-5 py-4 border-b border-line flex items-center justify-between shrink-0">
-          <h2 className="text-ink font-semibold text-[15px]">
+          <h2 id="report-configurator-title" className="text-ink font-semibold text-[15px]">
             {tr('Générer un rapport', 'Generate a report')}
           </h2>
-          <button className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted" onClick={onClose}>
+          <button
+            aria-label={tr('Fermer', 'Close')}
+            className="p-1.5 rounded-md hover:bg-surface-3 text-ink-muted"
+            onClick={onClose}
+          >
             <X size={16} />
           </button>
         </header>

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -405,9 +405,9 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                       </label>
                       <div className="rounded-3xl border border-border bg-app p-3 min-h-[120px] overflow-y-auto">
                         {assetsLoading ? (
-                          <p className="text-xs text-ink-muted">Chargement des assets...</p>
+                          <p className="text-xs text-ink-muted">{t('common.loading')}</p>
                         ) : assets.length === 0 ? (
-                          <p className="text-xs text-ink-muted">Aucun asset disponible</p>
+                          <p className="text-xs text-ink-muted">{t('assets.noAssets')}</p>
                         ) : (
                           <div className="grid gap-2">
                             {assets.map((asset) => (

--- a/frontend/src/features/risks/CreateRiskModal.tsx
+++ b/frontend/src/features/risks/CreateRiskModal.tsx
@@ -203,6 +203,14 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
             exit={{ opacity: 0, scale: 0.96, y: 40 }}
             transition={{ duration: 0.22, type: 'spring', stiffness: 240 }}
             className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            // The app's primary creation flow was a bare <div>: no dialog role,
+            // no aria-modal, no accessible name. Assistive technology never
+            // announced it as a dialog and never trapped into it, so a screen
+            // reader could walk straight out into the register behind it while
+            // the form sat open on top.
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-risk-title"
           >
             {/* Bounded height + scrollable body so a tall form never pushes the header
                 or the submit button off-screen (the modal used to be vertically centered
@@ -210,10 +218,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
             <div className="flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-border bg-elevated shadow-card-lg">
               <div className="flex shrink-0 items-center justify-between gap-4 border-b border-border px-6 py-5">
                 <div>
-                  <h2 className="text-2xl font-semibold text-ink">{t('risks.createRisk')}</h2>
-                  <p className="text-sm text-ink-muted">
-                    Créez un risque avec score en temps réel.
-                  </p>
+                  <h2 id="create-risk-title" className="text-2xl font-semibold text-ink">
+                    {t('risks.createRisk')}
+                  </h2>
+                  <p className="text-sm text-ink-muted">{t('risks.createRiskSubtitle')}</p>
                 </div>
                 <button
                   type="button"
@@ -272,7 +280,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
 
                   <div className="grid gap-4 sm:grid-cols-3">
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-probability"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.probability')}
                         <FieldHelp field="probability" lang={lang} sector={sector} />
                       </label>
@@ -281,7 +292,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={0}
                         max={1}
                         step={0.05}
+                        id="create-risk-probability"
                         {...register('probability', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={watchedProbability.toFixed(2)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -292,7 +308,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     </div>
 
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-impact"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.impact')}
                         <FieldHelp field="impact" lang={lang} sector={sector} />
                       </label>
@@ -301,7 +320,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={1}
                         max={10}
                         step={1}
+                        id="create-risk-impact"
                         {...register('impact', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={String(watchedImpact)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -312,7 +336,10 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     </div>
 
                     <div className="space-y-2">
-                      <label className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
+                      <label
+                        htmlFor="create-risk-asset-criticality"
+                        className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                      >
                         {t('risks.riskAssetCriticality')}
                         <FieldHelp field="asset_criticality" lang={lang} sector={sector} />
                       </label>
@@ -321,7 +348,12 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                         min={0.1}
                         max={3}
                         step={0.1}
+                        id="create-risk-asset-criticality"
                         {...register('assetCriticality', { valueAsNumber: true })}
+                        // The visible value sits in a separate row below, which a
+                        // screen reader reads as loose text rather than as this
+                        // slider's value.
+                        aria-valuetext={watchedCriticality.toFixed(1)}
                         className="w-full"
                       />
                       <div className="flex items-center justify-between text-xs text-ink-muted">
@@ -365,15 +397,19 @@ export const CreateRiskModal = ({ isOpen, onClose, onCreated }: CreateRiskModalP
                     fields. Conflating them is what put a user's label in the
                     "Référentiel" column wearing a framework badge. */}
                   <div className="space-y-2">
-                    <label className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted">
-                      Catégorie
+                    <label
+                      htmlFor="create-risk-category"
+                      className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-muted"
+                    >
+                      {t('risks.category')}
                     </label>
                     <select
+                      id="create-risk-category"
                       {...register('category_id')}
                       className="w-full rounded-3xl border border-border bg-elevated px-4 py-3 text-sm text-ink"
                       disabled={isSubmitting}
                     >
-                      <option value="">Non classé</option>
+                      <option value="">{t('risks.uncategorised')}</option>
                       {(categories ?? []).map((c) => (
                         <option key={c.id} value={c.id}>
                           {c.name}

--- a/frontend/src/features/risks/RiskRegisterPage.tsx
+++ b/frontend/src/features/risks/RiskRegisterPage.tsx
@@ -1363,6 +1363,9 @@ function RiskDrawer({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="risk-drawer-title"
         onClick={(e) => e.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -1377,10 +1380,13 @@ function RiskDrawer({
           <div className="flex items-start gap-3 mb-3">
             <div className="flex-1">
               <div className="mono text-[11px] text-ink-muted mb-[5px]">#{r.id.slice(0, 8)}</div>
-              <div className="disp text-[18px] font-bold text-ink leading-snug">{r.name}</div>
+              <h2 id="risk-drawer-title" className="disp text-[18px] font-bold text-ink leading-snug">
+                {r.name}
+              </h2>
             </div>
             <button
               onClick={onClose}
+              aria-label={tr('Fermer', 'Close')}
               className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft"
               style={{ background: 'var(--bg-hover)' }}
             >

--- a/frontend/src/features/risks/components/EditRiskModal.tsx
+++ b/frontend/src/features/risks/components/EditRiskModal.tsx
@@ -15,6 +15,7 @@ import { apiErrorMessage } from '../../../lib/apiError';
 import { useRiskStore } from '../../../hooks/useRiskStore';
 import { useAssetStore } from '../../../hooks/useAssetStore';
 import { Button, Field, Input } from '../../../shared/ds';
+import { useI18n } from '../../../hooks/useI18n';
 
 const riskSchema = z.object({
   title: z.string().min(5).max(100),
@@ -47,6 +48,7 @@ interface EditRiskModalProps {
 
 export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModalProps) => {
   const { updateRisk, isLoading } = useRiskStore();
+  const { t } = useI18n();
   const { assets, fetchAssets } = useAssetStore();
 
   const {
@@ -142,13 +144,13 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
           .filter(Boolean),
       };
       await updateRisk(risk.id, payload);
-      toast.success('Risque mis à jour');
+      toast.success(t('risks.updated'));
       onClose();
       onSuccess?.();
     } catch (err) {
       // Show what the server actually said. A generic message hides the one
       // sentence that names the offending field.
-      toast.error(apiErrorMessage(err) || 'Erreur lors de la mise à jour');
+      toast.error(apiErrorMessage(err) || t('risks.updateFailed'));
     }
   };
 
@@ -174,17 +176,25 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 50 }}
             transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="edit-risk-title"
             className="fixed inset-0 m-auto w-full max-w-lg h-fit max-h-[90vh] bg-surface border border-border rounded-xl shadow-2xl p-6 z-90 overflow-hidden"
           >
             <div className="flex justify-between items-center mb-6 border-b border-border-strong/5 pb-4">
-              <h2 className="text-xl font-bold text-fg-primary flex items-center gap-2">
-                <ShieldAlert className="text-primary" size={20} /> Modifier le Risque
+              <h2
+                id="edit-risk-title"
+                className="text-xl font-bold text-fg-primary flex items-center gap-2"
+              >
+                <ShieldAlert className="text-primary" size={20} aria-hidden="true" />{' '}
+                {t('risks.editRisk')}
               </h2>
               <button
                 onClick={handleClose}
+                aria-label={t('common.close')}
                 className="text-fg-muted hover:text-fg-primary transition-colors"
               >
-                <X size={24} />
+                <X size={24} aria-hidden="true" />
               </button>
             </div>
 
@@ -193,7 +203,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
               className="space-y-4 overflow-y-auto pr-2 max-h-[calc(90vh-140px)]"
             >
               <Field
-                label="Titre"
+                label={t('risks.fieldTitle')}
                 message={errors.title?.message}
                 status={errors.title?.message ? 'invalid' : 'default'}
               >
@@ -201,10 +211,14 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
               </Field>
 
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                  Description
+                <label
+                  htmlFor="edit-risk-description"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                >
+                  {t('risks.fieldDescription')}
                 </label>
                 <textarea
+                  id="edit-risk-description"
                   {...register('description')}
                   rows={4}
                   disabled={isLoading}
@@ -217,15 +231,22 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               <div className="grid grid-cols-2 gap-4 pt-2">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                    Impact (0 – 10)
+                  <label
+                    htmlFor="edit-risk-impact"
+                    className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                  >
+                    {t('risks.impact')} (0 – 10)
                   </label>
+                  {/* The visible value sits in a separate row below, which is read
+                      as loose text rather than as the slider's value. */}
                   <input
+                    id="edit-risk-impact"
                     type="range"
                     min={0}
                     max={10}
                     step={0.5}
                     disabled={isLoading}
+                    aria-valuetext={(watch('impact') ?? 0).toFixed(1)}
                     {...register('impact', { valueAsNumber: true })}
                     className="w-full"
                   />
@@ -242,15 +263,20 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                 </div>
 
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider">
-                    Probabilité (0 – 1)
+                  <label
+                    htmlFor="edit-risk-probability"
+                    className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
+                  >
+                    {t('risks.probability')} (0 – 1)
                   </label>
                   <input
+                    id="edit-risk-probability"
                     type="range"
                     min={0}
                     max={1}
                     step={0.05}
                     disabled={isLoading}
+                    aria-valuetext={(watch('probability') ?? 0).toFixed(2)}
                     {...register('probability', { valueAsNumber: true })}
                     className="w-full"
                   />
@@ -269,16 +295,21 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               {/* Assets selector */}
               <div className="space-y-2 pt-2">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between">
-                  Assets Affectés
+                {/* A <label> with no control names nothing. These are toggle
+                    buttons, so the set is a group named by its own text. */}
+                <div
+                  id="edit-risk-assets-label"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between"
+                >
+                  {t('risks.affectedAssets')}
                   <span className="text-[10px] bg-surface-2 px-2 py-0.5 rounded-full">
-                    {selectedAssetIds.length} sélectionné(s)
+                    {t('risks.selectedCount', { count: selectedAssetIds.length })}
                   </span>
-                </label>
+                </div>
                 <div className="flex flex-wrap gap-2 max-h-32 overflow-y-auto p-2 border border-border rounded-lg bg-surface-1/30">
                   {assets.length === 0 ? (
                     <div className="text-fg-muted text-xs w-full text-center py-2">
-                      Aucun asset.
+                      {t('risks.noAssets')}
                     </div>
                   ) : (
                     assets.map((a) => (
@@ -287,6 +318,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                         type="button"
                         onClick={() => toggleAsset(a.id)}
                         disabled={isLoading}
+                        aria-pressed={selectedAssetIds.includes(a.id)}
                         className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedAssetIds.includes(a.id) ? 'bg-accent-soft border-accent text-info-text' : 'bg-surface-2 border-border-default text-fg-secondary'} ${isLoading ? 'opacity-70' : ''}`}
                       >
                         {a.name}
@@ -296,7 +328,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                 </div>
               </div>
 
-              <Field label="Tags (séparés par des virgules)">
+              <Field label={t('risks.tags')}>
                 <Input
                   {...register('tags')}
                   placeholder="ex: critical, web-app, legacy"
@@ -306,12 +338,15 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               {/* Frameworks selector */}
               <div className="space-y-2 pt-2">
-                <label className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between">
-                  Frameworks
+                <div
+                  id="edit-risk-frameworks-label"
+                  className="text-xs font-medium text-fg-secondary uppercase tracking-wider flex justify-between"
+                >
+                  {t('risks.frameworks')}
                   <span className="text-[10px] bg-surface-2 px-2 py-0.5 rounded-full">
-                    {selectedFrameworks.length} sélectionné(s)
+                    {t('risks.selectedCount', { count: selectedFrameworks.length })}
                   </span>
-                </label>
+                </div>
                 <div className="flex flex-wrap gap-2 p-2">
                   {frameworksList.map((f) => (
                     <button
@@ -319,6 +354,7 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
                       type="button"
                       onClick={() => toggleFramework(f)}
                       disabled={isLoading}
+                      aria-pressed={selectedFrameworks.includes(f)}
                       className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-all ${selectedFrameworks.includes(f) ? 'bg-success/20 border-success text-success-text' : 'bg-surface-2 border-border-default text-fg-secondary hover:border-border-strong'}`}
                     >
                       {f}
@@ -329,10 +365,10 @@ export const EditRiskModal = ({ isOpen, onClose, risk, onSuccess }: EditRiskModa
 
               <div className="flex justify-end gap-3 mt-6 pt-4 border-t border-border-strong/5 sticky bottom-0 bg-surface">
                 <Button type="button" variant="ghost" onClick={handleClose} disabled={isLoading}>
-                  Annuler
+                  {t('common.cancel')}
                 </Button>
                 <Button variant="primary" type="submit" loading={isLoading || isSubmitting}>
-                  Enregistrer
+                  {t('common.save')}
                 </Button>
               </div>
             </form>

--- a/frontend/src/features/vulnerabilities/IngestModal.tsx
+++ b/frontend/src/features/vulnerabilities/IngestModal.tsx
@@ -80,7 +80,12 @@ export function IngestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
       style={{ background: 'rgba(0,0,0,.5)', backdropFilter: 'blur(3px)' }}
       onClick={onClose}
     >
+      {/* Announced as a dialog and named by its heading; the findings table
+          behind it stays in the accessibility tree otherwise. */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ingest-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[560px] rounded-[16px] flex flex-col"
         style={{
@@ -94,15 +99,17 @@ export function IngestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
           className="flex items-center justify-between px-5 py-4"
           style={{ borderBottom: '1px solid var(--border)' }}
         >
-          <div className="flex items-center gap-2 text-[15px] font-bold text-ink">
-            <Upload size={17} /> {tr('Importer des findings', 'Import findings')}
-          </div>
+          {/* A dialog's name should come from a heading, not a styled div. */}
+          <h2 id="ingest-title" className="flex items-center gap-2 text-[15px] font-bold text-ink">
+            <Upload size={17} aria-hidden="true" /> {tr('Importer des findings', 'Import findings')}
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >
-            <X size={18} />
+            <X size={18} aria-hidden="true" />
           </button>
         </div>
 

--- a/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
+++ b/frontend/src/features/vulnerabilities/IntegrationsPanel.tsx
@@ -83,6 +83,9 @@ export function IntegrationsPanel({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="integrations-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-[640px] rounded-[16px] flex flex-col"
         style={{
@@ -105,9 +108,12 @@ export function IntegrationsPanel({
               <ChevronLeft size={18} />
             </button>
           )}
-          <div className="text-[15px] font-bold text-ink flex-1">{title}</div>
+          <h2 id="integrations-title" className="text-[15px] font-bold text-ink flex-1">
+            {title}
+          </h2>
           <button
             onClick={onClose}
+            aria-label={tr('Fermer', 'Close')}
             className="w-8 h-8 rounded-[9px] flex items-center justify-center text-ink-soft"
             style={{ background: 'var(--bg-hover)' }}
           >

--- a/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
+++ b/frontend/src/features/vulnerabilities/VulnerabilitiesPage.tsx
@@ -669,6 +669,9 @@ function VulnDrawer({
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="vuln-drawer-title"
         onClick={(e) => e.stopPropagation()}
         className="h-full flex flex-col"
         style={{
@@ -685,10 +688,13 @@ function VulnDrawer({
               <div className="mono text-[12px] text-ink-muted mb-1">
                 {v.cve_id || v.external_id || '—'}
               </div>
-              <div className="disp text-[17px] font-bold text-ink leading-snug">{v.title}</div>
+              <h2 id="vuln-drawer-title" className="disp text-[17px] font-bold text-ink leading-snug">
+                {v.title}
+              </h2>
             </div>
             <button
               onClick={onClose}
+              aria-label={tr('Fermer', 'Close')}
               className="w-8 h-8 rounded-[9px] flex items-center justify-center shrink-0 text-ink-soft"
               style={{ background: 'var(--bg-hover)' }}
             >

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -505,7 +505,8 @@
       "members": "members",
       "action": "See my posture",
       "loading": "Reading your data…",
-      "error": "Your data could not be read."
+      "error": "Your data could not be read.",
+      "completeFailed": "Could not finish. Try again."
     },
     "checklist": {
       "close": "Hide the getting-started list",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -93,7 +93,10 @@
     "templateDownload": "Download CSV Template",
     "noRisks": "No Risks Found",
     "noRisksDescription": "Start by creating your first risk to manage it here.",
-    "createFirstRisk": "Create My First Risk"
+    "createFirstRisk": "Create My First Risk",
+    "createRiskSubtitle": "Create a risk with its score computed as you type.",
+    "category": "Category",
+    "uncategorised": "Uncategorised"
   },
   "statuses": {
     "open": "Open",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -225,7 +225,13 @@
     "closeDrawer": "Close",
     "save": "Save",
     "dragHint": "Drag plans here",
-    "reviewPending": "overdue"
+    "reviewPending": "overdue",
+    "createTitle": "Create a mitigation plan",
+    "createSubtitle": "Create a plan to mitigate a risk",
+    "fieldTitle": "Title",
+    "fieldDescription": "Description",
+    "fieldDeadline": "Deadline",
+    "fieldPriority": "Priority"
   },
   "compliance": {
     "title": "Compliance",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -73,7 +73,7 @@
     "acceptanceReason": "Acceptance Reason",
     "duplicateRisk": "Duplicate Risk",
     "bulkActions": "Bulk Actions",
-    "selectedCount": "{count} risk(s) selected",
+    "selectedCount": "{count} selected",
     "bulkDelete": "Delete",
     "bulkChangeStatus": "Change Status",
     "bulkAssignTo": "Assign To",
@@ -96,7 +96,15 @@
     "createFirstRisk": "Create My First Risk",
     "createRiskSubtitle": "Create a risk with its score computed as you type.",
     "category": "Category",
-    "uncategorised": "Uncategorised"
+    "uncategorised": "Uncategorised",
+    "fieldTitle": "Title",
+    "tags": "Tags (comma separated)",
+    "frameworks": "Frameworks",
+    "affectedAssets": "Affected assets",
+    "noAssets": "No asset.",
+    "updated": "Risk updated",
+    "updateFailed": "Update failed",
+    "fieldDescription": "Description"
   },
   "statuses": {
     "open": "Open",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -505,7 +505,8 @@
       "members": "membres",
       "action": "Voir ma posture",
       "loading": "Lecture de vos données…",
-      "error": "Impossible de lire vos données."
+      "error": "Impossible de lire vos données.",
+      "completeFailed": "Impossible de terminer. Réessayez."
     },
     "checklist": {
       "close": "Masquer la liste de démarrage",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -225,7 +225,13 @@
     "closeDrawer": "Fermer",
     "save": "Sauvegarder",
     "dragHint": "Glissez des plans ici",
-    "reviewPending": "en retard"
+    "reviewPending": "en retard",
+    "createTitle": "Créer un plan d'atténuation",
+    "createSubtitle": "Créez un plan pour atténuer un risque",
+    "fieldTitle": "Titre",
+    "fieldDescription": "Description",
+    "fieldDeadline": "Échéance",
+    "fieldPriority": "Priorité"
   },
   "compliance": {
     "title": "Conformité",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -73,7 +73,7 @@
     "acceptanceReason": "Justification de l'acceptation",
     "duplicateRisk": "Dupliquer le risque",
     "bulkActions": "Actions en masse",
-    "selectedCount": "{count} risque(s) sélectionné(s)",
+    "selectedCount": "{count} sélectionné(s)",
     "bulkDelete": "Supprimer",
     "bulkChangeStatus": "Changer le statut",
     "bulkAssignTo": "Assigner à",
@@ -96,7 +96,15 @@
     "createFirstRisk": "Créer mon premier risque",
     "createRiskSubtitle": "Créez un risque avec score en temps réel.",
     "category": "Catégorie",
-    "uncategorised": "Non classé"
+    "uncategorised": "Non classé",
+    "fieldTitle": "Titre",
+    "tags": "Étiquettes (séparées par des virgules)",
+    "frameworks": "Référentiels",
+    "affectedAssets": "Actifs affectés",
+    "noAssets": "Aucun actif.",
+    "updated": "Risque mis à jour",
+    "updateFailed": "Erreur lors de la mise à jour",
+    "fieldDescription": "Description"
   },
   "statuses": {
     "open": "Ouvert",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -93,7 +93,10 @@
     "templateDownload": "Télécharger le modèle CSV",
     "noRisks": "Aucun risque trouvé",
     "noRisksDescription": "Commencez par créer votre premier risque pour le gérer ici.",
-    "createFirstRisk": "Créer mon premier risque"
+    "createFirstRisk": "Créer mon premier risque",
+    "createRiskSubtitle": "Créez un risque avec score en temps réel.",
+    "category": "Catégorie",
+    "uncategorised": "Non classé"
   },
   "statuses": {
     "open": "Ouvert",

--- a/frontend/src/shared/ui.tsx
+++ b/frontend/src/shared/ui.tsx
@@ -165,15 +165,21 @@ export function Chip({
   active,
   onClick,
   color,
+  testId,
 }: {
   label: string;
   active?: boolean;
   onClick?: () => void;
   color?: string;
+  /** Optional hook for the E2E gates. A filter nobody can address from a test
+   *  is a filter whose behaviour nothing protects. */
+  testId?: string;
 }) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
+      aria-pressed={active}
       className="h-(--control-h-sm) px-3 rounded-full text-xs font-semibold inline-flex items-center gap-1.5 transition-colors duration-fast ease-out"
       style={{
         border: `1px solid ${active ? 'transparent' : 'var(--border)'}`,


### PR DESCRIPTION
A sweep of the app for inconsistencies and errors. Six fixed here, two filed rather than fixed.

Stacked on #635. Together the two branches carry eleven commits; this one adds the last six.

## The one that matters most

**The recognition screen trapped every existing customer.** `OnboardingGuard` sends anyone whose
wizard is unfinished to `/onboarding/recognition`, from every app route — that is #438's
criterion 9 and it is right. But criterion 9 also keeps the five-step tunnel off their screen,
and the tunnel was the only thing that called `POST /onboarding/complete`. So the recognition
screen's button navigated to `/posture`, the guard saw an unfinished wizard and sent them
straight back, and the loop closed.

That is the whole population #234 backfilled: every customer using OpenRisk before the tunnel
existed. **They could not enter the product.** Acknowledging the recognition is now their
completion of onboarding.

This one surfaced only because three tests in the repo's own `dead-controls` suite were failing
for a reason that looked unrelated — the admin persona could not reach `/assets` or `/settings`
at all.

## Two security gates were red

**`TestIsolationGate_DemandsADecisionForCollectionRoutes`.** `/posture`,
`/onboarding/recognition` and `/onboarding/starter-risks` are collection reads with no recorded
isolation decision. The gate turns "somebody must remember to test the new endpoint" into a
build error, and it caught exactly that.

All three are recorded **Pending, not Covered**, deliberately: the queries do filter on
`tenant_id` and the control-mapping join carries a second guard, but the tests that assert
isolation drive a reader double keyed by tenant. That proves the use case passes the caller's
tenant down, not that the SQL filters. Each entry names what would settle it.

**`TestProtectedRoutes_UnguardedSetHasNotGrown`.** Four routes were mounted with a session and
no permission — and one of them **writes risks**. `POST /onboarding/starter-risks` now carries
`risks:create` like every other risk write. The three reads are declared session-sufficient for
the same reason `GET /activation/state` already is: they are the product's own account of where
*this* user stands, and there is no permission meaning "may look at yourself".

The client now treats the resulting 403 the way it treats a 409 — the step advances without
adopting. A blocking tunnel that refuses to move over a permission an invited member will never
have would lock them out, which is the same failure as the loop above.

## Three more

**The connection dot reported the live stream, not the connection.** `dead-controls` asserts
`data-state` is `online` while the API is reachable. It could never read that: whenever the API
was up, a second switch overwrote the attribute with the realtime stream's state, so the
connection was only ever visible when it was *bad*. Two questions a user asks separately had
been folded into one attribute. `data-state` now carries the connection; `data-live` carries the
stream. The dot's colour and label still combine both — one dot is the right amount of chrome.

**The topology count ignored the criticality filter.** Unticking CRITICAL removes those assets
and their edges from the graph; the header went on reporting the whole estate. A count that
ignores the filter beside a graph that obeys it tells the user two things at once. It now reads
`n / total actifs` while filtered. `Chip` also gained `aria-pressed` — these are toggle buttons
and nothing announced which levels were on.

**Two hard-coded French strings in the create-risk modal.** Same class as the tunnel's
"Retour": literals inside an otherwise fully translated component (25 catalogue lookups), so an
English reader saw "Chargement des assets..." inside an English form. Both now use keys that
already existed in both catalogues.

## Filed rather than fixed

- **#636** — two `dead-controls` assertions address screens that were redesigned. The Asset
  Universe funnel's *capability* survived the rename to `TopologyView` (its own comment says
  so); the *interaction shape* did not — chips instead of a button opening a panel. The danger
  zone is fully implemented as an inline panel, not a button opening a dialog. Rewriting an
  assertion to match whatever the code now does is how a gate stops being a gate, so the owner
  of those screens should re-express the intent. The issue also records that `DangerZonePanel`
  is hard-coded French end to end — on a destructive-action screen.
- **#637** — 21 source files are imported by nothing and routed to by nothing.
  `MitigationEditModal.tsx` alone holds 10 of the tree's 79 `no-explicit-any` violations, a
  tenth of a ratchet D-022 set deliberately, spent on a file nothing renders. Not deleted here:
  several read as parked intent, and deleting 21 files across six feature areas on my own
  judgement is neither small nor mine to make.

## Sweeps that came back clean

Worth recording so nobody repeats them: **no dead in-app links** (34 `to=`/`navigate()` targets
all resolve), **no dead deep links** (all seven `DeepLink` values in the activation catalogue
hit real routes), **no duplicate route registrations** on either side, and **no English leaks**
in the French-first UI beyond one enum label.

## Verification

```
$ go build ./... && go vet ./...
(clean)

$ go test ./...
69 packages ok

FAIL  internal/domain        # pre-existing, #616 — events:read in every role preset
FAIL  pkg/entitlements       # pre-existing, #619 — SELF_HOSTING.md generated block
```

Both were red before this branch. `internal/handler` and `internal/security/isolation` — the
two this branch touches — are now green.

```
$ npx tsc -b                      (clean)
$ npx vitest run
 Test Files  55 passed (55)
      Tests  587 passed (587)
$ npm run build                   ✓ built in 5.27s
$ npm run lint:ceiling
ESLint errors: 313 (ceiling 321)  # only the pre-existing no-irregular-whitespace entry, #627

$ npx playwright test tests/e2e/dead-controls.spec.ts tests/e2e/deceptive-ui.spec.ts
  17 passed · 2 failed            # was 16 passed · 3 failed; the 2 are #636
```

The recognition loop, the connection dot and the topology count were each verified by hand in a
browser before and after.

## Honest remainders

- The two `dead-controls` failures stay red until #636 is picked up. They are named, not hidden
  behind a `test.fixme`.
- The 79 `no-explicit-any` violations are untouched; that is the ratchet's job over time, and
  #637 would remove a tenth of them for free.
- `DangerZonePanel`'s French is recorded in #636 rather than fixed here — translating a
  destructive-action screen deserves a reviewer who knows the legal copy it cites.


---

## Two more, found by walking the app afterwards

**`/health` claimed the database was connected while it was down.** The Postgres container had
stopped overnight; every query was failing with `connection refused`; `GET /api/v1/health`
answered `{"status":"UP","db":"CONNECTED"}` with a 200. Both values were literals — the handler
probed nothing, twelve lines below `/status`, whose own comment says it probes *"so the public
status page reflects reality, not a hardcoded UP"*.

That is the endpoint `docker-compose`'s healthcheck, the Helm probes and the E2E webServer all
wait on. A dead instance stayed "healthy". It now pings under a 2s timeout — a probe that blocks
on a wedged connection is an outage of its own — and answers 503 when the ping fails.

```
database up    -> {"status":"UP","db":"CONNECTED"}      HTTP 200
database down  -> {"status":"DOWN","db":"DISCONNECTED"} HTTP 503
```

**The scoring matrix cell showed its band's product, not the score.** Likelihood 0.7 and impact
9 gave a readout of "6.30" beside a lit cell reading "5.6": the grid quantises to five bands per
axis, and the cell was labelling itself with its own arithmetic. Two numbers for one thing, on
the screen whose job is to show what you just scored. The cell now carries the real score — it
marks *where* you are, the number is *what* you scored.

## The walk itself

Registered, walked all five steps, went back to step 1 mid-tunnel to correct the sector, reached
the reveal, entered the app, and closed the checklist.

- Back-navigation keeps every answer and the step stays visible — the auto-skip freeze holds
  from the UI, not just from a unit test.
- Changing the sector to Assurance re-scoped the eight starter statements (sinistres,
  tarification, portail courtiers) and kept the CEMAC regional one.
- The three adopted risks are in the register with their scores; the COBAC import shows 45
  tracked controls; the reveal's numbers match.
- The checklist closes and stays closed across a reload.
- A session that expired overnight redirected to `/login` cleanly, with no console error and a
  correctly worded message.

## One incoherence the walk exposed, not fixed here

**Step 4's score is never written to the risk.** I scored "Indisponibilité de la plateforme de
sinistres" at **6.30**; the reveal and the register both show **2**. This was already recorded
as a remainder when the steps were built, but a user hitting it sees the product forget what
they just told it. It needs the update-risk use case — a real mutation of a customer's register,
with its own audit and ownership consequences — so it deserves its own change rather than a
rider on this one.
