### PR TITLE
fix(onboarding): the tunnel's two value steps each claimed something untrue

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2869,7 +2869,11 @@ func main() {
 		WithProfileUpdater(userRepo).
 		// Auto-skip (criteria 2 and 3): GET /onboarding/state resolves the whole
 		// tunnel in one call, skipped steps included.
-		WithStepProbe(postureRepo)
+		WithStepProbe(postureRepo).
+		// Step 4's write path (#643). Same reasoning as step 2's writer below:
+		// the RISK use case owns scoring, so the tunnel goes through it rather
+		// than computing the frozen formula a second time.
+		WithStarterRiskScorer(risk.NewStarterScorer(riskRepo, updateRiskUseCase))
 	activationHandler := handlers.NewActivationHandler(
 		appactivation.NewGetStateUseCase(activationRepo),
 		appactivation.NewMarkCelebratedUseCase(activationRepo),

--- a/backend/internal/application/activation/onboarding.go
+++ b/backend/internal/application/activation/onboarding.go
@@ -7,6 +7,8 @@ package activation
 
 import (
 	"context"
+	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,6 +69,20 @@ type WizardState struct {
 	// Landing is where the wizard drops the user on completion (derived from the
 	// chosen goal).
 	Landing string `json:"landing"`
+	// ScoreTarget is the risk step 4 evaluates — resolved server-side so the
+	// step can name it, and so the client cannot nominate which risk an
+	// onboarding step rewrites (#643). Absent when the tenant adopted none.
+	ScoreTarget *ScoreTarget `json:"score_target,omitempty"`
+}
+
+// ScoreTarget is what the scoring step is about: the risk, and the values it
+// currently carries so the sliders open where the user left them rather than on
+// a hard-coded default.
+type ScoreTarget struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Probability float64 `json:"probability"`
+	Impact      float64 `json:"impact"`
 }
 
 // OnboardingUseCase serves the wizard: read state, save one step, complete.
@@ -81,7 +97,18 @@ type OnboardingUseCase struct {
 	// — showing a step the user did not need costs them a click; hiding one they
 	// did need loses their answer.
 	probe domain.OnboardingStepProbe
-	now   func() time.Time
+	// scorer applies step 4's sliders to the risk the tunnel is about (#643).
+	// Optional and nil-safe: with no scorer the step still stores its answers
+	// and the tunnel still walks, which is the behaviour that shipped — it just
+	// does not persist the score.
+	scorer domain.StarterRiskScorer
+	now    func() time.Time
+}
+
+// WithStarterRiskScorer attaches the step-4 write path (#643).
+func (uc *OnboardingUseCase) WithStarterRiskScorer(s domain.StarterRiskScorer) *OnboardingUseCase {
+	uc.scorer = s
+	return uc
 }
 
 // WithStepProbe attaches the auto-skip reader (#438 criteria 2 and 3).
@@ -180,7 +207,7 @@ func (uc *OnboardingUseCase) GetState(ctx context.Context, tenantID, userID uuid
 	// merely looked. The decision is frozen by the first SaveStep, which is the
 	// first moment there is a row to freeze it onto — and, crucially, it is taken
 	// there BEFORE that step writes anything.
-	return toWizardState(progress, uc.stepData(ctx, progress)), nil
+	return uc.withScoreTarget(ctx, tenantID, toWizardState(progress, uc.stepData(ctx, progress))), nil
 }
 
 // SaveStepInput is one step's submission.
@@ -273,6 +300,16 @@ func (uc *OnboardingUseCase) SaveStep(ctx context.Context, tenantID, userID uuid
 		}
 	case domain.OnboardingStepGoal:
 		progress.Goal = stringAnswer(input.Answers, "goal")
+
+	case domain.OnboardingStepScore:
+		// #643: this case did not exist. The sliders were stored by
+		// SetStepAnswers above and read by nothing, so a user who scored a risk
+		// at 6.30 found 2 in their register — the catalogue's default.
+		//
+		// Best-effort, like the organization step's writes above: a scoring
+		// failure must not lose the user's answers or block the tunnel. The step
+		// answers are already saved, so a retry re-applies them.
+		uc.applyScore(ctx, tenantID, input.Answers)
 	}
 
 	// Move the cursor. An explicit Next wins (including backwards); otherwise
@@ -284,7 +321,7 @@ func (uc *OnboardingUseCase) SaveStep(ctx context.Context, tenantID, userID uuid
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress, data), nil
+	return uc.withScoreTarget(ctx, tenantID, toWizardState(progress, data)), nil
 }
 
 // nextStep resolves the cursor move over the VISIBLE steps only.
@@ -375,7 +412,7 @@ func (uc *OnboardingUseCase) Complete(ctx context.Context, tenantID, userID uuid
 	if err := uc.repo.Save(ctx, progress); err != nil {
 		return nil, err
 	}
-	return toWizardState(progress, uc.stepData(ctx, progress)), nil
+	return uc.withScoreTarget(ctx, tenantID, toWizardState(progress, uc.stepData(ctx, progress))), nil
 }
 
 // Suggestions is the payload of GET /onboarding/suggestions: the sector/goal
@@ -505,4 +542,96 @@ func stringAnswer(answers domain.JSONMap, key string) string {
 		return strings.TrimSpace(v)
 	}
 	return ""
+}
+
+// floatAnswer reads a numeric wizard answer.
+//
+// JSON numbers arrive as float64 through encoding/json, but a stored answer that
+// round-tripped through the JSONMap column can come back as json.Number, and a
+// client that sent a string is not worth failing a step over. Returns ok=false
+// when the key is absent or unreadable, so a partial payload leaves the stored
+// value alone rather than resetting it to zero.
+func floatAnswer(answers domain.JSONMap, key string) (float64, bool) {
+	if answers == nil {
+		return 0, false
+	}
+	switch v := answers[key].(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// applyScore writes step 4's sliders onto the risk the tunnel is about (#643).
+//
+// Best-effort by design, and deliberately silent on failure: the step's answers
+// are already persisted by the time this runs, so a transient write failure
+// costs the user nothing that a Back-and-Continue does not recover. Failing the
+// step instead would strand them on screen 4 of 5 over a risk row — the exact
+// class of dead end #438 exists to remove.
+func (uc *OnboardingUseCase) applyScore(ctx context.Context, tenantID uuid.UUID, answers domain.JSONMap) {
+	if uc.scorer == nil {
+		return
+	}
+	probability, okP := floatAnswer(answers, "probability")
+	impact, okI := floatAnswer(answers, "impact")
+	if !okP || !okI {
+		return
+	}
+
+	target, err := uc.scorer.FirstStarterRisk(ctx, tenantID)
+	if err != nil || target == nil {
+		// No adopted starter risk is a normal state — adoption sits on step 2
+		// and is skippable. There is simply nothing to score.
+		return
+	}
+	_, _ = uc.scorer.ScoreStarterRisk(ctx, tenantID, target.ID, probability, impact)
+}
+
+// scoreTarget resolves what step 4 is scoring, for the client to name on screen.
+//
+// The step used to render "Évaluez ce risque" over two sliders and no risk, so
+// the user was scoring something the screen never identified. Nil when the
+// tenant adopted nothing — the client renders that state rather than a heading
+// about a risk that does not exist.
+func (uc *OnboardingUseCase) scoreTarget(ctx context.Context, tenantID uuid.UUID) *ScoreTarget {
+	if uc.scorer == nil {
+		return nil
+	}
+	risk, err := uc.scorer.FirstStarterRisk(ctx, tenantID)
+	if err != nil || risk == nil {
+		return nil
+	}
+	return &ScoreTarget{
+		ID:          risk.ID.String(),
+		Title:       risk.Title,
+		Probability: risk.Probability,
+		Impact:      risk.Impact,
+	}
+}
+
+// withScoreTarget attaches the scoring step's subject to a state response.
+//
+// Kept out of toWizardState, which is pure and has no context: resolving the
+// target is a tenant-scoped read, and threading a database call through a
+// formatting function is how formatting functions start doing IO.
+func (uc *OnboardingUseCase) withScoreTarget(ctx context.Context, tenantID uuid.UUID, state *WizardState) *WizardState {
+	if state == nil {
+		return nil
+	}
+	state.ScoreTarget = uc.scoreTarget(ctx, tenantID)
+	return state
 }

--- a/backend/internal/application/activation/score_step_test.go
+++ b/backend/internal/application/activation/score_step_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package activation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/opendefender/openrisk/internal/domain"
+)
+
+// ---------------------------------------------------------------------------
+// Step 4 of the tunnel (#643).
+//
+// The defect these guard: SaveStep's promotion switch had no case for `score`,
+// so the sliders were stored by SetStepAnswers and read by nothing. A user who
+// scored a risk at 6.30 found 2 in their register — the catalogue's default for
+// the adopted statement.
+// ---------------------------------------------------------------------------
+
+type fakeScorer struct {
+	target *domain.Risk
+
+	// recorded call
+	scoredTenant uuid.UUID
+	scoredRisk   uuid.UUID
+	probability  float64
+	impact       float64
+	calls        int
+
+	findErr  error
+	scoreErr error
+}
+
+func (f *fakeScorer) FirstStarterRisk(_ context.Context, tenantID uuid.UUID) (*domain.Risk, error) {
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	if tenantID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant is required")
+	}
+	return f.target, nil
+}
+
+func (f *fakeScorer) ScoreStarterRisk(_ context.Context, tenantID, riskID uuid.UUID, probability, impact float64) (*domain.Risk, error) {
+	f.calls++
+	if f.scoreErr != nil {
+		return nil, f.scoreErr
+	}
+	f.scoredTenant, f.scoredRisk = tenantID, riskID
+	f.probability, f.impact = probability, impact
+	return &domain.Risk{ID: riskID, Probability: probability, Impact: impact}, nil
+}
+
+func scoreFixture(t *testing.T) (*OnboardingUseCase, *fakeScorer, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	repo := newFakeRepo()
+	target := &domain.Risk{
+		ID:          uuid.New(),
+		Title:       "Indisponibilité de la plateforme de sinistres",
+		Probability: 0.2,
+		Impact:      10,
+	}
+	scorer := &fakeScorer{target: target}
+	uc := NewOnboardingUseCase(repo, NewRecorder(repo)).WithStarterRiskScorer(scorer)
+	return uc, scorer, uuid.New(), uuid.New()
+}
+
+func TestSaveScoreStep_Success_WritesTheSlidersOntoTheRisk(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+
+	state, err := uc.SaveStep(context.Background(), tenantID, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": 0.7, "impact": 9.0},
+	})
+	if err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+
+	if scorer.calls != 1 {
+		t.Fatalf("expected exactly one scoring call, got %d", scorer.calls)
+	}
+	if scorer.scoredTenant != tenantID {
+		t.Errorf("scored under tenant %s, want %s", scorer.scoredTenant, tenantID)
+	}
+	if scorer.scoredRisk != scorer.target.ID {
+		t.Errorf("scored risk %s, want the adopted starter risk %s", scorer.scoredRisk, scorer.target.ID)
+	}
+	if scorer.probability != 0.7 || scorer.impact != 9.0 {
+		t.Errorf("applied %.2f/%.2f, want 0.70/9.00", scorer.probability, scorer.impact)
+	}
+	// 0.7 × 9 = 6.30 — the number the readout showed, which is the whole point.
+	if got := scorer.probability * scorer.impact; got != 6.3 {
+		t.Errorf("resulting score %.2f, want 6.30", got)
+	}
+	if state == nil {
+		t.Fatal("expected a wizard state back")
+	}
+}
+
+func TestSaveScoreStep_NotFound_NoAdoptedRiskIsNotAnError(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+	// Adoption sits on step 2 and is skippable: a tenant can legitimately reach
+	// step 4 with nothing to score. That must not fail the step and strand the
+	// user on screen 4 of 5.
+	scorer.target = nil
+
+	state, err := uc.SaveStep(context.Background(), tenantID, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": 0.5, "impact": 5.0},
+	})
+	if err != nil {
+		t.Fatalf("a tenant with no adopted risk must still pass step 4: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected a wizard state back")
+	}
+	if scorer.calls != 0 {
+		t.Errorf("nothing to score, yet %d scoring calls were made", scorer.calls)
+	}
+	if state.ScoreTarget != nil {
+		t.Errorf("no adopted risk, yet a score target was reported: %+v", state.ScoreTarget)
+	}
+}
+
+func TestSaveScoreStep_Unauthorized_RefusesWithoutATenant(t *testing.T) {
+	uc, scorer, _, userID := scoreFixture(t)
+
+	_, err := uc.SaveStep(context.Background(), uuid.Nil, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": 0.7, "impact": 9.0},
+	})
+	if err == nil {
+		t.Fatal("a save with no tenant must be refused")
+	}
+	if scorer.calls != 0 {
+		t.Errorf("refused save still wrote: %d scoring calls", scorer.calls)
+	}
+}
+
+func TestSaveScoreStep_ScoringFailureDoesNotBlockTheTunnel(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+	scorer.scoreErr = errors.New("risk store down")
+
+	// The answers are persisted before this runs, so a transient write failure
+	// costs a Back-and-Continue — not the user's place in a five-step tunnel.
+	state, err := uc.SaveStep(context.Background(), tenantID, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": 0.7, "impact": 9.0},
+	})
+	if err != nil {
+		t.Fatalf("a scoring failure must not fail the step: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected a wizard state back")
+	}
+}
+
+func TestSaveScoreStep_IgnoresAPayloadWithoutBothSliders(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+
+	// A partial payload must leave the stored value alone rather than reset the
+	// missing axis to zero — which would read as "no impact at all".
+	if _, err := uc.SaveStep(context.Background(), tenantID, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": 0.7},
+	}); err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if scorer.calls != 0 {
+		t.Errorf("a half payload was applied: %d scoring calls", scorer.calls)
+	}
+}
+
+func TestSaveScoreStep_AcceptsNumbersThatRoundTrippedThroughJSON(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+
+	// A stored answer read back out of the JSONMap column can come back as a
+	// string; refusing it would silently stop persisting the score on a resume.
+	if _, err := uc.SaveStep(context.Background(), tenantID, userID, SaveStepInput{
+		Step:    domain.OnboardingStepScore,
+		Answers: domain.JSONMap{"probability": "0.7", "impact": "9"},
+	}); err != nil {
+		t.Fatalf("SaveStep: %v", err)
+	}
+	if scorer.calls != 1 {
+		t.Fatalf("expected the string form to be applied, got %d calls", scorer.calls)
+	}
+	if scorer.probability != 0.7 || scorer.impact != 9 {
+		t.Errorf("applied %.2f/%.2f, want 0.70/9.00", scorer.probability, scorer.impact)
+	}
+}
+
+func TestOnboardingState_NamesTheRiskStepFourScores(t *testing.T) {
+	uc, scorer, tenantID, userID := scoreFixture(t)
+
+	state, err := uc.GetState(context.Background(), tenantID, userID)
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if state.ScoreTarget == nil {
+		t.Fatal("step 4 has no subject to name — the screen would say 'this risk' about nothing")
+	}
+	if state.ScoreTarget.Title != scorer.target.Title {
+		t.Errorf("named %q, want %q", state.ScoreTarget.Title, scorer.target.Title)
+	}
+	// The sliders open on the risk's CURRENT values, not on a hard-coded 0.5/6.
+	if state.ScoreTarget.Probability != 0.2 || state.ScoreTarget.Impact != 10 {
+		t.Errorf("target carries %.2f/%.2f, want the risk's own 0.20/10.00",
+			state.ScoreTarget.Probability, state.ScoreTarget.Impact)
+	}
+}

--- a/backend/internal/application/risk/starter_risks.go
+++ b/backend/internal/application/risk/starter_risks.go
@@ -95,3 +95,91 @@ func (uc *CreateRiskUseCase) CreateStarterRisk(ctx context.Context, tenantID uui
 		// assessed risk. Step 4 of the tunnel is where they score one.
 	})
 }
+
+// ---------------------------------------------------------------------------
+// The tunnel's SCORING adapter (#643, step 4).
+//
+// Same reasoning as the write adapter above, one step later in the tunnel:
+// scoring a risk recomputes the score and its band, and a second path that did
+// its own arithmetic would be a second definition of the frozen formula. This
+// delegates to UpdateRiskUseCase so there is exactly one.
+// ---------------------------------------------------------------------------
+
+// StarterScorer satisfies domain.StarterRiskScorer.
+type StarterScorer struct {
+	riskRepo domain.RiskRepository
+	update   *UpdateRiskUseCase
+}
+
+// Compile-time proof of the port.
+var _ domain.StarterRiskScorer = (*StarterScorer)(nil)
+
+func NewStarterScorer(riskRepo domain.RiskRepository, update *UpdateRiskUseCase) *StarterScorer {
+	return &StarterScorer{riskRepo: riskRepo, update: update}
+}
+
+// FirstStarterRisk returns the earliest starter risk this tenant adopted.
+//
+// EARLIEST, not highest-scoring. Step 5 names the risk step 4 scored, and
+// ordering by score would let the user's own scoring change which risk that is —
+// so the two screens could name different risks precisely because the tunnel
+// worked.
+//
+// (nil, nil) when the tenant adopted none: that is a normal state, not an error.
+// Adoption sits on step 2 and is skippable, and the caller has to be able to
+// render "nothing to score here" rather than fail the step.
+func (s *StarterScorer) FirstStarterRisk(ctx context.Context, tenantID uuid.UUID) (*domain.Risk, error) {
+	if tenantID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant is required to read starter risks")
+	}
+	if s.riskRepo == nil {
+		return nil, nil
+	}
+
+	page, err := s.riskRepo.List(ctx, tenantID, domain.RiskQuery{
+		Source:    []string{string(domain.SourceStarter)},
+		SortBy:    "created_at",
+		SortOrder: "asc",
+		Page:      1,
+		Limit:     1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if page == nil || len(page.Data) == 0 {
+		return nil, nil
+	}
+	return &page.Data[0], nil
+}
+
+// ScoreStarterRisk applies the tunnel's likelihood and impact to one risk.
+//
+// It re-reads the row under the tenant before writing, so a risk id that belongs
+// to another tenant is a NotFound rather than a cross-tenant write — the update
+// use case scopes its own read too, and this keeps the refusal explicit here
+// rather than relying on a second layer to catch it.
+func (s *StarterScorer) ScoreStarterRisk(ctx context.Context, tenantID, riskID uuid.UUID, probability, impact float64) (*domain.Risk, error) {
+	if tenantID == uuid.Nil {
+		return nil, domain.NewForbiddenError("a tenant is required to score a starter risk")
+	}
+	if riskID == uuid.Nil {
+		return nil, domain.NewValidationError("a risk id is required to score a starter risk")
+	}
+	if s.update == nil {
+		return nil, domain.NewInternalError("starter risk scorer is not wired")
+	}
+	// The Score Engine's own bounds. Rejecting here rather than clamping: a
+	// slider cannot produce these, so a value outside them means the caller is
+	// not the slider, and silently clamping would hide that.
+	if probability < 0 || probability > 1 {
+		return nil, domain.NewValidationError("probability must be between 0 and 1")
+	}
+	if impact < 0 || impact > 10 {
+		return nil, domain.NewValidationError("impact must be between 0 and 10")
+	}
+
+	return s.update.Execute(ctx, tenantID, riskID, UpdateRiskInput{
+		Probability: &probability,
+		Impact:      &impact,
+	})
+}

--- a/backend/internal/domain/posture.go
+++ b/backend/internal/domain/posture.go
@@ -130,6 +130,33 @@ type StarterRiskWriter interface {
 	CreateStarterRisk(ctx context.Context, tenantID uuid.UUID, draft StarterRiskDraft) (*Risk, error)
 }
 
+// StarterRiskScorer is the write side of the tunnel's scoring step (#643).
+//
+// CreateStarterRisk deliberately leaves an adopted statement at DRAFT, and its
+// own comment says why: "Step 4 of the tunnel is where they score one." Nothing
+// implemented that, so the score the user set on screen was stored as an opaque
+// wizard answer and never reached the risk.
+//
+// The target is resolved server-side rather than named in the request: the step
+// evaluates THE risk the tunnel is about, and letting a client nominate which
+// risk an onboarding step may rewrite would be a write primitive wearing an
+// onboarding label.
+//
+// Both methods MUST filter on tenantID — ABSOLUTE RULE #2.
+type StarterRiskScorer interface {
+	// FirstStarterRisk returns the earliest starter risk this tenant adopted,
+	// or (nil, nil) when none was. Earliest rather than highest-scoring: the
+	// target has to survive step 4 changing the ranking, or step 5 would name a
+	// different risk than the one just scored.
+	FirstStarterRisk(ctx context.Context, tenantID uuid.UUID) (*Risk, error)
+
+	// ScoreStarterRisk persists likelihood and impact on one starter risk and
+	// returns it rescored. It goes through the ordinary risk update path, so the
+	// score, the band and the audit trail are computed exactly once, in one
+	// place.
+	ScoreStarterRisk(ctx context.Context, tenantID, riskID uuid.UUID, probability, impact float64) (*Risk, error)
+}
+
 // StarterExternalIDPrefix marks a risk row as written by the onboarding tunnel.
 // Paired with Source == SourceStarter, which is the indexed column PR 4 of #438
 // queries; the external id carries WHICH statement, the source carries THAT it

--- a/frontend/src/features/onboarding/__tests__/scoreStep.test.tsx
+++ b/frontend/src/features/onboarding/__tests__/scoreStep.test.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 OpenDefender Contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Step 4 of the tunnel (#643).
+//
+// The defect: the step rendered "Évaluez ce risque" over two sliders and no
+// risk, its sliders opened on a hard-coded 0.5/6 regardless of the risk, and
+// the score was stored as an opaque wizard answer and applied to nothing. A
+// user who scored 6.30 found 2 in their register.
+//
+// These own the two claims that do not need a server: the step names its
+// subject, and it opens on that subject's real values.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { OnboardingState } from '../../../services/activationService';
+
+const getOnboardingState = vi.fn();
+const saveStep = vi.fn();
+
+vi.mock('../../../services/activationService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/activationService')>(
+    '../../../services/activationService',
+  );
+  return {
+    ...actual,
+    activationService: {
+      getState: vi.fn(),
+      markCelebrated: vi.fn(),
+      getOnboardingState: (...a: unknown[]) => getOnboardingState(...a),
+      saveStep: (...a: unknown[]) => saveStep(...a),
+      complete: vi.fn(),
+      getSuggestions: vi.fn(),
+      getPosture: vi.fn(),
+    },
+  };
+});
+
+import { ScoreStep } from '../wizard/valueSteps';
+
+function baseState(overrides: Partial<OnboardingState> = {}): OnboardingState {
+  return {
+    current_step: 'score',
+    steps: ['organization', 'goal', 'framework', 'score', 'cover'],
+    skipped_steps: [],
+    step_index: 3,
+    completed: false,
+    percent: 60,
+    answers: {},
+    landing: '/dashboard',
+    ...overrides,
+  } as OnboardingState;
+}
+
+function renderStep() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/onboarding/score']}>
+        <ScoreStep />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ScoreStep', () => {
+  beforeEach(() => {
+    getOnboardingState.mockReset();
+    saveStep.mockReset();
+  });
+
+  it('names the risk it is scoring', async () => {
+    getOnboardingState.mockResolvedValue(
+      baseState({
+        score_target: {
+          id: 'r-1',
+          title: 'Indisponibilité de la plateforme de sinistres',
+          probability: 0.2,
+          impact: 10,
+        },
+      }),
+    );
+
+    renderStep();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('score-target')).toHaveTextContent(
+        'Indisponibilité de la plateforme de sinistres',
+      ),
+    );
+  });
+
+  it('opens the sliders on the risk’s own values, not on a hard-coded default', async () => {
+    getOnboardingState.mockResolvedValue(
+      baseState({
+        score_target: { id: 'r-1', title: 'Un risque', probability: 0.9, impact: 8 },
+      }),
+    );
+
+    renderStep();
+
+    // 0.9 × 8 = 7.20. The old defaults (0.5 × 6) would read 3.00.
+    await waitFor(() => expect(screen.getByTestId('score-readout')).toHaveTextContent('7.20'));
+  });
+
+  it('prefers a stored answer over the risk’s values, so a resume shows what was set', async () => {
+    getOnboardingState.mockResolvedValue(
+      baseState({
+        answers: { score: { probability: 0.7, impact: 9 } },
+        score_target: { id: 'r-1', title: 'Un risque', probability: 0.2, impact: 10 },
+      }),
+    );
+
+    renderStep();
+
+    // The number the bug report quotes: scored 6.30, register showed 2.
+    await waitFor(() => expect(screen.getByTestId('score-readout')).toHaveTextContent('6.30'));
+  });
+
+  it('stays passable when the tenant adopted no risk, and says why', async () => {
+    getOnboardingState.mockResolvedValue(baseState());
+
+    renderStep();
+
+    await waitFor(() => expect(screen.getByTestId('score-no-target')).toBeInTheDocument());
+    expect(screen.queryByTestId('score-target')).not.toBeInTheDocument();
+    // Criterion 5: nobody is trapped on a step they cannot complete.
+    expect(screen.getByRole('button', { name: /Continuer|Continue/i })).toBeEnabled();
+  });
+});

--- a/frontend/src/features/onboarding/wizard/valueSteps.tsx
+++ b/frontend/src/features/onboarding/wizard/valueSteps.tsx
@@ -13,14 +13,14 @@
 // Both honour prefers-reduced-motion by rendering the FINAL state directly
 // (criterion 13) — not a shorter animation, no animation.
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ShieldCheck } from 'lucide-react';
 
 import { useUIStore } from '../../../store/uiStore';
 import { useAuthStore } from '../../../hooks/useAuthStore';
 import { StepShell } from './stepPrimitives';
 import { num, useStepNav, useStoredAnswers } from './stepNav';
-import { usePosture, usePrefersReducedMotion } from '../useActivation';
+import { useOnboardingState, usePosture, usePrefersReducedMotion } from '../useActivation';
 import type { PostureRiskView } from '../../../services/activationService';
 
 // ---------------------------------------------------------------------------
@@ -66,13 +66,27 @@ export function ScoreStep() {
   const stored = useStoredAnswers('score');
   const { go, busy, error, retry } = useStepNav('score');
 
-  const [probability, setProbability] = useState(0.5);
-  const [impact, setImpact] = useState(6);
+  // WHICH risk this step scores, resolved by the server (#643). The step used to
+  // render "Évaluez ce risque" over two sliders and no risk at all, so the user
+  // was scoring something the screen never named — and the score was stored as
+  // an opaque answer and applied to nothing.
+  const { data: state } = useOnboardingState();
+  const target = state?.score_target;
 
-  useEffect(() => {
-    setProbability(num(stored, 'probability', 0.5));
-    setImpact(num(stored, 'impact', 6));
-  }, [stored]);
+  // Derived, not copied into state by an effect. The sliders have three possible
+  // sources in priority order — what the user is dragging right now, what they
+  // stored here last time, and the risk's own values — and an effect that copied
+  // the latter two into state would both cascade a render and race the query:
+  // the server's answer arrives after the first paint, so the effect had to fire
+  // a second time to correct what it had already shown.
+  //
+  // `edited` is null until the user touches a slider, which is exactly the
+  // "uncontrolled until interacted with" semantics this step wants.
+  const [edited, setEdited] = useState<{ probability: number; impact: number } | null>(null);
+  const probability = edited?.probability ?? num(stored, 'probability', target?.probability ?? 0.5);
+  const impact = edited?.impact ?? num(stored, 'impact', target?.impact ?? 6);
+  const setProbability = (next: number) => setEdited({ probability: next, impact });
+  const setImpact = (next: number) => setEdited({ probability, impact: next });
 
   const score = Math.round(probability * impact * 1000) / 1000;
   const band = bandOf(score);
@@ -91,10 +105,17 @@ export function ScoreStep() {
   return (
     <StepShell
       title={tr('Évaluez ce risque', 'Score this risk')}
-      subtitle={tr(
-        'Probabilité et impact. La matrice se met à jour pendant que vous bougez les curseurs — c’est le score que le moteur calculera.',
-        'Likelihood and impact. The matrix updates as you move the sliders — this is the score the engine will compute.',
-      )}
+      subtitle={
+        target
+          ? tr(
+              'Probabilité et impact. La matrice se met à jour pendant que vous bougez les curseurs — c’est le score qui sera enregistré sur ce risque.',
+              'Likelihood and impact. The matrix updates as you move the sliders — this is the score that will be saved on this risk.',
+            )
+          : tr(
+              'Probabilité et impact. La matrice se met à jour pendant que vous bougez les curseurs — c’est le score que le moteur calculera.',
+              'Likelihood and impact. The matrix updates as you move the sliders — this is the score the engine will compute.',
+            )
+      }
       onBack={() => go({ probability, impact }, -1)}
       onNext={() => go({ probability, impact }, 1)}
       nextLabel={tr('Continuer', 'Continue')}
@@ -108,6 +129,35 @@ export function ScoreStep() {
       )}
       retryLabel={tr('Réessayer', 'Try again')}
     >
+      {/* The risk being scored, named. Criterion 1 of #643: a step headed "this
+          risk" has to say which. */}
+      {target ? (
+        <div
+          className="mb-5 rounded-xl p-4"
+          style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
+          data-testid="score-target"
+        >
+          <div className="text-[11px] uppercase tracking-wide text-ink-muted">
+            {tr('Risque évalué', 'Risk being scored')}
+          </div>
+          <div className="text-[14px] font-semibold text-ink mt-0.5">{target.title}</div>
+        </div>
+      ) : (
+        // Adoption sits on step 2 and is skippable, so a tenant can legitimately
+        // arrive here with nothing to score. Say so and stay passable — nobody
+        // is trapped on a step they cannot complete (#643 criterion 5).
+        <div
+          className="mb-5 rounded-xl p-4 text-[13px] text-ink-soft"
+          style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-strong)' }}
+          data-testid="score-no-target"
+        >
+          {tr(
+            'Aucun risque n’a encore été adopté, donc cette évaluation ne sera rattachée à aucun risque. Vous pourrez évaluer vos risques depuis le registre.',
+            'No risk has been adopted yet, so this scoring will not be attached to a risk. You can score your risks from the register.',
+          )}
+        </div>
+      )}
+
       <div className="grid gap-5 sm:grid-cols-2">
         <div>
           <Slider
@@ -282,7 +332,6 @@ function Matrix({
 export function CoverStep() {
   const lang = useUIStore((s) => s.lang);
   const tr = (fr: string, en: string) => (lang === 'fr' ? fr : en);
-  const stored = useStoredAnswers('cover');
   const { go, busy, error, retry } = useStepNav('cover');
   const user = useAuthStore((s) => s.user);
 
@@ -291,23 +340,29 @@ export function CoverStep() {
   // invented client-side would be the placeholder criterion 7 forbids, on the
   // screen the whole tunnel builds towards.
   const { data: posture, isLoading } = usePosture();
-  const [accepted, setAccepted] = useState(false);
 
-  useEffect(() => {
-    setAccepted(stored.accepted === true);
-  }, [stored]);
-
-  const risk: PostureRiskView | undefined = useMemo(() => posture?.top_risks?.[0], [posture]);
+  // The SAME risk step 4 scored (#643 criterion 4). This used to be
+  // `top_risks[0]` — ordered by score — so the user's own scoring could change
+  // which risk step 5 named, and the two screens could disagree precisely
+  // because the tunnel worked. Falls back to the top risk when the tenant
+  // adopted nothing, which is the state that produced the old behaviour anyway.
+  const { data: state } = useOnboardingState();
+  const targetId = state?.score_target?.id;
+  const risk: PostureRiskView | undefined = useMemo(() => {
+    const top = posture?.top_risks;
+    if (!top?.length) return undefined;
+    return (targetId && top.find((r) => r.id === targetId)) || top[0];
+  }, [posture, targetId]);
 
   return (
     <StepShell
-      title={tr('Couvrez ce risque', 'Cover this risk')}
+      title={tr('Ce que vos contrôles couvrent déjà', 'What your controls already cover')}
       subtitle={tr(
-        'Acceptez le contrôle proposé : le risque résiduel est recalculé à partir de vos propres contrôles.',
-        'Accept the proposed control: the residual risk is recomputed from your own controls.',
+        'Le référentiel que vous venez d’importer couvre déjà une partie de ce risque. Voici l’écart entre son score inhérent et son score résiduel, calculé par le serveur à partir de vos propres contrôles.',
+        'The framework you just imported already covers part of this risk. Here is the gap between its inherent score and its residual score, computed by the server from your own controls.',
       )}
-      onBack={() => go({ accepted }, -1)}
-      onNext={() => go({ accepted, by: user?.id ?? '' }, 1)}
+      onBack={() => go({}, -1)}
+      onNext={() => go({ by: user?.id ?? '' }, 1)}
       nextLabel={tr('Voir ma posture', 'See my posture')}
       busy={busy}
       error={error}
@@ -338,45 +393,33 @@ export function CoverStep() {
         </div>
       )}
 
-      {!isLoading && risk && <ResidualCard risk={risk} accepted={accepted} tr={tr} />}
+      {!isLoading && risk && <ResidualCard risk={risk} tr={tr} />}
 
-      <label
-        className="mt-5 flex items-start gap-3 cursor-pointer"
-        style={{ userSelect: 'none' }}
-      >
-        <input
-          type="checkbox"
-          data-testid="cover-accept"
-          checked={accepted}
-          onChange={(e) => setAccepted(e.target.checked)}
-          className="mt-0.5"
-        />
-        <span className="text-[13.5px] text-ink">
-          {tr(
-            'J’accepte le contrôle proposé pour ce risque.',
-            'I accept the proposed control for this risk.',
-          )}
-        </span>
-      </label>
+      {/* #639: there used to be a checkbox here reading "J'accepte le contrôle
+          proposé pour ce risque." Ticking it created nothing — no control, no
+          mapping, and no backend path read the answer. It also drove which
+          number the card labelled "Résiduel", so leaving it unticked displayed
+          the INHERENT score under the residual label. Both are gone: the step
+          now shows what the imported framework has actually earned, which is
+          true and is the payoff the tunnel was built for. Proposing a real
+          control is still open on #639 and is a product decision. */}
     </StepShell>
   );
 }
 
 function ResidualCard({
   risk,
-  accepted,
   tr,
 }: {
   risk: PostureRiskView;
-  accepted: boolean;
   tr: (fr: string, en: string) => string;
 }) {
   const reduced = usePrefersReducedMotion();
 
-  // Both numbers come from the server. `accepted` only decides WHICH of the two
-  // the screen leads with — it never computes one. The user is being shown what
-  // their controls have already earned, not a projection.
-  const shown = accepted ? risk.residual.value : risk.residual.inherent;
+  // Both numbers come from the server and neither is conditional. A checkbox
+  // used to choose which of the two sat under the "Résiduel" label, so an
+  // unticked box showed the INHERENT score labelled as the residual (#639).
+  const shown = risk.residual.value;
   const band = bandOf(shown);
 
   return (
@@ -392,7 +435,10 @@ function ResidualCard({
         <ShieldCheck
           size={18}
           aria-hidden="true"
-          style={{ color: accepted ? 'var(--low)' : 'var(--fg-muted)', marginBottom: 6 }}
+          style={{
+            color: risk.residual.coverage.measured ? 'var(--low)' : 'var(--fg-muted)',
+            marginBottom: 6,
+          }}
         />
         <Figure
           label={tr('Résiduel', 'Residual')}

--- a/frontend/src/services/activationService.ts
+++ b/frontend/src/services/activationService.ts
@@ -54,6 +54,14 @@ export interface ActivationState {
  */
 export type OnboardingStepKey = 'organization' | 'goal' | 'framework' | 'score' | 'cover';
 
+/** What the scoring step is about, and where its sliders open. */
+export interface ScoreTarget {
+  id: string;
+  title: string;
+  probability: number;
+  impact: number;
+}
+
 export interface OnboardingState {
   current_step: OnboardingStepKey;
   /**
@@ -76,6 +84,14 @@ export interface OnboardingState {
   goal?: string;
   /** Raw per-step answers, so a resumed wizard repopulates exactly as left. */
   answers: Record<string, Record<string, unknown>>;
+  /**
+   * The risk step 4 scores (#643). Resolved server-side — the step evaluates THE
+   * risk the tunnel is about, and letting the client nominate one would make an
+   * onboarding step a general write primitive. Absent when the tenant adopted no
+   * starter risk, which is a normal state: adoption sits on step 2 and is
+   * skippable.
+   */
+  score_target?: ScoreTarget;
   /** Where to land after the wizard, derived from the chosen goal. */
   landing: string;
 }


### PR DESCRIPTION
Closes #643
Closes #639

The tunnel's two value steps — the ones that are supposed to give something
back — each told the user something that was not true.

## Step 4 scored nothing (#643)

`SaveStep`'s promotion switch handles the answers that drive something:
`organization` writes the org and user profiles, `goal` promotes the goal. **There
was no case for `score`.** The sliders were stored by `SetStepAnswers` and read
by no code path in the tree, so a user who moved a slider to 6.30, watched the
readout say 6.30, and clicked Continue found **2** in their register — the
catalogue's default for the statement they had adopted.

`CreateStarterRisk`'s own comment already said where this belonged:

> No explicit status: the risk enters the lifecycle at DRAFT like any other,
> because a statement the user merely recognised is not an assessed risk.
> **Step 4 of the tunnel is where they score one.**

Nothing implemented that sentence.

The step also **never named a risk**. It rendered "Évaluez ce risque" over two
sliders and a matrix, with no risk on screen and no identifier in the payload —
so even once the server was willing to apply a score, the request did not say to
what.

### How it is resolved

**The target is resolved server-side.** An onboarding step that accepts a risk id
in its body is a general write primitive wearing an onboarding label, and this
one runs for a user who is still three screens away from the product.

**It is the EARLIEST adopted starter risk, not the highest-scoring one.** Step 5
names the risk step 4 scored; ordering by score would let the user's own scoring
change which risk that is, so the two screens could name different risks
*precisely because the tunnel worked*.

**Scoring goes through `UpdateRiskUseCase`.** That use case already recomputes
`Score = Impact × Probability` and bands it. A second writer reaching past it
would be a second definition of a formula the constitution freezes.

**It is best-effort, deliberately.** The step's answers are persisted before the
scoring runs, so a transient failure costs a Back-and-Continue rather than the
user's place in a five-step tunnel. A tenant with no adopted risk is a normal
state — adoption sits on step 2 and is skippable — and says so on screen while
staying passable.

The sliders now open on the risk's real values instead of a hard-coded 0.5 / 6,
and are derived rather than copied into state by an effect: the effect version
cascaded a render and raced the query, since the server's answer lands after the
first paint and the effect had to fire again to correct what it had drawn.

## Step 5 claimed a control that did not exist (#639)

The step asked the user to tick **« J'accepte le contrôle proposé pour ce
risque. »** No control was proposed. Ticking it created nothing — no control, no
`risk_control_mappings` row, and no backend path read the answer.

Worse than the dead checkbox: **it drove which number the card printed under the
"Résiduel" label.** Left unticked, the step displayed the *inherent* score
labelled as the residual.

Both are gone. The step now shows, unconditionally, what the framework imported
at step 3 has actually earned on this risk — inherent beside residual, both from
the server. That is true, and it is the payoff the tunnel was built to deliver.

This is the resolution **#639 itself names as legitimate**: *"the honest fix is
the opposite one: change the copy so it stops claiming a control exists."*
Proposing a real control — criteria 1–4 of that issue — is a product decision
about which control to propose and by what rule, and stays open. I have recorded
that on the issue rather than inventing a heuristic here.

## Acceptance criteria (#643)

1. ✅ Step 4 names the risk and opens on its current likelihood and impact.
2. ✅ Continuing persists them; the score the readout showed is the score stored.
3. ✅ Going back shows what was saved — a stored answer wins over the risk's values.
4. ✅ Step 5 names the same risk; the target cannot move because scoring changed
   the ranking.
5. ✅ No adopted risk: the step says so and stays passable.
6. ✅ `FirstStarterRisk` and `ScoreStarterRisk` both take `tenantID` and refuse
   `uuid.Nil`; the write reuses the existing update path; `_Success`,
   `_NotFound` and `_Unauthorized` tests present.

## Verification

```
$ go build ./... && go vet ./...
(clean)

$ go test ./internal/application/activation/ ./internal/application/risk/ ./internal/domain/
ok  internal/application/activation
ok  internal/application/risk
ok  internal/domain

$ npx tsc -b                    clean
$ npx vitest run                56 files, 591 tests, 591 passed   (was 587)
$ npm run build                 ✓ built in 4.33s
$ npx eslint src                312 errors (ceiling 321) — unchanged
```

**11 new tests.** Backend (7): `_Success` proves 0.7 × 9 = 6.30 reaches the risk;
`_NotFound` proves a tenant with no adopted risk still passes the step;
`_Unauthorized` proves a nil tenant is refused with nothing written; plus a
scoring failure not blocking the tunnel, a half payload not resetting an axis to
zero, string-encoded numbers surviving the JSONMap round trip, and the state
naming the risk with its own values. Frontend (4): the step names its subject,
opens on the risk's values (0.9 × 8 = 7.20, where the old defaults read 3.00),
prefers a stored answer on resume, and stays passable with no adopted risk.

### Two pre-existing failures, not from this branch

```
FAIL  internal/handler           TestProtectedRoutes_UnguardedSetHasNotGrown
FAIL  internal/security/isolation TestIsolationGate_DemandsADecisionForCollectionRoutes
```

Both fail **identically on a clean `master` checkout** — verified by stashing
this branch and re-running. They are the two gates PR #638 fixes on its own
branch, which has not merged.

## Honest remainders

- **Not verified in a browser.** Docker Desktop is not running on this machine
  and `alex` is not in the `docker` group, so the stack and Playwright were
  unavailable. The DoD's third line — score at step 4, reach the register, read
  back the same number — is **not** evidenced here. It is the one check that
  proves the whole path end to end, and it should be run before merge.
- `#639`'s richer resolution (propose a real control, write the mapping) is not
  implemented and is not claimed.
- Nothing here touches the Score Engine formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe5aY9T9JwxBfD9ZHiGF1v
